### PR TITLE
feat: add AZ-KV-002 key vault public access rule and remediation playbook

### DIFF
--- a/compliance/frameworks/cis_azure_benchmark.json
+++ b/compliance/frameworks/cis_azure_benchmark.json
@@ -57,6 +57,11 @@
       "control_id": "3.7",
       "control_name": "Ensure that storage accounts have lifecycle management policies configured",
       "description": "Storage accounts without lifecycle management policies retain data indefinitely. This increases storage costs, expands the attack surface through accumulation of stale data, and may violate data retention compliance requirements. Lifecycle policies automate the transition and deletion of blobs based on age and access patterns."
+    },
+    "AZ-KV-002": {
+      "control_id": "8.3",
+      "control_name": "Ensure that public network access to Key Vault is disabled",
+      "description": "Azure Key Vault should not allow public network access unless absolutely necessary. Enabling public access increases the attack surface and exposes sensitive secrets, keys, and certificates to potential unauthorized access. Private endpoints should be used to restrict access to trusted networks."
     }
   }
 }

--- a/compliance/frameworks/iso27001.json
+++ b/compliance/frameworks/iso27001.json
@@ -57,6 +57,11 @@
       "control_id": "A.8.3.1",
       "control_name": "Management of removable media",
       "description": "Information stored on Azure storage accounts should be subject to formal lifecycle management controls governing retention and disposal. Storage accounts without lifecycle policies retain data indefinitely with no automated disposal mechanism, violating information handling and disposal requirements under this control."
-    }
+    },
+    "AZ-KV-002": {
+    "control_id": "A.13.1.1",
+    "control_name": "Network controls",
+    "description": "Networks should be managed and controlled to protect information systems and applications. Allowing public network access to Azure Key Vault increases exposure of sensitive secrets, keys, and certificates to external networks. Access should be restricted to trusted networks using private endpoints or network controls."
+   }
   }
 }

--- a/compliance/frameworks/nist_csf.json
+++ b/compliance/frameworks/nist_csf.json
@@ -57,6 +57,11 @@
       "control_id": "PR.DS-3",
       "control_name": "Assets are formally managed throughout removal, transfers, and disposition",
       "description": "Data stored in Azure storage accounts should be subject to formal lifecycle management policies that govern retention, transition, and deletion. Without these policies, stale data accumulates indefinitely and is never formally dispositioned, violating data management and minimisation requirements."
+    },
+    "AZ-KV-002": {
+      "control_id": "AC-17",
+      "control_name": "Remote Access",
+      "description": "Remote access to systems should be controlled, monitored, and restricted. Allowing public network access to Azure Key Vault increases exposure of sensitive secrets, keys, and certificates to external networks. Access should be limited to trusted networks using private endpoints or network restrictions."
     }
   }
 }

--- a/playbooks/cli/fix_az_kv_002.sh
+++ b/playbooks/cli/fix_az_kv_002.sh
@@ -1,25 +1,21 @@
 #!/bin/bash
 
-# Fix AZ-KV-002: Disable public network access on Key Vault
+set -euo pipefail
 
-VAULT_NAME=$1
-RESOURCE_GROUP=$2
+VAULT_NAME="${1:-}"
+RESOURCE_GROUP="${2:-}"
 
-if [ -z "$VAULT_NAME" ] || [ -z "$RESOURCE_GROUP" ]; then
+if [[ -z "$VAULT_NAME" || -z "$RESOURCE_GROUP" ]]; then
   echo "Usage: $0 <vault-name> <resource-group>"
   exit 1
 fi
 
-echo "Disabling public network access for Key Vault: $VAULT_NAME"
+echo "Disabling public network access for Key Vault: $VAULT_NAME (RG: $RESOURCE_GROUP)"
 
 az keyvault update \
   --name "$VAULT_NAME" \
   --resource-group "$RESOURCE_GROUP" \
   --public-network-access Disabled
 
-if [ $? -eq 0 ]; then
-  echo "Public network access disabled successfully."
-  echo "Next step: Configure a private endpoint for full security."
-else
-  echo "Failed to update Key Vault."
-fi
+echo "Public network access disabled successfully."
+echo "Next step: Configure a private endpoint for full protection."

--- a/playbooks/cli/fix_az_kv_002.sh
+++ b/playbooks/cli/fix_az_kv_002.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# Fix AZ-KV-002: Disable public network access on Key Vault
+
+VAULT_NAME=$1
+RESOURCE_GROUP=$2
+
+if [ -z "$VAULT_NAME" ] || [ -z "$RESOURCE_GROUP" ]; then
+  echo "Usage: $0 <vault-name> <resource-group>"
+  exit 1
+fi
+
+echo "Disabling public network access for Key Vault: $VAULT_NAME"
+
+az keyvault update \
+  --name "$VAULT_NAME" \
+  --resource-group "$RESOURCE_GROUP" \
+  --public-network-access Disabled
+
+if [ $? -eq 0 ]; then
+  echo "Public network access disabled successfully."
+  echo "Next step: Configure a private endpoint for full security."
+else
+  echo "Failed to update Key Vault."
+fi

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ azure-mgmt-keyvault==10.3.0
 azure-mgmt-rdbms==10.1.0
 azure-mgmt-authorization==4.0.0
 azure-monitor-ingestion==1.0.3
+psycopg2-binary==2.9.9
 python-dotenv==1.0.0
 pyjwt==2.8.0
 requests==2.31.0
-psycopg2-binary==2.9.9

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,4 +13,4 @@ azure-monitor-ingestion==1.0.3
 python-dotenv==1.0.0
 pyjwt==2.8.0
 requests==2.31.0
-psycopg2-binary==2.9.9  # Required for PostgreSQL support (may need pg_config locally)
+psycopg2-binary==2.9.9

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ azure-mgmt-keyvault==10.3.0
 azure-mgmt-rdbms==10.1.0
 azure-mgmt-authorization==4.0.0
 azure-monitor-ingestion==1.0.3
-psycopg2-binary==2.9.9
 python-dotenv==1.0.0
 pyjwt==2.8.0
 requests==2.31.0
+psycopg2-binary==2.9.9  # Required for PostgreSQL support (may need pg_config locally)

--- a/scanner/rules/az_kv_002.py
+++ b/scanner/rules/az_kv_002.py
@@ -27,11 +27,21 @@ def scan(azure_client: Any, subscription_id: str) -> List[Dict[str, Any]]:
 
     for vault in azure_client.get_key_vaults():
         props = getattr(vault, "properties", None)
+        if not props:
+            continue
 
-        public_access = getattr(props, "public_network_access", "Enabled")
-        private_endpoints = getattr(props, "private_endpoint_connections", [])
+        public_access = getattr(props, "public_network_access", None)
+        if public_access is None:
+            public_access = getattr(props, "publicNetworkAccess", None)
 
-        if str(public_access).lower() in ("enabled", "true", "1") and not private_endpoints:
+        private_endpoints = getattr(props, "private_endpoint_connections", None)
+        if private_endpoints is None:
+            private_endpoints = getattr(props, "privateEndpointConnections", None)
+
+        is_public = str(public_access).lower() in ("enabled", "true")
+        has_private_endpoint = bool(private_endpoints)
+
+        if is_public and not has_private_endpoint:
             parsed = azure_client.parse_resource_id(vault.id)
 
             findings.append({

--- a/scanner/rules/az_kv_002.py
+++ b/scanner/rules/az_kv_002.py
@@ -1,0 +1,55 @@
+"""AZ-KV-002: Key Vault allows public network access without private endpoint."""
+
+from typing import Any, Dict, List
+
+RULE_ID = "AZ-KV-002"
+RULE_NAME = "Key Vault Allows Public Network Access Without Private Endpoint"
+SEVERITY = "HIGH"
+CATEGORY = "Key Vault"
+FRAMEWORKS = {"CIS": "8.5", "NIST": "AC-17", "ISO27001": "A.13.1.1"}
+
+DESCRIPTION = (
+    "The Azure Key Vault is accessible over the public internet without a private endpoint configured. "
+    "This increases the risk of unauthorized access to sensitive secrets, keys, and certificates."
+)
+
+REMEDIATION = (
+    "Disable public network access for the Key Vault and configure a private endpoint "
+    "to restrict access to trusted virtual networks."
+)
+
+PLAYBOOK = "playbooks/cli/fix_az_kv_002.sh"
+
+
+def scan(azure_client: Any, subscription_id: str) -> List[Dict[str, Any]]:
+    """Detect Key Vaults with public network access enabled and no private endpoint configured."""
+    findings: List[Dict[str, Any]] = []
+
+    for vault in azure_client.get_key_vaults():
+        props = getattr(vault, "properties", None)
+
+        public_access = getattr(props, "public_network_access", "Enabled")
+        private_endpoints = getattr(props, "private_endpoint_connections", [])
+
+        if str(public_access).lower() in ("enabled", "true", "1") and not private_endpoints:
+            parsed = azure_client.parse_resource_id(vault.id)
+
+            findings.append({
+                "rule_id": RULE_ID,
+                "rule_name": RULE_NAME,
+                "severity": SEVERITY,
+                "category": CATEGORY,
+                "resource_id": vault.id,
+                "resource_name": vault.name,
+                "resource_type": "Microsoft.KeyVault/vaults",
+                "description": DESCRIPTION,
+                "remediation": REMEDIATION,
+                "playbook": PLAYBOOK,
+                "frameworks": FRAMEWORKS,
+                "metadata": {
+                    "resource_group": parsed.get("resource_group", ""),
+                    "location": getattr(vault, "location", ""),
+                },
+            })
+
+    return findings

--- a/scanner/rules/az_kv_002.py
+++ b/scanner/rules/az_kv_002.py
@@ -6,7 +6,11 @@ RULE_ID = "AZ-KV-002"
 RULE_NAME = "Key Vault Allows Public Network Access Without Private Endpoint"
 SEVERITY = "HIGH"
 CATEGORY = "Key Vault"
-FRAMEWORKS = {"CIS": "8.5", "NIST": "AC-17", "ISO27001": "A.13.1.1"}
+FRAMEWORKS = {
+    "CIS": "8.3",
+    "NIST": "AC-17",
+    "ISO27001": "A.13.1.1"
+}
 
 DESCRIPTION = (
     "The Azure Key Vault is accessible over the public internet without a private endpoint configured. "
@@ -30,6 +34,7 @@ def scan(azure_client: Any, subscription_id: str) -> List[Dict[str, Any]]:
         if not props:
             continue
 
+        # Handle SDK inconsistencies (snake_case vs camelCase)
         public_access = getattr(props, "public_network_access", None)
         if public_access is None:
             public_access = getattr(props, "publicNetworkAccess", None)
@@ -38,8 +43,9 @@ def scan(azure_client: Any, subscription_id: str) -> List[Dict[str, Any]]:
         if private_endpoints is None:
             private_endpoints = getattr(props, "privateEndpointConnections", None)
 
-        is_public = str(public_access).lower() in ("enabled", "true")
-        has_private_endpoint = bool(private_endpoints)
+        # Normalize values safely
+        is_public = str(public_access).lower() in ("enabled", "true", "1")
+        has_private_endpoint = bool(private_endpoints) and len(private_endpoints) > 0
 
         if is_public and not has_private_endpoint:
             parsed = azure_client.parse_resource_id(vault.id)


### PR DESCRIPTION
## What does this PR do?

Adds a new CSPM scan rule AZ-KV-002 to detect Azure Key Vaults that are publicly accessible without a private endpoint configured, along with a remediation playbook.

## Type of change

- [x] New scan rule
- [x] Remediation playbook
- [ ] Bug fix
- [ ] Frontend component
- [ ] API endpoint
- [ ] Documentation

## Rule details

- Rule ID: AZ-KV-002  
- Severity: HIGH  
- Category: Key Vault  
- Frameworks mapped: CIS 8.3 / NIST AC-17 / ISO 27001 A.13.1.1  

## Detection logic

Flags Key Vaults where:
- `publicNetworkAccess` is enabled  
- No `privateEndpointConnections` are configured  

Handles Azure SDK inconsistencies by:
- Supporting both snake_case and camelCase properties  
- Safely handling `None` values returned by the API  

## Testing

- [x] Tested against a real Azure free trial subscription  
- [x] Returns correct JSON output  
- [x] No hardcoded credentials or secrets  

Validation performed:
- Created Key Vault with public access enabled  
- Rule correctly detected the misconfiguration  
- Applied remediation using CLI playbook  
- Re-ran scan to confirm the finding is no longer present  

## Remediation

Includes CLI playbook:
`playbooks/cli/fix_az_kv_002.sh`

This script:
- Disables public network access for the Key Vault  
- Validates input parameters  
- Provides next-step guidance to configure a private endpoint  

## Notes

- This rule does not currently evaluate Key Vault firewall (`networkAcls`) configurations, which may lead to false positives in restricted network scenarios  
- Detection focuses on network exposure via public endpoints rather than access policy configuration  

## Related issue

Closes #7  

## Checklist

- [x] My code follows the rule template in CONTRIBUTING.md  
- [x] I have not committed any real Azure credentials  
- [x] My branch name follows the convention: feat/description  