### PR TITLE
Remove Contributors section from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,19 +166,6 @@ Contributors are credited below.
 
 ---
 
-## Contributors
-
-Thanks to everyone who has contributed to OpenShield.
-
-| Contributor | GitHub | Contribution |
-|---|---|---|
-| Vishnu Ajith | @Vishnu2707 | Architecture, core scanner, API, compliance mappings |
-| Tanvir Farhad | @TFT444 | Sentinel integration, network rules, playbooks, breach scenarios |
-| Parth J Rohit | @parthrohit22 | AZ-KV-002 Key Vault public access rule and playbook |
-| Ritik Sah | @ritiksah141 | AZ-STOR-003 storage lifecycle rule and CI pipeline |
-
----
-
 ## 📄 License
 
 MIT — free to use, modify, and distribute.


### PR DESCRIPTION
Removed the Contributors section from the README.

## What does this PR do?
<!-- One clear sentence describing the change -->

## Type of change
- [ ] New scan rule
- [ ] Remediation playbook
- [ ] Bug fix
- [ ] Dashboard/front-end work
- [ ] API endpoint
- [ ] Documentation
- [ ] Compliance mapping

## Rule details (if applicable)
- Rule ID: AZ-XXX-000
- Severity: HIGH / MEDIUM / LOW
- Category: Storage / Network / Identity / Database / Compute / Key Vault
- Frameworks mapped: CIS / NIST / ISO 27001 / SOC 2

## Testing
- [ ] Tested against a real Azure free trial subscription
- [ ] Returns correct JSON output
- [ ] All seven CI checks pass
- [ ] No hardcoded credentials or secrets

## Related issue
Closes #

## Checklist
- [ ] My code follows the rule template in CONTRIBUTING.md
- [ ] I added or updated the matching CLI playbook
- [ ] I added or updated all four compliance framework mappings
- [ ] I have not committed any real Azure credentials
- [ ] My branch name follows the convention: feat/description
