### PR TITLE
feat: add rule AZ-STOR-004 storage account diagnostic logging check

### DIFF
--- a/compliance/frameworks/cis_azure_benchmark.json
+++ b/compliance/frameworks/cis_azure_benchmark.json
@@ -98,6 +98,11 @@
       "control_name": "Ensure that storage accounts have lifecycle management policies configured",
       "description": "Storage accounts without lifecycle management policies retain data indefinitely. This increases storage costs, expands the attack surface through accumulation of stale data, and may violate data retention compliance requirements. Lifecycle policies automate the transition and deletion of blobs based on age and access patterns."
     },
+    "AZ-STOR-004": {
+      "control_id": "3.3",
+      "control_name": "Ensure Storage logging is enabled for Blob, Queue, and Table services for read, write, and delete requests",
+      "description": "Enabling diagnostic logging for Azure Storage blob, queue, and table services records read, write, and delete operations. Without logging, unauthorized access, data exfiltration, or destructive operations on storage services cannot be detected or investigated."
+    },
     "AZ-KV-002": {
       "control_id": "8.3",
       "control_name": "Ensure that public network access to Key Vault is disabled",

--- a/compliance/frameworks/iso27001.json
+++ b/compliance/frameworks/iso27001.json
@@ -98,6 +98,11 @@
       "control_name": "Management of removable media",
       "description": "Storage accounts without lifecycle policies retain data indefinitely with no automated disposal mechanism. Lifecycle management supports formal retention, tiering, and disposal of information assets."
     },
+    "AZ-STOR-004": {
+      "control_id": "A.12.4.1",
+      "control_name": "Event logging",
+      "description": "Diagnostic logging must be enabled on Azure Storage blob, queue, and table services to produce event logs for read, write, and delete operations. Event logs recording user activities, exceptions, and information security events should be produced, kept, and regularly reviewed."
+    },
     "AZ-KV-002": {
       "control_id": "A.13.1.1",
       "control_name": "Network controls",

--- a/compliance/frameworks/nist_csf.json
+++ b/compliance/frameworks/nist_csf.json
@@ -102,6 +102,11 @@
       "control_id": "PR.DS-3",
       "control_name": "Assets are formally managed throughout removal, transfers, and disposition",
       "description": "NIST CSF PR.DS-3 requires that data assets are managed through their full lifecycle including secure disposal. Storage accounts without a lifecycle management policy have no automated mechanism for expiring or deleting aged data, meaning data subject to disposal requirements persists indefinitely and is never formally retired from the asset inventory."
+    },
+    "AZ-STOR-004": {
+      "control_id": "DE.CM-7",
+      "control_name": "Monitoring for unauthorized personnel, connections, devices, and software is performed",
+      "description": "Diagnostic logging on Azure Storage services provides the audit trail needed to monitor for unauthorized or anomalous read, write, and delete operations. Without logging, detection of data exfiltration or unauthorized access to blob, queue, or table services is not possible."
     }
   }
 }

--- a/playbooks/cli/fix_az_stor_004.sh
+++ b/playbooks/cli/fix_az_stor_004.sh
@@ -1,0 +1,150 @@
+#!/bin/bash
+# OpenShield Remediation Playbook
+# Rule:     AZ-STOR-004 — Storage Account Diagnostic Logging Disabled
+# Usage:    ./fix_az_stor_004.sh <resource-group> <storage-account-name> <log-storage-account-id>
+# Severity: MEDIUM
+#
+# What this script does:
+#   Enables Azure Monitor diagnostic settings on the blob, queue, and table
+#   service sub-resources of the specified storage account. Each service gets
+#   a diagnostic setting named "openshield-storage-logging" with StorageRead,
+#   StorageWrite, and StorageDelete enabled at a 90-day retention. Logs are
+#   written to the destination storage account you supply.
+#
+# Prerequisites:
+#   - Azure CLI installed and logged in  (az login)
+#   - Contributor or Monitoring Contributor role on the target subscription
+#   - A destination storage account for logs (pass its full resource ID)
+#
+# Example:
+#   ./fix_az_stor_004.sh my-rg my-storage-account \
+#     /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/log-rg/providers/Microsoft.Storage/storageAccounts/logstore
+
+set -euo pipefail
+
+RESOURCE_GROUP="${1:-}"
+STORAGE_ACCOUNT="${2:-}"
+LOG_STORAGE_ACCOUNT_ID="${3:-}"
+
+# ── Argument validation ──────────────────────────────────────────────────────
+
+if [ -z "$RESOURCE_GROUP" ] || [ -z "$STORAGE_ACCOUNT" ] || [ -z "$LOG_STORAGE_ACCOUNT_ID" ]; then
+  echo "Usage: $0 <resource-group> <storage-account-name> <log-storage-account-id>"
+  echo ""
+  echo "Arguments:"
+  echo "  resource-group          Resource group of the storage account to remediate"
+  echo "  storage-account-name    Name of the storage account to remediate"
+  echo "  log-storage-account-id  Full Azure resource ID of the destination log storage account"
+  echo ""
+  echo "Example:"
+  echo "  $0 my-rg my-storage \\"
+  echo "    /subscriptions/<sub-id>/resourceGroups/log-rg/providers/Microsoft.Storage/storageAccounts/logstore"
+  exit 1
+fi
+
+# ── Validate names contain only Azure-safe characters ───────────────────────
+
+if ! [[ "$RESOURCE_GROUP" =~ ^[a-zA-Z0-9._()-]+$ ]]; then
+  echo "ERROR: resource-group contains invalid characters: '$RESOURCE_GROUP'"
+  exit 1
+fi
+
+if ! [[ "$STORAGE_ACCOUNT" =~ ^[a-z0-9]{3,24}$ ]]; then
+  echo "ERROR: storage-account-name must be 3-24 lowercase letters and numbers only."
+  exit 1
+fi
+
+# ── Resolve subscription ID ──────────────────────────────────────────────────
+
+SUBSCRIPTION_ID=$(az account show --query id -o tsv)
+if [ -z "$SUBSCRIPTION_ID" ]; then
+  echo "ERROR: Could not determine subscription ID. Run 'az login' first."
+  exit 1
+fi
+
+# ── Build base resource ID ───────────────────────────────────────────────────
+
+BASE_ID="/subscriptions/${SUBSCRIPTION_ID}/resourceGroups/${RESOURCE_GROUP}/providers/Microsoft.Storage/storageAccounts/${STORAGE_ACCOUNT}"
+
+BLOB_RESOURCE_ID="${BASE_ID}/blobServices/default"
+QUEUE_RESOURCE_ID="${BASE_ID}/queueServices/default"
+TABLE_RESOURCE_ID="${BASE_ID}/tableServices/default"
+
+LOG_SETTING_NAME="openshield-storage-logging"
+
+LOG_CATEGORIES='[
+  {"category":"StorageRead","enabled":true,"retentionPolicy":{"days":90,"enabled":true}},
+  {"category":"StorageWrite","enabled":true,"retentionPolicy":{"days":90,"enabled":true}},
+  {"category":"StorageDelete","enabled":true,"retentionPolicy":{"days":90,"enabled":true}}
+]'
+
+# ── Confirm before making changes ────────────────────────────────────────────
+
+echo "============================================================"
+echo "  OpenShield Remediation — AZ-STOR-004"
+echo "============================================================"
+echo ""
+echo "  Storage account  : $STORAGE_ACCOUNT"
+echo "  Resource group   : $RESOURCE_GROUP"
+echo "  Log destination  : $LOG_STORAGE_ACCOUNT_ID"
+echo ""
+echo "  Services to configure:"
+echo "    - blobServices/default"
+echo "    - queueServices/default"
+echo "    - tableServices/default"
+echo ""
+echo "  Each service will have diagnostic setting '$LOG_SETTING_NAME' with:"
+echo "    StorageRead, StorageWrite, StorageDelete (retention 90 days)"
+echo ""
+read -r -p "Proceed? [y/N] " CONFIRM
+if [[ "$CONFIRM" != "y" && "$CONFIRM" != "Y" ]]; then
+  echo "Aborted. No changes were made."
+  exit 0
+fi
+
+# ── Enable diagnostic settings on all three services ────────────────────────
+
+echo ""
+echo "[1/3] Enabling diagnostic logging on blob service ..."
+az monitor diagnostic-settings create \
+  --resource  "$BLOB_RESOURCE_ID" \
+  --name      "$LOG_SETTING_NAME" \
+  --storage-account "$LOG_STORAGE_ACCOUNT_ID" \
+  --logs      "$LOG_CATEGORIES"
+echo "      Done."
+
+echo ""
+echo "[2/3] Enabling diagnostic logging on queue service ..."
+az monitor diagnostic-settings create \
+  --resource  "$QUEUE_RESOURCE_ID" \
+  --name      "$LOG_SETTING_NAME" \
+  --storage-account "$LOG_STORAGE_ACCOUNT_ID" \
+  --logs      "$LOG_CATEGORIES"
+echo "      Done."
+
+echo ""
+echo "[3/3] Enabling diagnostic logging on table service ..."
+az monitor diagnostic-settings create \
+  --resource  "$TABLE_RESOURCE_ID" \
+  --name      "$LOG_SETTING_NAME" \
+  --storage-account "$LOG_STORAGE_ACCOUNT_ID" \
+  --logs      "$LOG_CATEGORIES"
+echo "      Done."
+
+# ── Confirmation ─────────────────────────────────────────────────────────────
+
+echo ""
+echo "============================================================"
+echo "  Remediation complete for: $STORAGE_ACCOUNT"
+echo "============================================================"
+echo ""
+echo "  Diagnostic setting '$LOG_SETTING_NAME' created on:"
+echo "    blobServices/default   — StorageRead, StorageWrite, StorageDelete (90-day retention)"
+echo "    queueServices/default  — StorageRead, StorageWrite, StorageDelete (90-day retention)"
+echo "    tableServices/default  — StorageRead, StorageWrite, StorageDelete (90-day retention)"
+echo ""
+echo "  To verify:"
+echo "    az monitor diagnostic-settings list --resource $BLOB_RESOURCE_ID"
+echo "    az monitor diagnostic-settings list --resource $QUEUE_RESOURCE_ID"
+echo "    az monitor diagnostic-settings list --resource $TABLE_RESOURCE_ID"
+echo "============================================================"

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,7 @@ azure-mgmt-keyvault==10.3.0
 azure-mgmt-rdbms==10.1.0
 azure-mgmt-authorization==4.0.0
 azure-monitor-ingestion==1.0.3
+azure-mgmt-monitor==6.0.0
 psycopg2-binary==2.9.9
 python-dotenv==1.0.0
 pyjwt==2.8.0

--- a/scanner/azure_client.py
+++ b/scanner/azure_client.py
@@ -11,6 +11,7 @@ from azure.mgmt.keyvault import KeyVaultManagementClient
 from azure.mgmt.network import NetworkManagementClient
 from azure.mgmt.rdbms.postgresql import PostgreSQLManagementClient
 from azure.mgmt.sql import SqlManagementClient
+from azure.mgmt.monitor import MonitorManagementClient
 from azure.mgmt.storage import StorageManagementClient
 
 logger = logging.getLogger(__name__)
@@ -124,6 +125,83 @@ class AzureClient:
             logger.error(
                 "get_storage_lifecycle_policy(%s) unexpected error: %s",
                 account_name,
+                exc,
+            )
+            return None
+
+    def get_storage_service_logging(
+        self, resource_group: str, account_name: str, service: str
+    ) -> Optional[bool]:
+        """Check Azure Monitor diagnostic settings for a storage service sub-resource.
+
+        Three-state return — the calling rule uses strict identity checks
+        (is False / is None) to distinguish these states:
+
+            True  — at least one diagnostic setting has StorageRead, StorageWrite,
+                    and StorageDelete all enabled (compliant).
+            False — no setting covers all three required categories (non-compliant).
+            None  — permission error or unexpected SDK failure.
+                    Caller must NOT create a finding — skip with a warning
+                    to avoid false positives.
+
+        Args:
+            resource_group: Resource group containing the storage account.
+            account_name:   Name of the storage account.
+            service:        Sub-service to check: "blob", "queue", or "table".
+
+        Returns:
+            Optional[bool] — True, False, or None as described above.
+        """
+        _REQUIRED = {"StorageRead", "StorageWrite", "StorageDelete"}
+        _SERVICE_MAP = {
+            "blob":  "blobServices",
+            "queue": "queueServices",
+            "table": "tableServices",
+        }
+        svc_path = _SERVICE_MAP.get(service)
+        if not svc_path:
+            logger.error(
+                "get_storage_service_logging: unknown service %r — must be "
+                "blob, queue, or table",
+                service,
+            )
+            return None
+
+        resource_uri = (
+            f"/subscriptions/{self.subscription_id}"
+            f"/resourceGroups/{resource_group}"
+            f"/providers/Microsoft.Storage/storageAccounts/{account_name}"
+            f"/{svc_path}/default"
+        )
+        try:
+            client = MonitorManagementClient(self.credential, self.subscription_id)
+            settings = list(client.diagnostic_settings.list(resource_uri))
+            for setting in settings:
+                enabled_categories = {
+                    log.category
+                    for log in (getattr(setting, "logs", None) or [])
+                    if getattr(log, "enabled", False)
+                }
+                if _REQUIRED.issubset(enabled_categories):
+                    return True
+            return False
+
+        except HttpResponseError as exc:
+            logger.error(
+                "get_storage_service_logging(%s/%s) HTTP %s — "
+                "check service principal permissions: %s",
+                account_name,
+                service,
+                exc.status_code,
+                exc,
+            )
+            return None
+
+        except Exception as exc:
+            logger.error(
+                "get_storage_service_logging(%s/%s) unexpected error: %s",
+                account_name,
+                service,
                 exc,
             )
             return None

--- a/scanner/rules/az_stor_004.py
+++ b/scanner/rules/az_stor_004.py
@@ -1,0 +1,121 @@
+"""AZ-STOR-004: Storage account diagnostic logging disabled for blob, queue, or table."""
+
+import logging
+from typing import Any, Dict, List, Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+# ── Required module-level constants ─────────────────────────────────────────
+
+RULE_ID = "AZ-STOR-004"
+RULE_NAME = "Storage Account Diagnostic Logging Disabled"
+SEVERITY = "MEDIUM"
+CATEGORY = "Storage"
+FRAMEWORKS = {
+    "CIS":      "3.3",
+    "NIST":     "DE.CM-7",
+    "ISO27001": "A.12.4.1",
+}
+DESCRIPTION = (
+    "Azure Monitor diagnostic logging is not fully enabled for the {service} "
+    "service on this storage account. StorageRead, StorageWrite, and "
+    "StorageDelete must all be enabled. Without logging, operations on this "
+    "service cannot be detected or investigated, making it impossible to "
+    "identify data exfiltration or unauthorised access. CIS Azure Benchmark "
+    "3.3 requires logging for blob, queue, and table services for read, write, "
+    "and delete requests."
+)
+REMEDIATION = (
+    "Enable Azure Monitor diagnostic settings on the storage account's "
+    "{service} service with StorageRead, StorageWrite, and StorageDelete all "
+    "set to enabled. Navigate to: Storage Account > Monitoring > "
+    "Diagnostic settings > {service} > Add diagnostic setting, then check "
+    "StorageRead, StorageWrite, and StorageDelete."
+)
+PLAYBOOK = "playbooks/cli/fix_az_stor_004.sh"
+
+# Maps service key → (sub-resource path segment, resource_type)
+_SERVICES: Dict[str, Tuple[str, str]] = {
+    "blob":  ("blobServices",  "Microsoft.Storage/storageAccounts/blobServices"),
+    "queue": ("queueServices", "Microsoft.Storage/storageAccounts/queueServices"),
+    "table": ("tableServices", "Microsoft.Storage/storageAccounts/tableServices"),
+}
+
+
+# ── Required scan function ───────────────────────────────────────────────────
+
+def scan(azure_client: Any, subscription_id: str) -> List[Dict[str, Any]]:
+    """Detect storage account services with incomplete diagnostic logging.
+
+    For each storage account, all three sub-services (blob, queue, table) are
+    checked independently. A separate finding is emitted for each service that
+    does not have StorageRead, StorageWrite, and StorageDelete all enabled.
+
+    Three-state return from get_storage_service_logging():
+        True  — all three log categories enabled → skip (compliant)
+        False — one or more categories missing → create finding
+        None  — permissions error or unexpected failure → skip with warning
+                to avoid false positives
+
+    Args:
+        azure_client:    An AzureClient instance with all SDK clients
+                         pre-configured.
+        subscription_id: The Azure subscription ID being scanned.
+
+    Returns:
+        A list of finding dicts — one per storage service sub-resource that
+        does not have full diagnostic logging. Services that could not be
+        checked are skipped and logged as warnings.
+    """
+    findings: List[Dict[str, Any]] = []
+
+    for account in azure_client.get_storage_accounts():
+        resource_id = getattr(account, "id", "")
+        account_name = getattr(account, "name", "")
+        location = getattr(account, "location", "")
+
+        if not resource_id or not account_name:
+            continue
+
+        parsed = azure_client.parse_resource_id(resource_id)
+        resource_group = parsed.get("resource_group", "")
+        if not resource_group:
+            continue
+
+        for service, (svc_path, resource_type) in _SERVICES.items():
+            # True = compliant, False = logging incomplete, None = could not determine
+            logging_status: Optional[bool] = azure_client.get_storage_service_logging(
+                resource_group, account_name, service
+            )
+
+            if logging_status is None:
+                logger.warning(
+                    "AZ-STOR-004: Could not determine %s logging status for %s "
+                    "— skipping. Ensure the service principal has "
+                    "microsoft.insights/diagnosticSettings/read permission.",
+                    service,
+                    account_name,
+                )
+                continue
+
+            if logging_status is False:
+                findings.append({
+                    "rule_id":       RULE_ID,
+                    "rule_name":     RULE_NAME,
+                    "severity":      SEVERITY,
+                    "category":      CATEGORY,
+                    "resource_id":   f"{resource_id}/{svc_path}/default",
+                    "resource_name": f"{account_name}/{svc_path}",
+                    "resource_type": resource_type,
+                    "description":   DESCRIPTION.format(service=service),
+                    "remediation":   REMEDIATION.format(service=service),
+                    "playbook":      PLAYBOOK,
+                    "frameworks":    FRAMEWORKS,
+                    "metadata": {
+                        "resource_group": resource_group,
+                        "location":       location,
+                        "service":        service,
+                    },
+                })
+
+    return findings


### PR DESCRIPTION
Adds AZ-STOR-004 to detect storage accounts with diagnostic logging not fully enabled on blob, queue, or table services. Emits one finding per non-compliant service. Adds get_storage_service_logging() to AzureClient and fix_az_stor_004.sh playbook. Frameworks: CIS 3.3, NIST DE.CM-7, ISO 27001 A.12.4.1. Closes #23