### PR TITLE
Refactor/azure client network methods

### DIFF
--- a/scanner/azure_client.py
+++ b/scanner/azure_client.py
@@ -83,6 +83,24 @@ class AzureClient:
             logger.error("get_network_interface(%s) failed: %s", nic_name, exc)
             return None
 
+    def get_virtual_networks(self) -> List[Any]:
+        """List all virtual networks in the subscription."""
+        try:
+            client = NetworkManagementClient(self.credential, self.subscription_id)
+            return list(client.virtual_networks.list_all())
+        except Exception as exc:
+            logger.error("get_virtual_networks failed: %s", exc)
+            return []
+
+    def get_public_ip_addresses(self) -> List[Any]:
+        """List all public IP addresses in the subscription."""
+        try:
+            client = NetworkManagementClient(self.credential, self.subscription_id)
+            return list(client.public_ip_addresses.list_all())
+        except Exception as exc:
+            logger.error("get_public_ip_addresses failed: %s", exc)
+            return []
+
     # ------------------------------------------------------------------ #
     # Compute                                                               #
     # ------------------------------------------------------------------ #

--- a/scanner/rules/az_net_005.py
+++ b/scanner/rules/az_net_005.py
@@ -27,20 +27,7 @@ def scan(azure_client: Any, subscription_id: str) -> List[Dict[str, Any]]:
     """Detect virtual networks without DDoS protection enabled."""
     findings: List[Dict[str, Any]] = []
 
-    try:
-        # NOTE: This rule creates a NetworkManagementClient directly rather than
-        # going through azure_client. A get_virtual_networks() method should be
-        # added to AzureClient in a follow-up PR for consistency.
-        from azure.mgmt.network import NetworkManagementClient
-        client = NetworkManagementClient(
-            azure_client.credential, azure_client.subscription_id
-        )
-        vnets = list(client.virtual_networks.list_all())
-    except Exception as exc:
-        logger.error("Failed to list virtual networks: %s", exc)
-        return findings
-
-    for vnet in vnets:
+    for vnet in azure_client.get_virtual_networks():
         ddos = getattr(vnet, "ddos_protection_plan", None)
         enable_ddos = getattr(vnet, "enable_ddos_protection", False)
         if not ddos and not enable_ddos:

--- a/scanner/rules/az_net_006.py
+++ b/scanner/rules/az_net_006.py
@@ -28,20 +28,7 @@ def scan(azure_client: Any, subscription_id: str) -> List[Dict[str, Any]]:
     """Detect public IP addresses not associated with any resource."""
     findings: List[Dict[str, Any]] = []
 
-    try:
-        # NOTE: This rule creates a NetworkManagementClient directly rather than
-        # going through azure_client. A get_public_ip_addresses() method should be
-        # added to AzureClient in a follow-up PR for consistency.
-        from azure.mgmt.network import NetworkManagementClient
-        client = NetworkManagementClient(
-            azure_client.credential, azure_client.subscription_id
-        )
-        public_ips = list(client.public_ip_addresses.list_all())
-    except Exception as exc:
-        logger.error("Failed to list public IP addresses: %s", exc)
-        return findings
-
-    for pip in public_ips:
+    for pip in azure_client.get_public_ip_addresses():
         ip_config = getattr(pip, "ip_configuration", None)
         nat_gateway = getattr(pip, "nat_gateway", None)
         if not ip_config and not nat_gateway:


### PR DESCRIPTION
Closes #20

## Summary

Resolves the inconsistency flagged during PR #16 review where AZ-NET-005 and AZ-NET-006 were instantiating NetworkManagementClient directly instead of going through the shared AzureClient wrapper.

## Changes

**scanner/azure_client.py**
Added two new methods to the Network section following the same pattern as all existing methods — consistent error handling, logging and credential management:
- get_virtual_networks() — lists all virtual networks in the subscription
- get_public_ip_addresses() — lists all public IP addresses in the subscription

**scanner/rules/az_net_005.py**
Refactored to call azure_client.get_virtual_networks() instead of instantiating NetworkManagementClient directly. Removed direct SDK import and client instantiation from the rule file.

**scanner/rules/az_net_006.py**
Refactored to call azure_client.get_public_ip_addresses() instead of instantiating NetworkManagementClient directly. Removed direct SDK import and client instantiation from the rule file.

## Why this matters

All scanner rules should access Azure resources through AzureClient methods so that any future changes to authentication, error handling or retry logic in AzureClient automatically apply to every rule without having to update individual rule files.

## References
- Flagged in PR #16 review by @Vishnu2707
- Issue #20