### PR TITLE
feat: AZ-NET-011 Network Watcher not enabled in all regions

### DIFF
--- a/compliance/frameworks/cis_azure_benchmark.json
+++ b/compliance/frameworks/cis_azure_benchmark.json
@@ -101,7 +101,7 @@
     "AZ-KV-001": {
       "control_id": "8.5",
       "control_name": "Ensure the Key Vault is Recoverable",
-      "description": "Azure Key Vault soft delete should be enabled on all Key Vaults. The soft delete feature allows recovery of deleted vaults and vault objects (keys, secrets, certificates) for a configurable retention period (7–90 days), protecting against accidental or malicious deletion."
+      "description": "Azure Key Vault soft delete should be enabled on all Key Vaults. The soft delete feature allows recovery of deleted vaults and vault objects (keys, secrets, certificates) for a configurable retention period (7\u201390 days), protecting against accidental or malicious deletion."
     },
     "AZ-STOR-003": {
       "control_id": "3.7",
@@ -117,6 +117,11 @@
       "control_id": "8.3",
       "control_name": "Ensure that public network access to Key Vault is disabled",
       "description": "Azure Key Vault should not allow public network access unless absolutely necessary. Enabling public access increases the attack surface and exposes sensitive secrets, keys, and certificates to potential unauthorized access. Private endpoints should be used to restrict access to trusted networks."
+    },
+    "AZ-NET-011": {
+      "control_id": "6.5",
+      "control_name": "Ensure that Network Watcher is enabled in all regions",
+      "description": "Network Watcher should be enabled in all regions where Azure resources are deployed. Network Watcher provides network monitoring, diagnostics, and logging capabilities essential for investigating network-level incidents."
     }
   }
 }

--- a/compliance/frameworks/iso27001.json
+++ b/compliance/frameworks/iso27001.json
@@ -117,6 +117,11 @@
       "control_id": "A.13.1.1",
       "control_name": "Network controls",
       "description": "Networks should be managed and controlled to protect information systems and applications. Allowing public network access to Azure Key Vault increases exposure of sensitive secrets, keys, and certificates to external networks. Access should be restricted to trusted networks using private endpoints or network controls."
+    },
+    "AZ-NET-011": {
+      "control_id": "A.12.4.1",
+      "control_name": "Event logging",
+      "description": "Network Watcher must be enabled in all regions where resources are deployed to ensure network events are logged and available for investigation. Event logs recording network activity should be produced and retained to support incident response."
     }
   }
 }

--- a/compliance/frameworks/nist_csf.json
+++ b/compliance/frameworks/nist_csf.json
@@ -97,7 +97,7 @@
       "control_id": "PR.DS-1",
       "control_name": "Data-at-rest is protected",
       "description": "Virtual machine OS and data disks are using platform-managed encryption only (EncryptionAtRestWithPlatformKey). PR.DS-1 requires that data at rest is protected using appropriate controls. Platform-managed encryption does not give the organisation control over the encryption keys. Customer-managed keys or Azure Disk Encryption are required to satisfy this control."
-   },
+    },
     "AZ-KV-001": {
       "control_id": "PR.IP-4",
       "control_name": "Backups of information are conducted, maintained, and tested",
@@ -117,6 +117,11 @@
       "control_id": "DE.CM-7",
       "control_name": "Monitoring for unauthorized personnel, connections, devices, and software is performed",
       "description": "Diagnostic logging on Azure Storage services provides the audit trail needed to monitor for unauthorized or anomalous read, write, and delete operations. Without logging, detection of data exfiltration or unauthorized access to blob, queue, or table services is not possible."
+    },
+    "AZ-NET-011": {
+      "control_id": "DE.CM-7",
+      "control_name": "Monitoring for unauthorized personnel, connections, devices, and software is performed",
+      "description": "Network Watcher must be enabled in all active regions to support continuous monitoring of network activity. Without it, unauthorized connections and anomalous network behaviour cannot be detected or investigated."
     }
   }
 }

--- a/compliance/frameworks/soc2.json
+++ b/compliance/frameworks/soc2.json
@@ -112,6 +112,11 @@
       "control_id": "CC6.6",
       "control_name": "Restricts Access from Outside the Network Boundary",
       "description": "A Key Vault accessible from the public internet allows any external party to attempt access to secrets, keys and certificates. CC6.6 requires that access from outside the network boundary is restricted and controlled. Locking Key Vault access to private endpoints or specific VNet service endpoints enforces this boundary and protects sensitive credentials from external exposure."
+    },
+    "AZ-NET-011": {
+      "control_id": "CC7.2",
+      "control_name": "System monitoring",
+      "description": "Network Watcher must be enabled in all regions where resources are deployed to support continuous system monitoring. Without it, network-level events cannot be detected or investigated, violating the requirement for ongoing monitoring of system components."
     }
   }
 }

--- a/playbooks/cli/fix_az_net_011.sh
+++ b/playbooks/cli/fix_az_net_011.sh
@@ -10,13 +10,9 @@ if [[ $# -lt 1 ]]; then
 fi
 
 SUBSCRIPTION_ID="$1"
-RESOURCE_GROUP="NetworkWatcherRG"
 
 echo "Setting subscription..."
 az account set --subscription "$SUBSCRIPTION_ID"
-
-echo "Ensuring resource group exists..."
-az group create --name "$RESOURCE_GROUP" --location eastus --output none 2>/dev/null || true
 
 echo "Fetching regions with resources..."
 RESOURCE_REGIONS=$(az resource list --subscription "$SUBSCRIPTION_ID" \
@@ -31,13 +27,17 @@ while IFS= read -r REGION; do
   if echo "$WATCHED_REGIONS" | grep -qx "$REGION"; then
     echo "  [SKIP] $REGION — already enabled"
   else
-    echo "  [FIX]  $REGION — enabling..."
+    RESOURCE_GROUP="NetworkWatcherRG-${REGION}"
+    echo "  [FIX]  $REGION — creating resource group $RESOURCE_GROUP..."
+    az group create --name "$RESOURCE_GROUP" --location "$REGION" --output none
+    echo "  [FIX]  $REGION — enabling Network Watcher..."
     az network watcher configure \
       --resource-group "$RESOURCE_GROUP" \
       --locations "$REGION" \
       --enabled true \
       --subscription "$SUBSCRIPTION_ID" \
       --output none
+    echo "         Done."
   fi
 done <<< "$RESOURCE_REGIONS"
 

--- a/playbooks/cli/fix_az_net_011.sh
+++ b/playbooks/cli/fix_az_net_011.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+# Playbook: fix_az_net_011.sh
+# Rule: AZ-NET-011 — Network Watcher not enabled in all regions
+
+set -euo pipefail
+
+if [[ $# -lt 1 ]]; then
+  echo "Usage: $0 <subscription_id>"
+  exit 1
+fi
+
+SUBSCRIPTION_ID="$1"
+RESOURCE_GROUP="NetworkWatcherRG"
+
+echo "Setting subscription..."
+az account set --subscription "$SUBSCRIPTION_ID"
+
+echo "Ensuring resource group exists..."
+az group create --name "$RESOURCE_GROUP" --location eastus --output none 2>/dev/null || true
+
+echo "Fetching regions with resources..."
+RESOURCE_REGIONS=$(az resource list --subscription "$SUBSCRIPTION_ID" \
+  --query "[].location" --output tsv | sort -u | tr -d ' ')
+
+echo "Fetching regions with Network Watcher..."
+WATCHED_REGIONS=$(az network watcher list --subscription "$SUBSCRIPTION_ID" \
+  --query "[].location" --output tsv 2>/dev/null | sort -u | tr -d ' ' || echo "")
+
+echo "Enabling Network Watcher in unmonitored regions..."
+while IFS= read -r REGION; do
+  if echo "$WATCHED_REGIONS" | grep -qx "$REGION"; then
+    echo "  [SKIP] $REGION — already enabled"
+  else
+    echo "  [FIX]  $REGION — enabling..."
+    az network watcher configure \
+      --resource-group "$RESOURCE_GROUP" \
+      --locations "$REGION" \
+      --enabled true \
+      --subscription "$SUBSCRIPTION_ID" \
+      --output none
+  fi
+done <<< "$RESOURCE_REGIONS"
+
+echo "Done! Verify with:"
+echo "  az network watcher list --subscription $SUBSCRIPTION_ID --output table"

--- a/scanner/azure_client.py
+++ b/scanner/azure_client.py
@@ -351,3 +351,31 @@ class AzureClient:
         except Exception as exc:
             logger.error("get_conditional_access_policies failed: %s", exc)
             return []
+    def get_regions_with_resources(self) -> List[str]:
+        """List all regions that have at least one resource deployed."""
+        try:
+            from azure.mgmt.resource import ResourceManagementClient
+            client = ResourceManagementClient(self.credential, self.subscription_id)
+            regions = {
+                r.location.lower().replace(" ", "")
+                for r in client.resources.list()
+                if r.location
+            }
+            return list(regions)
+        except Exception as exc:
+            logger.error("get_regions_with_resources failed: %s", exc)
+            return []
+
+    def get_network_watcher_regions(self) -> List[str]:
+        """List all regions that already have Network Watcher enabled."""
+        try:
+            client = NetworkManagementClient(self.credential, self.subscription_id)
+            regions = {
+                w.location.lower().replace(" ", "")
+                for w in client.network_watchers.list_all()
+                if w.location
+            }
+            return list(regions)
+        except Exception as exc:
+            logger.error("get_network_watcher_regions failed: %s", exc)
+            return []

--- a/scanner/rules/az_net_011.py
+++ b/scanner/rules/az_net_011.py
@@ -5,7 +5,7 @@ RULE_ID = "AZ-NET-011"
 RULE_NAME = "Network Watcher Not Enabled in All Regions"
 SEVERITY = "LOW"
 CATEGORY = "Network"
-FRAMEWORKS = {"CIS": "6.5", "NIST": "DE.CM-7", "ISO27001": "A.12.4.1"}
+FRAMEWORKS = {"CIS": "6.5", "NIST": "DE.CM-7", "ISO27001": "A.12.4.1", "SOC2": "CC7.2"}
 DESCRIPTION = (
     "Network Watcher is not enabled in one or more Azure regions where resources "
     "are deployed. Network Watcher provides network monitoring, diagnostics, and "

--- a/scanner/rules/az_net_011.py
+++ b/scanner/rules/az_net_011.py
@@ -1,0 +1,48 @@
+"""AZ-NET-011: Network Watcher not enabled in all regions."""
+from typing import Any, Dict, List
+
+RULE_ID = "AZ-NET-011"
+RULE_NAME = "Network Watcher Not Enabled in All Regions"
+SEVERITY = "LOW"
+CATEGORY = "Network"
+FRAMEWORKS = {"CIS": "6.5", "NIST": "DE.CM-7", "ISO27001": "A.12.4.1"}
+DESCRIPTION = (
+    "Network Watcher is not enabled in one or more Azure regions where resources "
+    "are deployed. Network Watcher provides network monitoring, diagnostics, and "
+    "logging capabilities. Without it, network-level incidents cannot be "
+    "investigated or diagnosed."
+)
+REMEDIATION = (
+    "Enable Network Watcher in all regions where Azure resources are deployed. "
+    "Run: az network watcher configure --resource-group NetworkWatcherRG "
+    "--locations <region> --enabled true"
+)
+PLAYBOOK = "playbooks/cli/fix_az_net_011.sh"
+
+
+def scan(azure_client: Any, subscription_id: str) -> List[Dict[str, Any]]:
+    """Detect regions where resources exist but Network Watcher is not enabled."""
+    findings: List[Dict[str, Any]] = []
+
+    regions_with_resources = azure_client.get_regions_with_resources()
+    regions_with_watcher = azure_client.get_network_watcher_regions()
+
+    unmonitored_regions = set(regions_with_resources) - set(regions_with_watcher)
+
+    for region in sorted(unmonitored_regions):
+        findings.append({
+            "rule_id": RULE_ID,
+            "rule_name": RULE_NAME,
+            "severity": SEVERITY,
+            "category": CATEGORY,
+            "resource_id": f"/subscriptions/{subscription_id}/regions/{region}",
+            "resource_name": region,
+            "resource_type": "Microsoft.Network/networkWatchers",
+            "description": DESCRIPTION,
+            "remediation": REMEDIATION,
+            "playbook": PLAYBOOK,
+            "frameworks": FRAMEWORKS,
+            "metadata": {"region": region},
+        })
+
+    return findings


### PR DESCRIPTION

## What does this PR do?
Adds AZ-NET-011 scanner rule to detect Azure regions where resources exist but Network Watcher is not enabled, along with a remediation playbook and compliance mappings.

## Type of change
- [x] New scan rule
- [x] Remediation playbook
- [ ] Bug fix
- [ ] Dashboard/front-end work
- [ ] API endpoint
- [ ] Documentation
- [x] Compliance mapping

## Rule details (if applicable)
- Rule ID: AZ-NET-011
- Severity: LOW
- Category: Network
- Frameworks mapped: CIS / NIST / ISO 27001

## Testing
- [ ] Tested against a real Azure free trial subscription
- [x] Returns correct JSON output
- [ ] All seven CI checks pass
- [x] No hardcoded credentials or secrets

## Related issue
Closes #28
