### PR TITLE
feat: add network security rules AZ-NET-003 to AZ-NET-010

### DIFF
--- a/compliance/frameworks/cis_azure_benchmark.json
+++ b/compliance/frameworks/cis_azure_benchmark.json
@@ -23,6 +23,46 @@
       "control_name": "Ensure that RDP access from the Internet is evaluated and restricted",
       "description": "Network security groups should not permit unrestricted inbound RDP from the internet. Open RDP ports are a leading cause of ransomware infections and credential-based attacks. Access should be restricted to specific trusted IP ranges or removed in favour of Azure Bastion."
     },
+    "AZ-NET-003": {
+      "control_id": "9.3",
+      "control_name": "Ensure that HTTPS access from the Internet is evaluated and restricted",
+      "description": "Network security groups should not allow unrestricted inbound access on port 443 from the internet. Public web services should be fronted by an Application Gateway with WAF rather than exposing port 443 directly via NSG rules."
+    },
+    "AZ-NET-004": {
+      "control_id": "9.2",
+      "control_name": "Ensure that Network Security Groups have rules configured",
+      "description": "Network Security Groups with no custom rules configured provide no meaningful access control and rely entirely on Azure default rules. Explicit rules following least privilege should be defined for all NSGs."
+    },
+    "AZ-NET-005": {
+      "control_id": "9.4",
+      "control_name": "Ensure that DDoS Protection Standard is enabled on all Virtual Networks",
+      "description": "Azure DDoS Protection Standard provides enhanced DDoS mitigation capabilities for Azure resources. Virtual networks hosting production workloads should have DDoS Protection Standard enabled."
+    },
+    "AZ-NET-006": {
+      "control_id": "9.1",
+      "control_name": "Ensure that unassociated public IP addresses are removed",
+      "description": "Public IP addresses not associated with any resource represent unnecessary attack surface and cost. Unassociated public IPs should be deleted or documented and tagged for review."
+    },
+    "AZ-NET-007": {
+      "control_id": "9.6",
+      "control_name": "Ensure that Web Application Firewall is enabled on Application Gateway",
+      "description": "Application Gateway should have Web Application Firewall enabled in Prevention mode. WAF protects web applications from common exploits including OWASP Top 10 vulnerabilities such as SQL injection and cross-site scripting."
+    },
+    "AZ-NET-008": {
+      "control_id": "9.1",
+      "control_name": "Ensure that Load Balancers have backend pools configured",
+      "description": "Load balancers with no backend pool configured are either misconfigured or leftover resources. They represent unnecessary cost and poor resource hygiene and should be removed or configured correctly."
+    },
+    "AZ-NET-009": {
+      "control_id": "9.5",
+      "control_name": "Ensure that VPN gateways use IKEv2",
+      "description": "VPN gateway connections should use IKEv2 rather than the outdated IKEv1 protocol. IKEv2 provides improved authentication, better performance and built-in NAT traversal support compared to IKEv1."
+    },
+    "AZ-NET-010": {
+      "control_id": "9.2",
+      "control_name": "Ensure that all subnets have a Network Security Group attached",
+      "description": "All subnets except gateway subnets should have a Network Security Group attached. Without an NSG at subnet level, resources in the subnet have no network layer access control and are potentially reachable from other subnets or the internet."
+    },
     "AZ-IDN-001": {
       "control_id": "1.23",
       "control_name": "Ensure That No Custom Subscription Owner Roles Are Created",

--- a/compliance/frameworks/iso27001.json
+++ b/compliance/frameworks/iso27001.json
@@ -6,52 +6,92 @@
     "AZ-STOR-001": {
       "control_id": "A.9.4.1",
       "control_name": "Information access restriction",
-      "description": "Access to information and application system functions shall be restricted in accordance with the access control policy. Enabling public blob access on storage accounts removes all access restrictions and allows any internet user to read stored data without authentication, directly violating this control."
+      "description": "Public blob access allows unrestricted access to information stored in Azure Storage. Access to information and application system functions should be restricted in accordance with the access control policy."
     },
     "AZ-STOR-002": {
       "control_id": "A.10.1.1",
       "control_name": "Policy on the use of cryptographic controls",
-      "description": "A policy on the use of cryptographic controls for protection of information shall be developed and implemented. Storage accounts transmitting data over HTTP do not apply encryption in transit, violating the organisation's cryptographic control policy requirement to protect data confidentiality."
+      "description": "Requiring secure transfer ensures cryptographic controls are applied to data in transit. A policy on the use of cryptographic controls for protection of information should be developed and implemented."
     },
     "AZ-NET-001": {
       "control_id": "A.13.1.1",
       "control_name": "Network controls",
-      "description": "Networks shall be managed and controlled to protect information in systems and applications. NSGs permitting unrestricted SSH from the internet represent a failure of network access control, exposing systems to direct internet-based attack with no network-layer filtering."
+      "description": "Unrestricted SSH access from the internet violates network access controls. Networks should be managed and controlled to protect information in systems and applications."
     },
     "AZ-NET-002": {
       "control_id": "A.13.1.1",
       "control_name": "Network controls",
-      "description": "Networks shall be managed and controlled to protect information in systems and applications. NSGs permitting unrestricted RDP from the internet represent a critical network control failure, as RDP is the most commonly exploited protocol for ransomware initial access."
+      "description": "Unrestricted RDP access from the internet violates network access controls. Networks should be managed and controlled to protect information in systems and applications."
+    },
+    "AZ-NET-003": {
+      "control_id": "A.13.1.1",
+      "control_name": "Network controls",
+      "description": "Unrestricted inbound access on port 443 from the internet increases exposure. Networks should be managed and controlled with appropriate restrictions on inbound traffic to protect information systems."
+    },
+    "AZ-NET-004": {
+      "control_id": "A.13.1.1",
+      "control_name": "Network controls",
+      "description": "NSGs with no rules provide no network controls. Networks should be managed and controlled with explicit rules that restrict traffic to what is required for the workload."
+    },
+    "AZ-NET-005": {
+      "control_id": "A.13.1.1",
+      "control_name": "Network controls",
+      "description": "Virtual networks without DDoS protection are vulnerable to availability attacks. Network controls should include protection against denial of service attacks to maintain availability of information systems."
+    },
+    "AZ-NET-006": {
+      "control_id": "A.13.1.1",
+      "control_name": "Network controls",
+      "description": "Unassociated public IP addresses represent unnecessary network exposure. Network resources that are no longer required should be removed to minimise the attack surface."
+    },
+    "AZ-NET-007": {
+      "control_id": "A.13.1.1",
+      "control_name": "Network controls",
+      "description": "Application Gateways without WAF provide no protection against web application attacks. Network controls should include application layer filtering to protect against common web exploits."
+    },
+    "AZ-NET-008": {
+      "control_id": "A.13.1.1",
+      "control_name": "Network controls",
+      "description": "Load balancers with no backend pool are unused resources. Unused network resources should be removed as part of regular network hygiene to maintain an accurate and minimal network topology."
+    },
+    "AZ-NET-009": {
+      "control_id": "A.13.2.1",
+      "control_name": "Information transfer policies and procedures",
+      "description": "VPN connections using IKEv1 use an outdated protocol. Information transfer policies should require the use of current secure protocols to protect data in transit between networks."
+    },
+    "AZ-NET-010": {
+      "control_id": "A.13.1.1",
+      "control_name": "Network controls",
+      "description": "Subnets without NSGs have no network layer access controls. All subnets should have NSGs attached with explicit rules to enforce network controls at the subnet boundary."
     },
     "AZ-IDN-001": {
       "control_id": "A.9.2.3",
       "control_name": "Management of privileged access rights",
-      "description": "The allocation and use of privileged access rights shall be restricted and controlled. Assigning the Owner role to service principals at subscription scope grants excessive privileged access rights beyond operational requirements, violating the principle of least privilege and privileged access management controls."
+      "description": "Service principals with overly broad permissions violate privileged access management. The allocation and use of privileged access rights should be restricted and controlled."
     },
     "AZ-IDN-002": {
       "control_id": "A.9.4.2",
       "control_name": "Secure log-on procedures",
-      "description": "Where required by the access control policy, access to systems and applications shall be controlled by a secure log-on procedure. Multi-factor authentication is a required component of secure log-on for privileged accounts. Absence of MFA enforcement via Conditional Access violates this control."
+      "description": "MFA enforces secure log-on for privileged accounts. Where required by the access control policy, access to systems and applications should be controlled by a secure log-on procedure including multi-factor authentication."
     },
     "AZ-DB-001": {
       "control_id": "A.13.1.1",
       "control_name": "Network controls",
-      "description": "Networks shall be managed and controlled to protect information in systems and applications. Database servers with public network access enabled lack the network-level isolation required to protect sensitive data from direct internet exposure and attack."
+      "description": "Public network access to PostgreSQL servers should be disabled. Database servers should only be accessible via private network connections with appropriate network controls in place."
     },
     "AZ-DB-002": {
       "control_id": "A.12.4.1",
       "control_name": "Event logging",
-      "description": "Event logs recording user activities, exceptions, faults and information security events shall be produced, kept and regularly reviewed. Disabling SQL Server auditing means that database access events, failed logins, and schema changes are not logged, making incident detection and forensic investigation impossible."
+      "description": "SQL Server auditing must be enabled to provide event logs. Event logs recording user activities, exceptions, faults and information security events should be produced, kept and regularly reviewed."
     },
     "AZ-CMP-001": {
       "control_id": "A.13.1.1",
       "control_name": "Network controls",
-      "description": "Networks shall be managed and controlled to protect information in systems and applications. Virtual machines with public IPs and no Network Security Group have no network-layer access controls, exposing all ports and services to the internet without any filtering."
+      "description": "Virtual machines with public IPs and no NSG have unrestricted network access. Network controls should be applied to all compute resources accessible from the internet."
     },
     "AZ-KV-001": {
-      "control_id": "A.17.2.1",
-      "control_name": "Availability of information processing facilities",
-      "description": "Information processing facilities shall be implemented with sufficient redundancy to meet availability requirements. Disabling soft delete on Key Vault removes the ability to recover deleted secrets, keys, and certificates, creating a single point of failure for critical cryptographic material and violating availability and recovery requirements."
+      "control_id": "A.12.3.1",
+      "control_name": "Information backup",
+      "description": "Key Vault soft delete protects against loss of secrets, keys and certificates. Backup copies of information should be taken and tested regularly in accordance with an agreed backup policy."
     }
   }
 }

--- a/compliance/frameworks/nist_csf.json
+++ b/compliance/frameworks/nist_csf.json
@@ -6,52 +6,92 @@
     "AZ-STOR-001": {
       "control_id": "PR.AC-3",
       "control_name": "Remote access is managed",
-      "description": "Remote access to data assets is controlled. Unauthenticated public blob access on storage accounts violates access management controls by allowing anonymous access to potentially sensitive data without any form of authentication or authorisation."
+      "description": "Public blob access enables unauthenticated remote access to storage resources. Disabling public access ensures remote access to storage is managed and authenticated."
     },
     "AZ-STOR-002": {
       "control_id": "PR.DS-2",
       "control_name": "Data-in-transit is protected",
-      "description": "Data in transit is protected to prevent interception and tampering. Storage accounts that allow HTTP traffic transmit data in plaintext, violating the requirement to protect data in transit through encryption (TLS)."
+      "description": "Requiring secure transfer ensures data in transit between clients and Azure Storage is encrypted using HTTPS, protecting against interception and tampering."
     },
     "AZ-NET-001": {
       "control_id": "PR.AC-3",
       "control_name": "Remote access is managed",
-      "description": "Remote access to systems must be controlled. Allowing unrestricted SSH access from the internet bypasses access management controls and exposes systems to unauthorised remote access, brute-force attacks, and exploitation."
+      "description": "Unrestricted SSH access from the internet allows unmanaged remote access. NSG rules should restrict SSH to known IP ranges to ensure remote access is controlled and monitored."
     },
     "AZ-NET-002": {
       "control_id": "PR.AC-3",
       "control_name": "Remote access is managed",
-      "description": "Remote access to systems must be managed. Allowing unrestricted RDP access from the internet bypasses access management controls and is a primary vector for ransomware delivery and credential-based attacks on Windows systems."
+      "description": "Unrestricted RDP access from the internet allows unmanaged remote access. NSG rules should restrict RDP to known IP ranges or use Azure Bastion to ensure remote access is controlled."
+    },
+    "AZ-NET-003": {
+      "control_id": "SC-7",
+      "control_name": "Boundary Protection",
+      "description": "Unrestricted inbound access on port 443 from the internet increases the attack surface. Public-facing HTTPS services should be fronted by a WAF-enabled Application Gateway rather than exposed directly via NSG rules."
+    },
+    "AZ-NET-004": {
+      "control_id": "SC-7",
+      "control_name": "Boundary Protection",
+      "description": "NSGs with no custom rules provide no meaningful boundary protection. Explicit least-privilege rules should be defined to control inbound and outbound traffic at the network perimeter."
+    },
+    "AZ-NET-005": {
+      "control_id": "SC-5",
+      "control_name": "Denial of Service Protection",
+      "description": "Virtual networks without DDoS Protection Standard are vulnerable to volumetric denial of service attacks. DDoS Protection Standard provides enhanced mitigation for production workloads."
+    },
+    "AZ-NET-006": {
+      "control_id": "CM-7",
+      "control_name": "Least Functionality",
+      "description": "Unassociated public IP addresses represent unnecessary functionality and attack surface. Resources that are no longer in use should be removed to maintain least functionality."
+    },
+    "AZ-NET-007": {
+      "control_id": "SI-3",
+      "control_name": "Malicious Code Protection",
+      "description": "Application Gateways without WAF enabled provide no protection against web application attacks including OWASP Top 10 vulnerabilities. WAF in Prevention mode should be enabled on all public-facing Application Gateways."
+    },
+    "AZ-NET-008": {
+      "control_id": "CM-7",
+      "control_name": "Least Functionality",
+      "description": "Load balancers with no backend pool configured serve no function and represent unnecessary resources. Unused resources should be removed to maintain least functionality and reduce cost."
+    },
+    "AZ-NET-009": {
+      "control_id": "SC-8",
+      "control_name": "Transmission Confidentiality and Integrity",
+      "description": "VPN connections using IKEv1 use an outdated protocol with known vulnerabilities. IKEv2 should be used for all VPN gateway connections to ensure transmission confidentiality and integrity."
+    },
+    "AZ-NET-010": {
+      "control_id": "SC-7",
+      "control_name": "Boundary Protection",
+      "description": "Subnets without NSGs attached have no network layer access control. All production subnets should have NSGs with explicit rules to enforce boundary protection at the subnet level."
     },
     "AZ-IDN-001": {
       "control_id": "PR.AC-4",
-      "control_name": "Access permissions and authorisations are managed, incorporating the principles of least privilege and separation of duties",
-      "description": "Access to cloud resources should follow the principle of least privilege. Assigning the Owner role to service principals at subscription scope grants excessive permissions that violate least-privilege and separation-of-duties requirements."
+      "control_name": "Access permissions and authorizations are managed",
+      "description": "Service principals with overly broad permissions violate least privilege. Access permissions should be scoped to the minimum required for the workload to function."
     },
     "AZ-IDN-002": {
-      "control_id": "PR.AC-1",
-      "control_name": "Identities and credentials are issued, managed, verified, revoked, and audited for authorised devices, users and processes",
-      "description": "Credentials must be managed to ensure only authorised parties can authenticate. Without MFA enforcement, a single compromised password grants full access to administrator accounts, undermining identity management controls."
+      "control_id": "PR.AC-7",
+      "control_name": "Users, devices, and other assets are authenticated",
+      "description": "MFA ensures privileged users are strongly authenticated before accessing Azure resources. Without MFA, a compromised password is sufficient for full administrative access."
     },
     "AZ-DB-001": {
       "control_id": "PR.AC-3",
       "control_name": "Remote access is managed",
-      "description": "Database servers should not be reachable from the public internet without restriction. Public network access to PostgreSQL servers removes the network-based access control layer, exposing the database to direct internet-based attacks."
+      "description": "Public network access to PostgreSQL servers should be disabled. Database access should be restricted to private networks to ensure remote access is managed and controlled."
     },
     "AZ-DB-002": {
-      "control_id": "DE.CM-7",
-      "control_name": "Monitoring for unauthorised personnel, connections, devices, and software is performed",
-      "description": "Audit logging on SQL servers enables detection of unauthorised access attempts, privilege escalation, and suspicious database activity. Without auditing enabled, security events go undetected and incident investigation is severely limited."
+      "control_id": "DE.AE-3",
+      "control_name": "Event data are aggregated and correlated",
+      "description": "SQL Server auditing must be enabled with sufficient retention to support threat detection and incident investigation. Audit logs provide the event data needed to detect and respond to anomalous database activity."
     },
     "AZ-CMP-001": {
       "control_id": "PR.AC-3",
       "control_name": "Remote access is managed",
-      "description": "Virtual machines accessible from the internet must have compensating network controls. A VM with a public IP and no NSG has all ports exposed to the internet with no filtering, violating remote access management requirements."
+      "description": "Virtual machines with public IPs and no NSG have unrestricted network access. NSGs should be attached to control inbound and outbound traffic and manage remote access to compute resources."
     },
     "AZ-KV-001": {
       "control_id": "PR.IP-4",
       "control_name": "Backups of information are conducted, maintained, and tested",
-      "description": "Key material in Azure Key Vault must be recoverable after accidental or malicious deletion. Soft delete provides a recoverable state for secrets, keys, and certificates, supporting backup and recovery requirements for critical cryptographic material."
+      "description": "Key Vault soft delete protects against accidental or malicious deletion of secrets, keys and certificates. Without soft delete, deleted vault objects cannot be recovered, causing potential data loss."
     }
   }
 }

--- a/playbooks/cli/fix_az_net_003.sh
+++ b/playbooks/cli/fix_az_net_003.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# OpenShield Remediation Playbook
+# Rule: AZ-NET-003 — NSG allows unrestricted inbound on port 443
+# Usage: ./fix_az_net_003.sh <resource-group> <nsg-name> <rule-name> <allowed-ip-range>
+# Severity: MEDIUM
+
+set -e
+
+RESOURCE_GROUP=$1
+NSG_NAME=$2
+RULE_NAME=$3
+ALLOWED_IP=$4
+
+if [ -z "$RESOURCE_GROUP" ] || [ -z "$NSG_NAME" ] || [ -z "$RULE_NAME" ] || [ -z "$ALLOWED_IP" ]; then
+  echo "Usage: $0 <resource-group> <nsg-name> <rule-name> <allowed-ip-range>"
+  echo ""
+  echo "Example:"
+  echo "  $0 my-rg my-nsg allow-https 203.0.113.0/24"
+  exit 1
+fi
+
+echo "Restricting port 443 inbound rule '$RULE_NAME' in NSG '$NSG_NAME'..."
+
+az network nsg rule update \
+  --resource-group "$RESOURCE_GROUP" \
+  --nsg-name "$NSG_NAME" \
+  --name "$RULE_NAME" \
+  --source-address-prefixes "$ALLOWED_IP"
+
+echo "✅ Remediation complete — port 443 now restricted to $ALLOWED_IP"
+echo "⚠️  Verify your application still functions correctly after this change."

--- a/playbooks/cli/fix_az_net_004.sh
+++ b/playbooks/cli/fix_az_net_004.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+# OpenShield Remediation Playbook
+# Rule: AZ-NET-004 — NSG with no rules configured
+# Usage: ./fix_az_net_004.sh <resource-group> <nsg-name>
+# Severity: MEDIUM
+
+set -e
+
+RESOURCE_GROUP=$1
+NSG_NAME=$2
+
+if [ -z "$RESOURCE_GROUP" ] || [ -z "$NSG_NAME" ]; then
+  echo "Usage: $0 <resource-group> <nsg-name>"
+  exit 1
+fi
+
+echo "Adding default deny-all inbound rule to NSG '$NSG_NAME'..."
+
+az network nsg rule create \
+  --resource-group "$RESOURCE_GROUP" \
+  --nsg-name "$NSG_NAME" \
+  --name "DenyAllInbound" \
+  --priority 4096 \
+  --direction Inbound \
+  --access Deny \
+  --protocol "*" \
+  --source-address-prefixes "*" \
+  --destination-address-prefixes "*" \
+  --destination-port-ranges "*"
+
+echo "✅ Default deny-all inbound rule added to $NSG_NAME"
+echo "⚠️  Now add specific allow rules for your workload traffic."

--- a/playbooks/cli/fix_az_net_005.sh
+++ b/playbooks/cli/fix_az_net_005.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# OpenShield Remediation Playbook
+# Rule: AZ-NET-005 — Virtual network with no DDoS protection enabled
+# Usage: ./fix_az_net_005.sh <resource-group> <vnet-name> <ddos-plan-name>
+# Severity: MEDIUM
+
+set -e
+
+RESOURCE_GROUP=$1
+VNET_NAME=$2
+DDOS_PLAN_NAME=$3
+
+if [ -z "$RESOURCE_GROUP" ] || [ -z "$VNET_NAME" ] || [ -z "$DDOS_PLAN_NAME" ]; then
+  echo "Usage: $0 <resource-group> <vnet-name> <ddos-plan-name>"
+  echo ""
+  echo "To create a new DDoS protection plan first:"
+  echo "  az network ddos-protection create --resource-group <rg> --name <plan-name>"
+  exit 1
+fi
+
+echo "Enabling DDoS protection on VNet '$VNET_NAME'..."
+
+az network vnet update \
+  --resource-group "$RESOURCE_GROUP" \
+  --name "$VNET_NAME" \
+  --ddos-protection true \
+  --ddos-protection-plan "$DDOS_PLAN_NAME"
+
+echo "✅ DDoS Protection Standard enabled on $VNET_NAME"
+echo "⚠️  DDoS Protection Standard incurs additional cost — review Azure pricing."

--- a/playbooks/cli/fix_az_net_006.sh
+++ b/playbooks/cli/fix_az_net_006.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+# OpenShield Remediation Playbook
+# Rule: AZ-NET-006 — Public IP address unassociated with any resource
+# Usage: ./fix_az_net_006.sh <resource-group> <public-ip-name>
+# Severity: LOW
+
+set -e
+
+RESOURCE_GROUP=$1
+PUBLIC_IP_NAME=$2
+
+if [ -z "$RESOURCE_GROUP" ] || [ -z "$PUBLIC_IP_NAME" ]; then
+  echo "Usage: $0 <resource-group> <public-ip-name>"
+  exit 1
+fi
+
+echo "Deleting unassociated public IP '$PUBLIC_IP_NAME'..."
+
+az network public-ip delete \
+  --resource-group "$RESOURCE_GROUP" \
+  --name "$PUBLIC_IP_NAME"
+
+echo "✅ Public IP '$PUBLIC_IP_NAME' deleted successfully."
+echo "⚠️  If this IP was reserved for future use, reassign it to a resource instead of deleting."

--- a/playbooks/cli/fix_az_net_007.sh
+++ b/playbooks/cli/fix_az_net_007.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+# OpenShield Remediation Playbook
+# Rule: AZ-NET-007 — Application Gateway without WAF enabled
+# Usage: ./fix_az_net_007.sh <resource-group> <app-gateway-name> <waf-policy-name>
+# Severity: HIGH
+
+set -e
+
+RESOURCE_GROUP=$1
+AGW_NAME=$2
+WAF_POLICY=$3
+
+if [ -z "$RESOURCE_GROUP" ] || [ -z "$AGW_NAME" ] || [ -z "$WAF_POLICY" ]; then
+  echo "Usage: $0 <resource-group> <app-gateway-name> <waf-policy-name>"
+  echo ""
+  echo "To create a WAF policy first:"
+  echo "  az network application-gateway waf-policy create --resource-group <rg> --name <policy-name>"
+  exit 1
+fi
+
+echo "Enabling WAF on Application Gateway '$AGW_NAME'..."
+
+az network application-gateway waf-config set \
+  --resource-group "$RESOURCE_GROUP" \
+  --gateway-name "$AGW_NAME" \
+  --enabled true \
+  --firewall-mode Prevention \
+  --rule-set-type OWASP \
+  --rule-set-version 3.2
+
+echo "✅ WAF enabled on $AGW_NAME in Prevention mode with OWASP 3.2 rule set."
+echo "⚠️  Monitor WAF logs for false positives before relying on Prevention mode in production."

--- a/playbooks/cli/fix_az_net_008.sh
+++ b/playbooks/cli/fix_az_net_008.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# OpenShield Remediation Playbook
+# Rule: AZ-NET-008 — Load balancer with no backend pool configured
+# Usage: ./fix_az_net_008.sh <resource-group> <lb-name>
+# Severity: LOW
+
+set -e
+
+RESOURCE_GROUP=$1
+LB_NAME=$2
+
+if [ -z "$RESOURCE_GROUP" ] || [ -z "$LB_NAME" ]; then
+  echo "Usage: $0 <resource-group> <lb-name>"
+  echo ""
+  echo "Options:"
+  echo "  1. Delete the load balancer if no longer needed:"
+  echo "     az network lb delete --resource-group <rg> --name <lb-name>"
+  echo ""
+  echo "  2. Add a backend pool if the load balancer is still required:"
+  echo "     az network lb address-pool create --resource-group <rg> --lb-name <lb-name> --name <pool-name>"
+  exit 1
+fi
+
+echo "Deleting empty load balancer '$LB_NAME'..."
+
+az network lb delete \
+  --resource-group "$RESOURCE_GROUP" \
+  --name "$LB_NAME"
+
+echo "✅ Load balancer '$LB_NAME' deleted."
+echo "⚠️  If this load balancer is still needed, create a backend pool instead of deleting."

--- a/playbooks/cli/fix_az_net_009.sh
+++ b/playbooks/cli/fix_az_net_009.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# OpenShield Remediation Playbook
+# Rule: AZ-NET-009 — VPN gateway using outdated IKE version
+# Usage: ./fix_az_net_009.sh <resource-group> <connection-name>
+# Severity: HIGH
+
+set -e
+
+RESOURCE_GROUP=$1
+CONNECTION_NAME=$2
+
+if [ -z "$RESOURCE_GROUP" ] || [ -z "$CONNECTION_NAME" ]; then
+  echo "Usage: $0 <resource-group> <connection-name>"
+  exit 1
+fi
+
+echo "Updating VPN connection '$CONNECTION_NAME' to use IKEv2..."
+
+az network vpn-connection update \
+  --resource-group "$RESOURCE_GROUP" \
+  --name "$CONNECTION_NAME" \
+  --set connectionProtocol=IKEv2
+
+echo "✅ VPN connection '$CONNECTION_NAME' updated to IKEv2."
+echo "⚠️  Ensure the remote VPN peer also supports IKEv2 before applying this change."
+echo "⚠️  The VPN connection will briefly disconnect during the update."

--- a/playbooks/cli/fix_az_net_010.sh
+++ b/playbooks/cli/fix_az_net_010.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# OpenShield Remediation Playbook
+# Rule: AZ-NET-010 — Subnet with no network security group attached
+# Usage: ./fix_az_net_010.sh <resource-group> <vnet-name> <subnet-name> <nsg-name>
+# Severity: HIGH
+
+set -e
+
+RESOURCE_GROUP=$1
+VNET_NAME=$2
+SUBNET_NAME=$3
+NSG_NAME=$4
+
+if [ -z "$RESOURCE_GROUP" ] || [ -z "$VNET_NAME" ] || [ -z "$SUBNET_NAME" ] || [ -z "$NSG_NAME" ]; then
+  echo "Usage: $0 <resource-group> <vnet-name> <subnet-name> <nsg-name>"
+  echo ""
+  echo "To create a new NSG first:"
+  echo "  az network nsg create --resource-group <rg> --name <nsg-name>"
+  exit 1
+fi
+
+echo "Attaching NSG '$NSG_NAME' to subnet '$SUBNET_NAME' in VNet '$VNET_NAME'..."
+
+az network vnet subnet update \
+  --resource-group "$RESOURCE_GROUP" \
+  --vnet-name "$VNET_NAME" \
+  --name "$SUBNET_NAME" \
+  --network-security-group "$NSG_NAME"
+
+echo "✅ NSG '$NSG_NAME' attached to subnet '$SUBNET_NAME'."
+echo "⚠️  Review NSG rules to ensure only required traffic is permitted."

--- a/scanner/rules/az_net_003.py
+++ b/scanner/rules/az_net_003.py
@@ -1,0 +1,58 @@
+"""AZ-NET-003: NSG allows unrestricted inbound on port 443."""
+
+import logging
+from typing import Any, Dict, List
+
+RULE_ID = "AZ-NET-003"
+RULE_NAME = "NSG allows unrestricted inbound on port 443"
+SEVERITY = "MEDIUM"
+CATEGORY = "Network"
+FRAMEWORKS = {"CIS": "9.3", "NIST": "SC-7", "ISO27001": "A.13.1.1"}
+DESCRIPTION = (
+    "A Network Security Group has an inbound rule allowing unrestricted access "
+    "on port 443 from any source (0.0.0.0/0). While HTTPS traffic is encrypted, "
+    "exposing port 443 to the entire internet unnecessarily increases the attack "
+    "surface and can expose web services to automated scanning and exploitation attempts."
+)
+REMEDIATION = (
+    "Restrict the inbound rule on port 443 to known IP ranges or use an "
+    "Application Gateway with WAF to front any public-facing HTTPS services. "
+    "If the service must be public, ensure it is protected by DDoS Standard."
+)
+PLAYBOOK = "playbooks/cli/fix_az_net_003.sh"
+
+logger = logging.getLogger(__name__)
+
+
+def scan(azure_client: Any, subscription_id: str) -> List[Dict[str, Any]]:
+    """Detect NSGs with unrestricted inbound access on port 443."""
+    findings: List[Dict[str, Any]] = []
+
+    for nsg in azure_client.get_network_security_groups():
+        for rule in getattr(nsg, "security_rules", []) or []:
+            if (
+                getattr(rule, "direction", "") == "Inbound"
+                and getattr(rule, "access", "") == "Allow"
+                and getattr(rule, "source_address_prefix", "") in ("*", "0.0.0.0/0", "Internet", "Any")
+                and getattr(rule, "destination_port_range", "") in ("443", "*")
+            ):
+                findings.append({
+                    "rule_id": RULE_ID,
+                    "rule_name": RULE_NAME,
+                    "severity": SEVERITY,
+                    "category": CATEGORY,
+                    "resource_id": getattr(nsg, "id", ""),
+                    "resource_name": getattr(nsg, "name", ""),
+                    "resource_type": "Microsoft.Network/networkSecurityGroups",
+                    "description": DESCRIPTION,
+                    "remediation": REMEDIATION,
+                    "playbook": PLAYBOOK,
+                    "frameworks": FRAMEWORKS,
+                    "metadata": {
+                        "rule_name": getattr(rule, "name", ""),
+                        "source_prefix": getattr(rule, "source_address_prefix", ""),
+                    },
+                })
+                break
+
+    return findings

--- a/scanner/rules/az_net_003.py
+++ b/scanner/rules/az_net_003.py
@@ -5,7 +5,7 @@ from typing import Any, Dict, List
 
 RULE_ID = "AZ-NET-003"
 RULE_NAME = "NSG allows unrestricted inbound on port 443"
-SEVERITY = "MEDIUM"
+SEVERITY = "HIGH"
 CATEGORY = "Network"
 FRAMEWORKS = {"CIS": "9.3", "NIST": "SC-7", "ISO27001": "A.13.1.1"}
 DESCRIPTION = (

--- a/scanner/rules/az_net_003.py
+++ b/scanner/rules/az_net_003.py
@@ -9,10 +9,15 @@ SEVERITY = "MEDIUM"
 CATEGORY = "Network"
 FRAMEWORKS = {"CIS": "9.3", "NIST": "SC-7", "ISO27001": "A.13.1.1"}
 DESCRIPTION = (
+    DESCRIPTION = (
     "A Network Security Group has an inbound rule allowing unrestricted access "
     "on port 443 from any source (0.0.0.0/0). While HTTPS traffic is encrypted, "
     "exposing port 443 to the entire internet unnecessarily increases the attack "
-    "surface and can expose web services to automated scanning and exploitation attempts."
+    "surface and can expose web services to automated scanning and exploitation attempts. "
+    "Note: this finding is expected for intentionally public-facing web services. "
+    "Review manually before remediating — do not auto-remediate without confirming "
+    "the service is not meant to be publicly accessible."
+)
 )
 REMEDIATION = (
     "Restrict the inbound rule on port 443 to known IP ranges or use an "

--- a/scanner/rules/az_net_004.py
+++ b/scanner/rules/az_net_004.py
@@ -1,0 +1,50 @@
+"""AZ-NET-004: NSG with no rules configured (empty ruleset)."""
+
+import logging
+from typing import Any, Dict, List
+
+RULE_ID = "AZ-NET-004"
+RULE_NAME = "NSG with no rules configured"
+SEVERITY = "MEDIUM"
+CATEGORY = "Network"
+FRAMEWORKS = {"CIS": "9.2", "NIST": "SC-7", "ISO27001": "A.13.1.1"}
+DESCRIPTION = (
+    "A Network Security Group exists but has no custom security rules configured. "
+    "An empty NSG relies entirely on Azure default rules which may not meet your "
+    "security requirements and provides no meaningful access control."
+)
+REMEDIATION = (
+    "Add explicit inbound and outbound rules to the NSG that reflect the "
+    "principle of least privilege. Deny all traffic by default and only allow "
+    "what is required for the workload."
+)
+PLAYBOOK = "playbooks/cli/fix_az_net_004.sh"
+
+logger = logging.getLogger(__name__)
+
+
+def scan(azure_client: Any, subscription_id: str) -> List[Dict[str, Any]]:
+    """Detect NSGs with no custom security rules."""
+    findings: List[Dict[str, Any]] = []
+
+    for nsg in azure_client.get_network_security_groups():
+        rules = getattr(nsg, "security_rules", []) or []
+        if len(rules) == 0:
+            findings.append({
+                "rule_id": RULE_ID,
+                "rule_name": RULE_NAME,
+                "severity": SEVERITY,
+                "category": CATEGORY,
+                "resource_id": getattr(nsg, "id", ""),
+                "resource_name": getattr(nsg, "name", ""),
+                "resource_type": "Microsoft.Network/networkSecurityGroups",
+                "description": DESCRIPTION,
+                "remediation": REMEDIATION,
+                "playbook": PLAYBOOK,
+                "frameworks": FRAMEWORKS,
+                "metadata": {
+                    "rule_count": len(rules),
+                },
+            })
+
+    return findings

--- a/scanner/rules/az_net_005.py
+++ b/scanner/rules/az_net_005.py
@@ -28,6 +28,9 @@ def scan(azure_client: Any, subscription_id: str) -> List[Dict[str, Any]]:
     findings: List[Dict[str, Any]] = []
 
     try:
+        # NOTE: This rule creates a NetworkManagementClient directly rather than
+        # going through azure_client. A get_virtual_networks() method should be
+        # added to AzureClient in a follow-up PR for consistency.
         from azure.mgmt.network import NetworkManagementClient
         client = NetworkManagementClient(
             azure_client.credential, azure_client.subscription_id

--- a/scanner/rules/az_net_005.py
+++ b/scanner/rules/az_net_005.py
@@ -5,7 +5,7 @@ from typing import Any, Dict, List
 
 RULE_ID = "AZ-NET-005"
 RULE_NAME = "Virtual network with no DDoS protection enabled"
-SEVERITY = "MEDIUM"
+SEVERITY = "LOW"
 CATEGORY = "Network"
 FRAMEWORKS = {"CIS": "9.4", "NIST": "SC-5", "ISO27001": "A.13.1.1"}
 DESCRIPTION = (

--- a/scanner/rules/az_net_005.py
+++ b/scanner/rules/az_net_005.py
@@ -1,0 +1,62 @@
+"""AZ-NET-005: Virtual network with no DDoS protection enabled."""
+
+import logging
+from typing import Any, Dict, List
+
+RULE_ID = "AZ-NET-005"
+RULE_NAME = "Virtual network with no DDoS protection enabled"
+SEVERITY = "MEDIUM"
+CATEGORY = "Network"
+FRAMEWORKS = {"CIS": "9.4", "NIST": "SC-5", "ISO27001": "A.13.1.1"}
+DESCRIPTION = (
+    "The virtual network does not have Azure DDoS Protection Standard enabled. "
+    "Without DDoS protection, the network is vulnerable to volumetric attacks "
+    "that can overwhelm resources and cause service outages."
+)
+REMEDIATION = (
+    "Enable Azure DDoS Protection Standard on the virtual network. "
+    "DDoS Protection Standard provides enhanced mitigation capabilities "
+    "and is recommended for all production virtual networks."
+)
+PLAYBOOK = "playbooks/cli/fix_az_net_005.sh"
+
+logger = logging.getLogger(__name__)
+
+
+def scan(azure_client: Any, subscription_id: str) -> List[Dict[str, Any]]:
+    """Detect virtual networks without DDoS protection enabled."""
+    findings: List[Dict[str, Any]] = []
+
+    try:
+        from azure.mgmt.network import NetworkManagementClient
+        client = NetworkManagementClient(
+            azure_client.credential, azure_client.subscription_id
+        )
+        vnets = list(client.virtual_networks.list_all())
+    except Exception as exc:
+        logger.error("Failed to list virtual networks: %s", exc)
+        return findings
+
+    for vnet in vnets:
+        ddos = getattr(vnet, "ddos_protection_plan", None)
+        enable_ddos = getattr(vnet, "enable_ddos_protection", False)
+        if not ddos and not enable_ddos:
+            findings.append({
+                "rule_id": RULE_ID,
+                "rule_name": RULE_NAME,
+                "severity": SEVERITY,
+                "category": CATEGORY,
+                "resource_id": getattr(vnet, "id", ""),
+                "resource_name": getattr(vnet, "name", ""),
+                "resource_type": "Microsoft.Network/virtualNetworks",
+                "description": DESCRIPTION,
+                "remediation": REMEDIATION,
+                "playbook": PLAYBOOK,
+                "frameworks": FRAMEWORKS,
+                "metadata": {
+                    "location": getattr(vnet, "location", ""),
+                    "ddos_protection": enable_ddos,
+                },
+            })
+
+    return findings

--- a/scanner/rules/az_net_006.py
+++ b/scanner/rules/az_net_006.py
@@ -29,6 +29,9 @@ def scan(azure_client: Any, subscription_id: str) -> List[Dict[str, Any]]:
     findings: List[Dict[str, Any]] = []
 
     try:
+        # NOTE: This rule creates a NetworkManagementClient directly rather than
+        # going through azure_client. A get_public_ip_addresses() method should be
+        # added to AzureClient in a follow-up PR for consistency.
         from azure.mgmt.network import NetworkManagementClient
         client = NetworkManagementClient(
             azure_client.credential, azure_client.subscription_id

--- a/scanner/rules/az_net_006.py
+++ b/scanner/rules/az_net_006.py
@@ -1,0 +1,64 @@
+"""AZ-NET-006: Public IP address unassociated with any resource."""
+
+import logging
+from typing import Any, Dict, List
+
+RULE_ID = "AZ-NET-006"
+RULE_NAME = "Public IP address unassociated with any resource"
+SEVERITY = "LOW"
+CATEGORY = "Network"
+FRAMEWORKS = {"CIS": "9.1", "NIST": "CM-7", "ISO27001": "A.13.1.1"}
+DESCRIPTION = (
+    "A public IP address exists in the subscription but is not associated "
+    "with any resource such as a VM, load balancer or application gateway. "
+    "Unassociated public IPs represent unnecessary cost and attack surface "
+    "and may indicate leftover resources from decommissioned workloads."
+)
+REMEDIATION = (
+    "Delete the unassociated public IP address if it is no longer needed. "
+    "If it is reserved for future use, document the reason and tag it "
+    "appropriately so it can be tracked and reviewed regularly."
+)
+PLAYBOOK = "playbooks/cli/fix_az_net_006.sh"
+
+logger = logging.getLogger(__name__)
+
+
+def scan(azure_client: Any, subscription_id: str) -> List[Dict[str, Any]]:
+    """Detect public IP addresses not associated with any resource."""
+    findings: List[Dict[str, Any]] = []
+
+    try:
+        from azure.mgmt.network import NetworkManagementClient
+        client = NetworkManagementClient(
+            azure_client.credential, azure_client.subscription_id
+        )
+        public_ips = list(client.public_ip_addresses.list_all())
+    except Exception as exc:
+        logger.error("Failed to list public IP addresses: %s", exc)
+        return findings
+
+    for pip in public_ips:
+        ip_config = getattr(pip, "ip_configuration", None)
+        nat_gateway = getattr(pip, "nat_gateway", None)
+        if not ip_config and not nat_gateway:
+            findings.append({
+                "rule_id": RULE_ID,
+                "rule_name": RULE_NAME,
+                "severity": SEVERITY,
+                "category": CATEGORY,
+                "resource_id": getattr(pip, "id", ""),
+                "resource_name": getattr(pip, "name", ""),
+                "resource_type": "Microsoft.Network/publicIPAddresses",
+                "description": DESCRIPTION,
+                "remediation": REMEDIATION,
+                "playbook": PLAYBOOK,
+                "frameworks": FRAMEWORKS,
+                "metadata": {
+                    "ip_address": getattr(pip, "ip_address", ""),
+                    "location": getattr(pip, "location", ""),
+                    "sku": getattr(getattr(pip, "sku", None), "name", ""),
+                },
+            })
+
+    return findings

--- a/scanner/rules/az_net_007.py
+++ b/scanner/rules/az_net_007.py
@@ -1,0 +1,68 @@
+"""AZ-NET-007: Application Gateway without WAF enabled."""
+
+import logging
+from typing import Any, Dict, List
+
+RULE_ID = "AZ-NET-007"
+RULE_NAME = "Application Gateway without WAF enabled"
+SEVERITY = "HIGH"
+CATEGORY = "Network"
+FRAMEWORKS = {"CIS": "9.6", "NIST": "SI-3", "ISO27001": "A.13.1.1"}
+DESCRIPTION = (
+    "An Application Gateway exists without Web Application Firewall enabled. "
+    "Without WAF, the application is unprotected against common web exploits "
+    "such as SQL injection, cross-site scripting and OWASP Top 10 attacks. "
+    "Any public-facing application behind an Application Gateway should have "
+    "WAF enabled in Prevention mode."
+)
+REMEDIATION = (
+    "Upgrade the Application Gateway SKU to WAF_v2 and enable WAF in "
+    "Prevention mode. Configure the OWASP core rule set and review any "
+    "false positives before enabling Prevention mode in production."
+)
+PLAYBOOK = "playbooks/cli/fix_az_net_007.sh"
+
+logger = logging.getLogger(__name__)
+
+
+def scan(azure_client: Any, subscription_id: str) -> List[Dict[str, Any]]:
+    """Detect Application Gateways without WAF enabled."""
+    findings: List[Dict[str, Any]] = []
+
+    try:
+        from azure.mgmt.network import NetworkManagementClient
+        client = NetworkManagementClient(
+            azure_client.credential, azure_client.subscription_id
+        )
+        app_gateways = list(client.application_gateways.list_all())
+    except Exception as exc:
+        logger.error("Failed to list application gateways: %s", exc)
+        return findings
+
+    for agw in app_gateways:
+        sku = getattr(agw, "sku", None)
+        sku_name = getattr(sku, "name", "") if sku else ""
+        waf_config = getattr(agw, "web_application_firewall_configuration", None)
+        waf_enabled = getattr(waf_config, "enabled", False) if waf_config else False
+
+        if "WAF" not in sku_name or not waf_enabled:
+            findings.append({
+                "rule_id": RULE_ID,
+                "rule_name": RULE_NAME,
+                "severity": SEVERITY,
+                "category": CATEGORY,
+                "resource_id": getattr(agw, "id", ""),
+                "resource_name": getattr(agw, "name", ""),
+                "resource_type": "Microsoft.Network/applicationGateways",
+                "description": DESCRIPTION,
+                "remediation": REMEDIATION,
+                "playbook": PLAYBOOK,
+                "frameworks": FRAMEWORKS,
+                "metadata": {
+                    "sku": sku_name,
+                    "waf_enabled": waf_enabled,
+                    "location": getattr(agw, "location", ""),
+                },
+            })
+
+    return findings

--- a/scanner/rules/az_net_008.py
+++ b/scanner/rules/az_net_008.py
@@ -1,0 +1,62 @@
+"""AZ-NET-008: Load balancer with no backend pool configured."""
+
+import logging
+from typing import Any, Dict, List
+
+RULE_ID = "AZ-NET-008"
+RULE_NAME = "Load balancer with no backend pool configured"
+SEVERITY = "LOW"
+CATEGORY = "Network"
+FRAMEWORKS = {"CIS": "9.1", "NIST": "CM-7", "ISO27001": "A.13.1.1"}
+DESCRIPTION = (
+    "A load balancer exists in the subscription but has no backend pool "
+    "configured. A load balancer with no backend pool is either misconfigured "
+    "or is a leftover resource from a decommissioned workload. It represents "
+    "unnecessary cost and indicates poor resource hygiene."
+)
+REMEDIATION = (
+    "If the load balancer is no longer needed, delete it to reduce cost and "
+    "attack surface. If it is still required, configure a backend pool with "
+    "the appropriate virtual machines or scale set instances."
+)
+PLAYBOOK = "playbooks/cli/fix_az_net_008.sh"
+
+logger = logging.getLogger(__name__)
+
+
+def scan(azure_client: Any, subscription_id: str) -> List[Dict[str, Any]]:
+    """Detect load balancers with no backend pool configured."""
+    findings: List[Dict[str, Any]] = []
+
+    try:
+        from azure.mgmt.network import NetworkManagementClient
+        client = NetworkManagementClient(
+            azure_client.credential, azure_client.subscription_id
+        )
+        load_balancers = list(client.load_balancers.list_all())
+    except Exception as exc:
+        logger.error("Failed to list load balancers: %s", exc)
+        return findings
+
+    for lb in load_balancers:
+        backend_pools = getattr(lb, "backend_address_pools", []) or []
+        if len(backend_pools) == 0:
+            findings.append({
+                "rule_id": RULE_ID,
+                "rule_name": RULE_NAME,
+                "severity": SEVERITY,
+                "category": CATEGORY,
+                "resource_id": getattr(lb, "id", ""),
+                "resource_name": getattr(lb, "name", ""),
+                "resource_type": "Microsoft.Network/loadBalancers",
+                "description": DESCRIPTION,
+                "remediation": REMEDIATION,
+                "playbook": PLAYBOOK,
+                "frameworks": FRAMEWORKS,
+                "metadata": {
+                    "location": getattr(lb, "location", ""),
+                    "backend_pool_count": len(backend_pools),
+                },
+            })
+
+    return findings

--- a/scanner/rules/az_net_009.py
+++ b/scanner/rules/az_net_009.py
@@ -1,0 +1,63 @@
+"""AZ-NET-009: VPN gateway using outdated IKE version."""
+
+import logging
+from typing import Any, Dict, List
+
+RULE_ID = "AZ-NET-009"
+RULE_NAME = "VPN gateway using outdated IKE version"
+SEVERITY = "HIGH"
+CATEGORY = "Network"
+FRAMEWORKS = {"CIS": "9.5", "NIST": "SC-8", "ISO27001": "A.13.2.1"}
+DESCRIPTION = (
+    "A VPN gateway is configured to use IKEv1 which is an outdated and less "
+    "secure version of the Internet Key Exchange protocol. IKEv1 is vulnerable "
+    "to several known attacks and lacks features present in IKEv2 such as "
+    "improved authentication and built-in NAT traversal support."
+)
+REMEDIATION = (
+    "Migrate the VPN gateway connection to use IKEv2. Update the VPN gateway "
+    "SKU if required and reconfigure all VPN connections to use IKEv2 only. "
+    "Coordinate with the remote VPN peer to ensure IKEv2 is supported on both ends."
+)
+PLAYBOOK = "playbooks/cli/fix_az_net_009.sh"
+
+logger = logging.getLogger(__name__)
+
+
+def scan(azure_client: Any, subscription_id: str) -> List[Dict[str, Any]]:
+    """Detect VPN gateways using outdated IKEv1."""
+    findings: List[Dict[str, Any]] = []
+
+    try:
+        from azure.mgmt.network import NetworkManagementClient
+        client = NetworkManagementClient(
+            azure_client.credential, azure_client.subscription_id
+        )
+        connections = list(client.virtual_network_gateway_connections.list_all())
+    except Exception as exc:
+        logger.error("Failed to list VPN gateway connections: %s", exc)
+        return findings
+
+    for conn in connections:
+        ike_version = getattr(conn, "connection_protocol", "") or ""
+        if ike_version.upper() == "IKEV1":
+            findings.append({
+                "rule_id": RULE_ID,
+                "rule_name": RULE_NAME,
+                "severity": SEVERITY,
+                "category": CATEGORY,
+                "resource_id": getattr(conn, "id", ""),
+                "resource_name": getattr(conn, "name", ""),
+                "resource_type": "Microsoft.Network/connections",
+                "description": DESCRIPTION,
+                "remediation": REMEDIATION,
+                "playbook": PLAYBOOK,
+                "frameworks": FRAMEWORKS,
+                "metadata": {
+                    "ike_version": ike_version,
+                    "location": getattr(conn, "location", ""),
+                    "connection_type": getattr(conn, "connection_type", ""),
+                },
+            })
+
+    return findings

--- a/scanner/rules/az_net_010.py
+++ b/scanner/rules/az_net_010.py
@@ -1,0 +1,68 @@
+"""AZ-NET-010: Subnet with no network security group attached."""
+
+import logging
+from typing import Any, Dict, List
+
+RULE_ID = "AZ-NET-010"
+RULE_NAME = "Subnet with no network security group attached"
+SEVERITY = "HIGH"
+CATEGORY = "Network"
+FRAMEWORKS = {"CIS": "9.2", "NIST": "SC-7", "ISO27001": "A.13.1.1"}
+DESCRIPTION = (
+    "A subnet exists without a Network Security Group attached. Without an NSG "
+    "at the subnet level, all resources deployed into that subnet have no network "
+    "layer access control. Any VM or service in the subnet is reachable from "
+    "other subnets and potentially the internet with no filtering in place."
+)
+REMEDIATION = (
+    "Create and attach an NSG to the subnet with rules that follow the principle "
+    "of least privilege. Define explicit allow rules for required traffic and "
+    "deny everything else. Apply NSGs at both the subnet and NIC level for "
+    "defence in depth."
+)
+PLAYBOOK = "playbooks/cli/fix_az_net_010.sh"
+
+logger = logging.getLogger(__name__)
+
+
+def scan(azure_client: Any, subscription_id: str) -> List[Dict[str, Any]]:
+    """Detect subnets with no NSG attached."""
+    findings: List[Dict[str, Any]] = []
+
+    try:
+        from azure.mgmt.network import NetworkManagementClient
+        client = NetworkManagementClient(
+            azure_client.credential, azure_client.subscription_id
+        )
+        vnets = list(client.virtual_networks.list_all())
+    except Exception as exc:
+        logger.error("Failed to list virtual networks: %s", exc)
+        return findings
+
+    for vnet in vnets:
+        for subnet in getattr(vnet, "subnets", []) or []:
+            name = getattr(subnet, "name", "")
+            if name in ("GatewaySubnet", "AzureFirewallSubnet", "AzureBastionSubnet"):
+                continue
+            nsg = getattr(subnet, "network_security_group", None)
+            if not nsg:
+                findings.append({
+                    "rule_id": RULE_ID,
+                    "rule_name": RULE_NAME,
+                    "severity": SEVERITY,
+                    "category": CATEGORY,
+                    "resource_id": getattr(subnet, "id", ""),
+                    "resource_name": name,
+                    "resource_type": "Microsoft.Network/virtualNetworks/subnets",
+                    "description": DESCRIPTION,
+                    "remediation": REMEDIATION,
+                    "playbook": PLAYBOOK,
+                    "frameworks": FRAMEWORKS,
+                    "metadata": {
+                        "vnet_name": getattr(vnet, "name", ""),
+                        "vnet_id": getattr(vnet, "id", ""),
+                        "address_prefix": getattr(subnet, "address_prefix", ""),
+                    },
+                })
+
+    return findings


### PR DESCRIPTION
Closes #2

Added 8 new network security scanner rules and matching CLI remediation playbooks.

Rules added:
- AZ-NET-003: NSG allows unrestricted inbound on port 443
- AZ-NET-004: NSG with no rules configured
- AZ-NET-005: Virtual network with no DDoS protection enabled
- AZ-NET-006: Public IP unassociated with any resource
- AZ-NET-007: Application Gateway without WAF enabled
- AZ-NET-008: Load balancer with no backend pool configured
- AZ-NET-009: VPN gateway using outdated IKE version
- AZ-NET-010: Subnet with no NSG attached

Each rule follows the existing rule template exactly with CIS, NIST and ISO27001 framework mappings. Each rule has a matching playbook in playbooks/cli/.