### PR TITLE
feat: add rule AZ-CMP-002 — VM without disk encryption enabled

### DIFF
--- a/compliance/frameworks/cis_azure_benchmark.json
+++ b/compliance/frameworks/cis_azure_benchmark.json
@@ -13,11 +13,6 @@
       "control_name": "Ensure that 'Secure transfer required' is set to 'Enabled'",
       "description": "Enabling 'Secure transfer required' on a storage account ensures that all requests made to the storage account use HTTPS. Any requests using HTTP are rejected, protecting data in transit from eavesdropping and man-in-the-middle attacks."
     },
-    "AZ-STOR-003": {
-      "control_id": "3.7",
-      "control_name": "Ensure that storage accounts have lifecycle management policies configured",
-      "description": "Storage accounts without lifecycle management policies retain data indefinitely. This increases storage costs, expands the attack surface through accumulation of stale data, and may violate data retention compliance requirements. Lifecycle policies automate the transition and deletion of blobs based on age and access patterns."
-    },
     "AZ-NET-001": {
       "control_id": "6.2",
       "control_name": "Ensure that SSH access from the Internet is evaluated and restricted",
@@ -102,6 +97,11 @@
       "control_id": "8.5",
       "control_name": "Ensure the Key Vault is Recoverable",
       "description": "Azure Key Vault soft delete should be enabled on all Key Vaults. The soft delete feature allows recovery of deleted vaults and vault objects (keys, secrets, certificates) for a configurable retention period (7–90 days), protecting against accidental or malicious deletion."
+    },
+    "AZ-STOR-003": {
+      "control_id": "3.7",
+      "control_name": "Ensure that storage accounts have lifecycle management policies configured",
+      "description": "Storage accounts without lifecycle management policies retain data indefinitely. This increases storage costs, expands the attack surface through accumulation of stale data, and may violate data retention compliance requirements. Lifecycle policies automate the transition and deletion of blobs based on age and access patterns."
     },
     "AZ-KV-002": {
       "control_id": "8.3",

--- a/compliance/frameworks/cis_azure_benchmark.json
+++ b/compliance/frameworks/cis_azure_benchmark.json
@@ -13,6 +13,11 @@
       "control_name": "Ensure that 'Secure transfer required' is set to 'Enabled'",
       "description": "Enabling 'Secure transfer required' on a storage account ensures that all requests made to the storage account use HTTPS. Any requests using HTTP are rejected, protecting data in transit from eavesdropping and man-in-the-middle attacks."
     },
+    "AZ-STOR-003": {
+      "control_id": "3.7",
+      "control_name": "Ensure that storage accounts have lifecycle management policies configured",
+      "description": "Storage accounts without lifecycle management policies retain data indefinitely. This increases storage costs, expands the attack surface through accumulation of stale data, and may violate data retention compliance requirements. Lifecycle policies automate the transition and deletion of blobs based on age and access patterns."
+    },
     "AZ-NET-001": {
       "control_id": "6.2",
       "control_name": "Ensure that SSH access from the Internet is evaluated and restricted",
@@ -88,15 +93,15 @@
       "control_name": "Ensure that 'OS disk' are encrypted",
       "description": "Virtual machines that are reachable from the internet should have Network Security Groups attached to their network interfaces to control and restrict inbound and outbound traffic, reducing the attack surface."
     },
+    "AZ-CMP-002": {
+      "control_id": "7.2",
+      "control_name": "Ensure that 'OS disk' are encrypted",
+      "description": "Virtual machine OS and data disks should be encrypted using Azure Disk Encryption or server-side encryption with customer-managed keys. Unencrypted disks can be snapshotted and read by an attacker who gains subscription access without needing VM credentials."
+    },
     "AZ-KV-001": {
       "control_id": "8.5",
       "control_name": "Ensure the Key Vault is Recoverable",
       "description": "Azure Key Vault soft delete should be enabled on all Key Vaults. The soft delete feature allows recovery of deleted vaults and vault objects (keys, secrets, certificates) for a configurable retention period (7–90 days), protecting against accidental or malicious deletion."
-    },
-    "AZ-STOR-003": {
-      "control_id": "3.7",
-      "control_name": "Ensure that storage accounts have lifecycle management policies configured",
-      "description": "Storage accounts without lifecycle management policies retain data indefinitely. This increases storage costs, expands the attack surface through accumulation of stale data, and may violate data retention compliance requirements. Lifecycle policies automate the transition and deletion of blobs based on age and access patterns."
     },
     "AZ-KV-002": {
       "control_id": "8.3",

--- a/compliance/frameworks/cis_azure_benchmark.json
+++ b/compliance/frameworks/cis_azure_benchmark.json
@@ -96,7 +96,7 @@
     "AZ-CMP-002": {
       "control_id": "7.2",
       "control_name": "Ensure that 'OS disk' are encrypted",
-      "description": "Virtual machine OS and data disks should be encrypted using Azure Disk Encryption or server-side encryption with customer-managed keys. Unencrypted disks can be snapshotted and read by an attacker who gains subscription access without needing VM credentials."
+      "description": "Virtual machine OS and data disks are using platform-managed encryption only (EncryptionAtRestWithPlatformKey). CIS 7.2 requires disks to be protected using customer-managed keys or Azure Disk Encryption. Platform-managed encryption does not give the organisation control over the encryption keys and does not satisfy this control."
     },
     "AZ-KV-001": {
       "control_id": "8.5",

--- a/compliance/frameworks/iso27001.json
+++ b/compliance/frameworks/iso27001.json
@@ -13,6 +13,11 @@
       "control_name": "Policy on the use of cryptographic controls",
       "description": "Requiring secure transfer ensures cryptographic controls are applied to data in transit. A policy on the use of cryptographic controls for protection of information should be developed and implemented."
     },
+    "AZ-STOR-003": {
+      "control_id": "A.8.3.1",
+      "control_name": "Management of removable media",
+      "description": "Storage accounts without lifecycle policies retain data indefinitely with no automated disposal mechanism. Lifecycle management supports formal retention, tiering, and disposal of information assets."
+    },
     "AZ-NET-001": {
       "control_id": "A.13.1.1",
       "control_name": "Network controls",
@@ -88,15 +93,15 @@
       "control_name": "Network controls",
       "description": "Virtual machines with public IPs and no NSG have unrestricted network access. Network controls should be applied to all compute resources accessible from the internet."
     },
+    "AZ-CMP-002": {
+      "control_id": "A.10.1.1",
+      "control_name": "Policy on the use of cryptographic controls",
+      "description": "Virtual machine OS and data disks that are not encrypted store data in plain text on disk. A.10.1.1 requires that a policy on the use of cryptographic controls is developed and implemented for protection of information. Enabling Azure Disk Encryption or server-side encryption with customer-managed keys ensures data at rest on VM disks is protected using cryptographic controls."
+    },
     "AZ-KV-001": {
       "control_id": "A.17.2.1",
       "control_name": "Availability of information processing facilities",
       "description": "Key Vault soft delete protects against loss of secrets, keys and certificates. Without soft delete, deleted vault objects cannot be recovered, reducing availability and recovery options for critical cryptographic material."
-    },
-    "AZ-STOR-003": {
-      "control_id": "A.8.3.1",
-      "control_name": "Management of removable media",
-      "description": "Storage accounts without lifecycle policies retain data indefinitely with no automated disposal mechanism. Lifecycle management supports formal retention, tiering, and disposal of information assets."
     },
     "AZ-KV-002": {
       "control_id": "A.13.1.1",

--- a/compliance/frameworks/iso27001.json
+++ b/compliance/frameworks/iso27001.json
@@ -1,112 +1,112 @@
 {
-  "framework": "ISO/IEC 27001:2013",
-  "version": "2013",
-  "published": "2013-10",
+  "framework": "NIST Cybersecurity Framework",
+  "version": "1.1",
+  "published": "2018-04",
   "controls": {
     "AZ-STOR-001": {
-      "control_id": "A.9.4.1",
-      "control_name": "Information access restriction",
-      "description": "Public blob access allows unrestricted access to information stored in Azure Storage. Access to information and application system functions should be restricted in accordance with the access control policy."
+      "control_id": "PR.AC-3",
+      "control_name": "Remote access is managed",
+      "description": "Public blob access enables unauthenticated remote access to storage resources. Disabling public access ensures remote access to storage is managed and authenticated."
     },
     "AZ-STOR-002": {
-      "control_id": "A.10.1.1",
-      "control_name": "Policy on the use of cryptographic controls",
-      "description": "Requiring secure transfer ensures cryptographic controls are applied to data in transit. A policy on the use of cryptographic controls for protection of information should be developed and implemented."
+      "control_id": "PR.DS-2",
+      "control_name": "Data-in-transit is protected",
+      "description": "Requiring secure transfer ensures data in transit between clients and Azure Storage is encrypted using HTTPS, protecting against interception and tampering."
     },
     "AZ-STOR-003": {
-      "control_id": "A.8.3.1",
-      "control_name": "Management of removable media",
-      "description": "Storage accounts without lifecycle policies retain data indefinitely with no automated disposal mechanism. Lifecycle management supports formal retention, tiering, and disposal of information assets."
+      "control_id": "PR.DS-3",
+      "control_name": "Assets are formally managed throughout removal, transfers, and disposition",
+      "description": "NIST CSF PR.DS-3 requires that data assets are managed through their full lifecycle including secure disposal. Storage accounts without a lifecycle management policy have no automated mechanism for expiring or deleting aged data, meaning data subject to disposal requirements persists indefinitely and is never formally retired from the asset inventory."
     },
     "AZ-NET-001": {
-      "control_id": "A.13.1.1",
-      "control_name": "Network controls",
-      "description": "Unrestricted SSH access from the internet violates network access controls. Networks should be managed and controlled to protect information in systems and applications."
+      "control_id": "PR.AC-3",
+      "control_name": "Remote access is managed",
+      "description": "Unrestricted SSH access from the internet allows unmanaged remote access. NSG rules should restrict SSH to known IP ranges to ensure remote access is controlled and monitored."
     },
     "AZ-NET-002": {
-      "control_id": "A.13.1.1",
-      "control_name": "Network controls",
-      "description": "Unrestricted RDP access from the internet violates network access controls. Networks should be managed and controlled to protect information in systems and applications."
+      "control_id": "PR.AC-3",
+      "control_name": "Remote access is managed",
+      "description": "Unrestricted RDP access from the internet allows unmanaged remote access. NSG rules should restrict RDP to known IP ranges or use Azure Bastion to ensure remote access is controlled."
     },
     "AZ-NET-003": {
-      "control_id": "A.13.1.1",
-      "control_name": "Network controls",
-      "description": "Unrestricted inbound access on port 443 from the internet increases exposure. Networks should be managed and controlled with appropriate restrictions on inbound traffic to protect information systems."
+      "control_id": "SC-7",
+      "control_name": "Boundary Protection",
+      "description": "Unrestricted inbound access on port 443 from the internet increases the attack surface. Public-facing HTTPS services should be fronted by a WAF-enabled Application Gateway rather than exposed directly via NSG rules."
     },
     "AZ-NET-004": {
-      "control_id": "A.13.1.1",
-      "control_name": "Network controls",
-      "description": "NSGs with no rules provide no network controls. Networks should be managed and controlled with explicit rules that restrict traffic to what is required for the workload."
+      "control_id": "SC-7",
+      "control_name": "Boundary Protection",
+      "description": "NSGs with no custom rules provide no meaningful boundary protection. Explicit least-privilege rules should be defined to control inbound and outbound traffic at the network perimeter."
     },
     "AZ-NET-005": {
-      "control_id": "A.13.1.1",
-      "control_name": "Network controls",
-      "description": "Virtual networks without DDoS protection are vulnerable to availability attacks. Network controls should include protection against denial of service attacks to maintain availability of information systems."
+      "control_id": "SC-5",
+      "control_name": "Denial of Service Protection",
+      "description": "Virtual networks without DDoS Protection Standard are vulnerable to volumetric denial of service attacks. DDoS Protection Standard provides enhanced mitigation for production workloads."
     },
     "AZ-NET-006": {
-      "control_id": "A.13.1.1",
-      "control_name": "Network controls",
-      "description": "Unassociated public IP addresses represent unnecessary network exposure. Network resources that are no longer required should be removed to minimise the attack surface."
+      "control_id": "CM-7",
+      "control_name": "Least Functionality",
+      "description": "Unassociated public IP addresses represent unnecessary functionality and attack surface. Resources that are no longer in use should be removed to maintain least functionality."
     },
     "AZ-NET-007": {
-      "control_id": "A.13.1.1",
-      "control_name": "Network controls",
-      "description": "Application Gateways without WAF provide no protection against web application attacks. Network controls should include application layer filtering to protect against common web exploits."
+      "control_id": "SI-3",
+      "control_name": "Malicious Code Protection",
+      "description": "Application Gateways without WAF enabled provide no protection against web application attacks including OWASP Top 10 vulnerabilities. WAF in Prevention mode should be enabled on all public-facing Application Gateways."
     },
     "AZ-NET-008": {
-      "control_id": "A.13.1.1",
-      "control_name": "Network controls",
-      "description": "Load balancers with no backend pool are unused resources. Unused network resources should be removed as part of regular network hygiene to maintain an accurate and minimal network topology."
+      "control_id": "CM-7",
+      "control_name": "Least Functionality",
+      "description": "Load balancers with no backend pool configured serve no function and represent unnecessary resources. Unused resources should be removed to maintain least functionality and reduce cost."
     },
     "AZ-NET-009": {
-      "control_id": "A.13.2.1",
-      "control_name": "Information transfer policies and procedures",
-      "description": "VPN connections using IKEv1 use an outdated protocol. Information transfer policies should require the use of current secure protocols to protect data in transit between networks."
+      "control_id": "SC-8",
+      "control_name": "Transmission Confidentiality and Integrity",
+      "description": "VPN connections using IKEv1 use an outdated protocol with known vulnerabilities. IKEv2 should be used for all VPN gateway connections to ensure transmission confidentiality and integrity."
     },
     "AZ-NET-010": {
-      "control_id": "A.13.1.1",
-      "control_name": "Network controls",
-      "description": "Subnets without NSGs have no network layer access controls. All subnets should have NSGs attached with explicit rules to enforce network controls at the subnet boundary."
+      "control_id": "SC-7",
+      "control_name": "Boundary Protection",
+      "description": "Subnets without NSGs attached have no network layer access control. All production subnets should have NSGs with explicit rules to enforce boundary protection at the subnet level."
     },
     "AZ-IDN-001": {
-      "control_id": "A.9.2.3",
-      "control_name": "Management of privileged access rights",
-      "description": "Service principals with overly broad permissions violate privileged access management. The allocation and use of privileged access rights should be restricted and controlled."
+      "control_id": "PR.AC-4",
+      "control_name": "Access permissions and authorizations are managed",
+      "description": "Service principals with overly broad permissions violate least privilege. Access permissions should be scoped to the minimum required for the workload to function."
     },
     "AZ-IDN-002": {
-      "control_id": "A.9.4.2",
-      "control_name": "Secure log-on procedures",
-      "description": "MFA enforces secure log-on for privileged accounts. Where required by the access control policy, access to systems and applications should be controlled by a secure log-on procedure including multi-factor authentication."
+      "control_id": "PR.AC-7",
+      "control_name": "Users, devices, and other assets are authenticated",
+      "description": "MFA ensures privileged users are strongly authenticated before accessing Azure resources. Without MFA, a compromised password is sufficient for full administrative access."
     },
     "AZ-DB-001": {
-      "control_id": "A.13.1.1",
-      "control_name": "Network controls",
-      "description": "Public network access to PostgreSQL servers should be disabled. Database servers should only be accessible via private network connections with appropriate network controls in place."
+      "control_id": "PR.AC-3",
+      "control_name": "Remote access is managed",
+      "description": "Public network access to PostgreSQL servers should be disabled. Database access should be restricted to private networks to ensure remote access is managed and controlled."
     },
     "AZ-DB-002": {
-      "control_id": "A.12.4.1",
-      "control_name": "Event logging",
-      "description": "SQL Server auditing must be enabled to provide event logs. Event logs recording user activities, exceptions, faults and information security events should be produced, kept and regularly reviewed."
+      "control_id": "DE.AE-3",
+      "control_name": "Event data are aggregated and correlated",
+      "description": "SQL Server auditing must be enabled with sufficient retention to support threat detection and incident investigation. Audit logs provide the event data needed to detect and respond to anomalous database activity."
     },
     "AZ-CMP-001": {
-      "control_id": "A.13.1.1",
-      "control_name": "Network controls",
-      "description": "Virtual machines with public IPs and no NSG have unrestricted network access. Network controls should be applied to all compute resources accessible from the internet."
+      "control_id": "PR.AC-3",
+      "control_name": "Remote access is managed",
+      "description": "Virtual machines with public IPs and no NSG have unrestricted network access. NSGs should be attached to control inbound and outbound traffic and manage remote access to compute resources."
     },
     "AZ-CMP-002": {
-      "control_id": "A.10.1.1",
-      "control_name": "Policy on the use of cryptographic controls",
-      "description": "Virtual machine OS and data disks are using platform-managed encryption only (EncryptionAtRestWithPlatformKey). A.10.1.1 requires that a policy on the use of cryptographic controls is developed and implemented. Platform-managed encryption does not give the organisation control over the encryption keys. Customer-managed keys or Azure Disk Encryption are required to satisfy this control."
+      "control_id": "PR.DS-1",
+      "control_name": "Data-at-rest is protected",
+      "description": "Virtual machine OS and data disks are using platform-managed encryption only (EncryptionAtRestWithPlatformKey). PR.DS-1 requires that data at rest is protected using appropriate controls. Platform-managed encryption does not give the organisation control over the encryption keys. Customer-managed keys or Azure Disk Encryption are required to satisfy this control."
     },
     "AZ-KV-001": {
-      "control_id": "A.17.2.1",
-      "control_name": "Availability of information processing facilities",
-      "description": "Key Vault soft delete protects against loss of secrets, keys and certificates. Without soft delete, deleted vault objects cannot be recovered, reducing availability and recovery options for critical cryptographic material."
+      "control_id": "PR.IP-4",
+      "control_name": "Backups of information are conducted, maintained, and tested",
+      "description": "Key material in Azure Key Vault must be recoverable after accidental or malicious deletion. Soft delete provides a recoverable state for secrets, keys, and certificates, supporting backup and recovery requirements for critical cryptographic material."
     },
     "AZ-KV-002": {
-      "control_id": "A.13.1.1",
-      "control_name": "Network controls",
-      "description": "Networks should be managed and controlled to protect information systems and applications. Allowing public network access to Azure Key Vault increases exposure of sensitive secrets, keys, and certificates to external networks. Access should be restricted to trusted networks using private endpoints or network controls."
+      "control_id": "AC-17",
+      "control_name": "Remote access",
+      "description": "Key Vaults that allow public network access expose sensitive secrets, keys, and certificates to remote access attempts from outside trusted networks. Restricting access through private endpoints or trusted networks helps manage remote access paths."
     }
   }
 }

--- a/compliance/frameworks/iso27001.json
+++ b/compliance/frameworks/iso27001.json
@@ -96,7 +96,7 @@
     "AZ-CMP-002": {
       "control_id": "A.10.1.1",
       "control_name": "Policy on the use of cryptographic controls",
-      "description": "Virtual machine OS and data disks that are not encrypted store data in plain text on disk. A.10.1.1 requires that a policy on the use of cryptographic controls is developed and implemented for protection of information. Enabling Azure Disk Encryption or server-side encryption with customer-managed keys ensures data at rest on VM disks is protected using cryptographic controls."
+      "description": "Virtual machine OS and data disks are using platform-managed encryption only (EncryptionAtRestWithPlatformKey). A.10.1.1 requires that a policy on the use of cryptographic controls is developed and implemented. Platform-managed encryption does not give the organisation control over the encryption keys. Customer-managed keys or Azure Disk Encryption are required to satisfy this control."
     },
     "AZ-KV-001": {
       "control_id": "A.17.2.1",

--- a/compliance/frameworks/iso27001.json
+++ b/compliance/frameworks/iso27001.json
@@ -1,112 +1,112 @@
 {
-  "framework": "NIST Cybersecurity Framework",
-  "version": "1.1",
-  "published": "2018-04",
+  "framework": "ISO/IEC 27001:2013",
+  "version": "2013",
+  "published": "2013-10",
   "controls": {
     "AZ-STOR-001": {
-      "control_id": "PR.AC-3",
-      "control_name": "Remote access is managed",
-      "description": "Public blob access enables unauthenticated remote access to storage resources. Disabling public access ensures remote access to storage is managed and authenticated."
+      "control_id": "A.9.4.1",
+      "control_name": "Information access restriction",
+      "description": "Public blob access allows unrestricted access to information stored in Azure Storage. Access to information and application system functions should be restricted in accordance with the access control policy."
     },
     "AZ-STOR-002": {
-      "control_id": "PR.DS-2",
-      "control_name": "Data-in-transit is protected",
-      "description": "Requiring secure transfer ensures data in transit between clients and Azure Storage is encrypted using HTTPS, protecting against interception and tampering."
-    },
-    "AZ-STOR-003": {
-      "control_id": "PR.DS-3",
-      "control_name": "Assets are formally managed throughout removal, transfers, and disposition",
-      "description": "NIST CSF PR.DS-3 requires that data assets are managed through their full lifecycle including secure disposal. Storage accounts without a lifecycle management policy have no automated mechanism for expiring or deleting aged data, meaning data subject to disposal requirements persists indefinitely and is never formally retired from the asset inventory."
+      "control_id": "A.10.1.1",
+      "control_name": "Policy on the use of cryptographic controls",
+      "description": "Requiring secure transfer ensures cryptographic controls are applied to data in transit. A policy on the use of cryptographic controls for protection of information should be developed and implemented."
     },
     "AZ-NET-001": {
-      "control_id": "PR.AC-3",
-      "control_name": "Remote access is managed",
-      "description": "Unrestricted SSH access from the internet allows unmanaged remote access. NSG rules should restrict SSH to known IP ranges to ensure remote access is controlled and monitored."
+      "control_id": "A.13.1.1",
+      "control_name": "Network controls",
+      "description": "Unrestricted SSH access from the internet violates network access controls. Networks should be managed and controlled to protect information in systems and applications."
     },
     "AZ-NET-002": {
-      "control_id": "PR.AC-3",
-      "control_name": "Remote access is managed",
-      "description": "Unrestricted RDP access from the internet allows unmanaged remote access. NSG rules should restrict RDP to known IP ranges or use Azure Bastion to ensure remote access is controlled."
+      "control_id": "A.13.1.1",
+      "control_name": "Network controls",
+      "description": "Unrestricted RDP access from the internet violates network access controls. Networks should be managed and controlled to protect information in systems and applications."
     },
     "AZ-NET-003": {
-      "control_id": "SC-7",
-      "control_name": "Boundary Protection",
-      "description": "Unrestricted inbound access on port 443 from the internet increases the attack surface. Public-facing HTTPS services should be fronted by a WAF-enabled Application Gateway rather than exposed directly via NSG rules."
+      "control_id": "A.13.1.1",
+      "control_name": "Network controls",
+      "description": "Unrestricted inbound access on port 443 from the internet increases exposure. Networks should be managed and controlled with appropriate restrictions on inbound traffic to protect information systems."
     },
     "AZ-NET-004": {
-      "control_id": "SC-7",
-      "control_name": "Boundary Protection",
-      "description": "NSGs with no custom rules provide no meaningful boundary protection. Explicit least-privilege rules should be defined to control inbound and outbound traffic at the network perimeter."
+      "control_id": "A.13.1.1",
+      "control_name": "Network controls",
+      "description": "NSGs with no rules provide no network controls. Networks should be managed and controlled with explicit rules that restrict traffic to what is required for the workload."
     },
     "AZ-NET-005": {
-      "control_id": "SC-5",
-      "control_name": "Denial of Service Protection",
-      "description": "Virtual networks without DDoS Protection Standard are vulnerable to volumetric denial of service attacks. DDoS Protection Standard provides enhanced mitigation for production workloads."
+      "control_id": "A.13.1.1",
+      "control_name": "Network controls",
+      "description": "Virtual networks without DDoS protection are vulnerable to availability attacks. Network controls should include protection against denial of service attacks to maintain availability of information systems."
     },
     "AZ-NET-006": {
-      "control_id": "CM-7",
-      "control_name": "Least Functionality",
-      "description": "Unassociated public IP addresses represent unnecessary functionality and attack surface. Resources that are no longer in use should be removed to maintain least functionality."
+      "control_id": "A.13.1.1",
+      "control_name": "Network controls",
+      "description": "Unassociated public IP addresses represent unnecessary network exposure. Network resources that are no longer required should be removed to minimise the attack surface."
     },
     "AZ-NET-007": {
-      "control_id": "SI-3",
-      "control_name": "Malicious Code Protection",
-      "description": "Application Gateways without WAF enabled provide no protection against web application attacks including OWASP Top 10 vulnerabilities. WAF in Prevention mode should be enabled on all public-facing Application Gateways."
+      "control_id": "A.13.1.1",
+      "control_name": "Network controls",
+      "description": "Application Gateways without WAF provide no protection against web application attacks. Network controls should include application layer filtering to protect against common web exploits."
     },
     "AZ-NET-008": {
-      "control_id": "CM-7",
-      "control_name": "Least Functionality",
-      "description": "Load balancers with no backend pool configured serve no function and represent unnecessary resources. Unused resources should be removed to maintain least functionality and reduce cost."
+      "control_id": "A.13.1.1",
+      "control_name": "Network controls",
+      "description": "Load balancers with no backend pool are unused resources. Unused network resources should be removed as part of regular network hygiene to maintain an accurate and minimal network topology."
     },
     "AZ-NET-009": {
-      "control_id": "SC-8",
-      "control_name": "Transmission Confidentiality and Integrity",
-      "description": "VPN connections using IKEv1 use an outdated protocol with known vulnerabilities. IKEv2 should be used for all VPN gateway connections to ensure transmission confidentiality and integrity."
+      "control_id": "A.13.2.1",
+      "control_name": "Information transfer policies and procedures",
+      "description": "VPN connections using IKEv1 use an outdated protocol. Information transfer policies should require the use of current secure protocols to protect data in transit between networks."
     },
     "AZ-NET-010": {
-      "control_id": "SC-7",
-      "control_name": "Boundary Protection",
-      "description": "Subnets without NSGs attached have no network layer access control. All production subnets should have NSGs with explicit rules to enforce boundary protection at the subnet level."
+      "control_id": "A.13.1.1",
+      "control_name": "Network controls",
+      "description": "Subnets without NSGs have no network layer access controls. All subnets should have NSGs attached with explicit rules to enforce network controls at the subnet boundary."
     },
     "AZ-IDN-001": {
-      "control_id": "PR.AC-4",
-      "control_name": "Access permissions and authorizations are managed",
-      "description": "Service principals with overly broad permissions violate least privilege. Access permissions should be scoped to the minimum required for the workload to function."
+      "control_id": "A.9.2.3",
+      "control_name": "Management of privileged access rights",
+      "description": "Service principals with overly broad permissions violate privileged access management. The allocation and use of privileged access rights should be restricted and controlled."
     },
     "AZ-IDN-002": {
-      "control_id": "PR.AC-7",
-      "control_name": "Users, devices, and other assets are authenticated",
-      "description": "MFA ensures privileged users are strongly authenticated before accessing Azure resources. Without MFA, a compromised password is sufficient for full administrative access."
+      "control_id": "A.9.4.2",
+      "control_name": "Secure log-on procedures",
+      "description": "MFA enforces secure log-on for privileged accounts. Where required by the access control policy, access to systems and applications should be controlled by a secure log-on procedure including multi-factor authentication."
     },
     "AZ-DB-001": {
-      "control_id": "PR.AC-3",
-      "control_name": "Remote access is managed",
-      "description": "Public network access to PostgreSQL servers should be disabled. Database access should be restricted to private networks to ensure remote access is managed and controlled."
+      "control_id": "A.13.1.1",
+      "control_name": "Network controls",
+      "description": "Public network access to PostgreSQL servers should be disabled. Database servers should only be accessible via private network connections with appropriate network controls in place."
     },
     "AZ-DB-002": {
-      "control_id": "DE.AE-3",
-      "control_name": "Event data are aggregated and correlated",
-      "description": "SQL Server auditing must be enabled with sufficient retention to support threat detection and incident investigation. Audit logs provide the event data needed to detect and respond to anomalous database activity."
+      "control_id": "A.12.4.1",
+      "control_name": "Event logging",
+      "description": "SQL Server auditing must be enabled to provide event logs. Event logs recording user activities, exceptions, faults and information security events should be produced, kept and regularly reviewed."
     },
     "AZ-CMP-001": {
-      "control_id": "PR.AC-3",
-      "control_name": "Remote access is managed",
-      "description": "Virtual machines with public IPs and no NSG have unrestricted network access. NSGs should be attached to control inbound and outbound traffic and manage remote access to compute resources."
+      "control_id": "A.13.1.1",
+      "control_name": "Network controls",
+      "description": "Virtual machines with public IPs and no NSG have unrestricted network access. Network controls should be applied to all compute resources accessible from the internet."
     },
     "AZ-CMP-002": {
-      "control_id": "PR.DS-1",
-      "control_name": "Data-at-rest is protected",
-      "description": "Virtual machine OS and data disks are using platform-managed encryption only (EncryptionAtRestWithPlatformKey). PR.DS-1 requires that data at rest is protected using appropriate controls. Platform-managed encryption does not give the organisation control over the encryption keys. Customer-managed keys or Azure Disk Encryption are required to satisfy this control."
+      "control_id": "A.10.1.1",
+      "control_name": "Policy on the use of cryptographic controls",
+      "description": "Virtual machine OS and data disks are using platform-managed encryption only (EncryptionAtRestWithPlatformKey). A.10.1.1 requires that a policy on the use of cryptographic controls is developed and implemented. Platform-managed encryption does not give the organisation control over the encryption keys. Customer-managed keys or Azure Disk Encryption are required to satisfy this control."
     },
     "AZ-KV-001": {
-      "control_id": "PR.IP-4",
-      "control_name": "Backups of information are conducted, maintained, and tested",
-      "description": "Key material in Azure Key Vault must be recoverable after accidental or malicious deletion. Soft delete provides a recoverable state for secrets, keys, and certificates, supporting backup and recovery requirements for critical cryptographic material."
+      "control_id": "A.17.2.1",
+      "control_name": "Availability of information processing facilities",
+      "description": "Key Vault soft delete protects against loss of secrets, keys and certificates. Without soft delete, deleted vault objects cannot be recovered, reducing availability and recovery options for critical cryptographic material."
+    },
+    "AZ-STOR-003": {
+      "control_id": "A.8.3.1",
+      "control_name": "Management of removable media",
+      "description": "Storage accounts without lifecycle policies retain data indefinitely with no automated disposal mechanism. Lifecycle management supports formal retention, tiering, and disposal of information assets."
     },
     "AZ-KV-002": {
-      "control_id": "AC-17",
-      "control_name": "Remote access",
-      "description": "Key Vaults that allow public network access expose sensitive secrets, keys, and certificates to remote access attempts from outside trusted networks. Restricting access through private endpoints or trusted networks helps manage remote access paths."
+      "control_id": "A.13.1.1",
+      "control_name": "Network controls",
+      "description": "Networks should be managed and controlled to protect information systems and applications. Allowing public network access to Azure Key Vault increases exposure of sensitive secrets, keys, and certificates to external networks. Access should be restricted to trusted networks using private endpoints or network controls."
     }
   }
 }

--- a/compliance/frameworks/nist_csf.json
+++ b/compliance/frameworks/nist_csf.json
@@ -101,4 +101,12 @@
     "AZ-KV-001": {
       "control_id": "PR.IP-4",
       "control_name": "Backups of information are conducted, maintained, and tested",
-      "description": "Key ma
+      "description": "Key material in Azure Key Vault must be recoverable after accidental or malicious deletion. Soft delete provides a recoverable state for secrets, keys, and certificates, supporting backup and recovery requirements for critical cryptographic material."
+    },
+    "AZ-KV-002": {
+      "control_id": "AC-17",
+      "control_name": "Remote access",
+      "description": "Key Vaults that allow public network access expose sensitive secrets, keys, and certificates to remote access attempts from outside trusted networks. Restricting access through private endpoints or trusted networks helps manage remote access paths."
+    }
+  }
+}

--- a/compliance/frameworks/nist_csf.json
+++ b/compliance/frameworks/nist_csf.json
@@ -101,7 +101,7 @@
     "AZ-KV-001": {
       "control_id": "PR.IP-4",
       "control_name": "Backups of information are conducted, maintained, and tested",
-      "description": "Key material in Azure Key Vault must be recoverable after accidental or malicious deletion. Soft delete provides a recoverable state for secrets, keys, and certificates, supporting backup and recovery requirements for critical cryptographic material."
+      "description": "Key material in Azure Key Vault must be recoverable after accidental or malicious deletion. Soft delete provides a recoverable state for secrets, keys, and certificates supporting backup and recovery requirements for critical cryptographic material."
     },
     "AZ-KV-002": {
       "control_id": "AC-17",

--- a/compliance/frameworks/nist_csf.json
+++ b/compliance/frameworks/nist_csf.json
@@ -13,6 +13,11 @@
       "control_name": "Data-in-transit is protected",
       "description": "Requiring secure transfer ensures data in transit between clients and Azure Storage is encrypted using HTTPS, protecting against interception and tampering."
     },
+    "AZ-STOR-003": {
+      "control_id": "PR.DS-3",
+      "control_name": "Assets are formally managed throughout removal, transfers, and disposition",
+      "description": "NIST CSF PR.DS-3 requires that data assets are managed through their full lifecycle including secure disposal. Storage accounts without a lifecycle management policy have no automated mechanism for expiring or deleting aged data, meaning data subject to disposal requirements persists indefinitely and is never formally retired from the asset inventory."
+    },
     "AZ-NET-001": {
       "control_id": "PR.AC-3",
       "control_name": "Remote access is managed",
@@ -89,24 +94,11 @@
       "description": "Virtual machines with public IPs and no NSG have unrestricted network access. NSGs should be attached to control inbound and outbound traffic and manage remote access to compute resources."
     },
     "AZ-CMP-002": {
-     "control_id": "PR.DS-1",
-     "control_name": "Data-at-rest is protected",
-    "description": "Virtual machine OS and data disks that are not encrypted with Azure Disk Encryption or customer-managed keys store data in plain text. PR.DS-1 requires that data at rest is protected. Enabling disk encryption ensures that disk contents are unreadable without the encryption key even if the disk is snapshotted or physically accessed."
-   },
+      "control_id": "PR.DS-1",
+      "control_name": "Data-at-rest is protected",
+      "description": "Virtual machine OS and data disks are using platform-managed encryption only (EncryptionAtRestWithPlatformKey). PR.DS-1 requires that data at rest is protected using appropriate controls. Platform-managed encryption does not give the organisation control over the encryption keys. Customer-managed keys or Azure Disk Encryption are required to satisfy this control."
+    },
     "AZ-KV-001": {
       "control_id": "PR.IP-4",
       "control_name": "Backups of information are conducted, maintained, and tested",
-      "description": "Key material in Azure Key Vault must be recoverable after accidental or malicious deletion. Soft delete provides a recoverable state for secrets, keys, and certificates, supporting backup and recovery requirements for critical cryptographic material."
-    },
-    "AZ-KV-002": {
-      "control_id": "AC-17",
-      "control_name": "Remote access",
-      "description": "Key Vaults that allow public network access expose sensitive secrets, keys, and certificates to remote access attempts from outside trusted networks. Restricting access through private endpoints or trusted networks helps manage remote access paths."
-    },
-    "AZ-STOR-003": {
-      "control_id": "PR.DS-3",
-      "control_name": "Assets are formally managed throughout removal, transfers, and disposition",
-      "description": "NIST CSF PR.DS-3 requires that data assets are managed through their full lifecycle including secure disposal. Storage accounts without a lifecycle management policy have no automated mechanism for expiring or deleting aged data, meaning data subject to disposal requirements persists indefinitely and is never formally retired from the asset inventory."
-    }
-  }
-}
+      "description": "Key ma

--- a/compliance/frameworks/nist_csf.json
+++ b/compliance/frameworks/nist_csf.json
@@ -1,112 +1,107 @@
 {
-  "framework": "ISO/IEC 27001:2013",
-  "version": "2013",
-  "published": "2013-10",
+  "framework": "NIST Cybersecurity Framework",
+  "version": "1.1",
+  "published": "2018-04",
   "controls": {
     "AZ-STOR-001": {
-      "control_id": "A.9.4.1",
-      "control_name": "Information access restriction",
-      "description": "Public blob access allows unrestricted access to information stored in Azure Storage. Access to information and application system functions should be restricted in accordance with the access control policy."
+      "control_id": "PR.AC-3",
+      "control_name": "Remote access is managed",
+      "description": "Public blob access enables unauthenticated remote access to storage resources. Disabling public access ensures remote access to storage is managed and authenticated."
     },
     "AZ-STOR-002": {
-      "control_id": "A.10.1.1",
-      "control_name": "Policy on the use of cryptographic controls",
-      "description": "Requiring secure transfer ensures cryptographic controls are applied to data in transit. A policy on the use of cryptographic controls for protection of information should be developed and implemented."
+      "control_id": "PR.DS-2",
+      "control_name": "Data-in-transit is protected",
+      "description": "Requiring secure transfer ensures data in transit between clients and Azure Storage is encrypted using HTTPS, protecting against interception and tampering."
     },
     "AZ-NET-001": {
-      "control_id": "A.13.1.1",
-      "control_name": "Network controls",
-      "description": "Unrestricted SSH access from the internet violates network access controls. Networks should be managed and controlled to protect information in systems and applications."
+      "control_id": "PR.AC-3",
+      "control_name": "Remote access is managed",
+      "description": "Unrestricted SSH access from the internet allows unmanaged remote access. NSG rules should restrict SSH to known IP ranges to ensure remote access is controlled and monitored."
     },
     "AZ-NET-002": {
-      "control_id": "A.13.1.1",
-      "control_name": "Network controls",
-      "description": "Unrestricted RDP access from the internet violates network access controls. Networks should be managed and controlled to protect information in systems and applications."
+      "control_id": "PR.AC-3",
+      "control_name": "Remote access is managed",
+      "description": "Unrestricted RDP access from the internet allows unmanaged remote access. NSG rules should restrict RDP to known IP ranges or use Azure Bastion to ensure remote access is controlled."
     },
     "AZ-NET-003": {
-      "control_id": "A.13.1.1",
-      "control_name": "Network controls",
-      "description": "Unrestricted inbound access on port 443 from the internet increases exposure. Networks should be managed and controlled with appropriate restrictions on inbound traffic to protect information systems."
+      "control_id": "SC-7",
+      "control_name": "Boundary Protection",
+      "description": "Unrestricted inbound access on port 443 from the internet increases the attack surface. Public-facing HTTPS services should be fronted by a WAF-enabled Application Gateway rather than exposed directly via NSG rules."
     },
     "AZ-NET-004": {
-      "control_id": "A.13.1.1",
-      "control_name": "Network controls",
-      "description": "NSGs with no rules provide no network controls. Networks should be managed and controlled with explicit rules that restrict traffic to what is required for the workload."
+      "control_id": "SC-7",
+      "control_name": "Boundary Protection",
+      "description": "NSGs with no custom rules provide no meaningful boundary protection. Explicit least-privilege rules should be defined to control inbound and outbound traffic at the network perimeter."
     },
     "AZ-NET-005": {
-      "control_id": "A.13.1.1",
-      "control_name": "Network controls",
-      "description": "Virtual networks without DDoS protection are vulnerable to availability attacks. Network controls should include protection against denial of service attacks to maintain availability of information systems."
+      "control_id": "SC-5",
+      "control_name": "Denial of Service Protection",
+      "description": "Virtual networks without DDoS Protection Standard are vulnerable to volumetric denial of service attacks. DDoS Protection Standard provides enhanced mitigation for production workloads."
     },
     "AZ-NET-006": {
-      "control_id": "A.13.1.1",
-      "control_name": "Network controls",
-      "description": "Unassociated public IP addresses represent unnecessary network exposure. Network resources that are no longer required should be removed to minimise the attack surface."
+      "control_id": "CM-7",
+      "control_name": "Least Functionality",
+      "description": "Unassociated public IP addresses represent unnecessary functionality and attack surface. Resources that are no longer in use should be removed to maintain least functionality."
     },
     "AZ-NET-007": {
-      "control_id": "A.13.1.1",
-      "control_name": "Network controls",
-      "description": "Application Gateways without WAF provide no protection against web application attacks. Network controls should include application layer filtering to protect against common web exploits."
+      "control_id": "SI-3",
+      "control_name": "Malicious Code Protection",
+      "description": "Application Gateways without WAF enabled provide no protection against web application attacks including OWASP Top 10 vulnerabilities. WAF in Prevention mode should be enabled on all public-facing Application Gateways."
     },
     "AZ-NET-008": {
-      "control_id": "A.13.1.1",
-      "control_name": "Network controls",
-      "description": "Load balancers with no backend pool are unused resources. Unused network resources should be removed as part of regular network hygiene to maintain an accurate and minimal network topology."
+      "control_id": "CM-7",
+      "control_name": "Least Functionality",
+      "description": "Load balancers with no backend pool configured serve no function and represent unnecessary resources. Unused resources should be removed to maintain least functionality and reduce cost."
     },
     "AZ-NET-009": {
-      "control_id": "A.13.2.1",
-      "control_name": "Information transfer policies and procedures",
-      "description": "VPN connections using IKEv1 use an outdated protocol. Information transfer policies should require the use of current secure protocols to protect data in transit between networks."
+      "control_id": "SC-8",
+      "control_name": "Transmission Confidentiality and Integrity",
+      "description": "VPN connections using IKEv1 use an outdated protocol with known vulnerabilities. IKEv2 should be used for all VPN gateway connections to ensure transmission confidentiality and integrity."
     },
     "AZ-NET-010": {
-      "control_id": "A.13.1.1",
-      "control_name": "Network controls",
-      "description": "Subnets without NSGs have no network layer access controls. All subnets should have NSGs attached with explicit rules to enforce network controls at the subnet boundary."
+      "control_id": "SC-7",
+      "control_name": "Boundary Protection",
+      "description": "Subnets without NSGs attached have no network layer access control. All production subnets should have NSGs with explicit rules to enforce boundary protection at the subnet level."
     },
     "AZ-IDN-001": {
-      "control_id": "A.9.2.3",
-      "control_name": "Management of privileged access rights",
-      "description": "Service principals with overly broad permissions violate privileged access management. The allocation and use of privileged access rights should be restricted and controlled."
+      "control_id": "PR.AC-4",
+      "control_name": "Access permissions and authorizations are managed",
+      "description": "Service principals with overly broad permissions violate least privilege. Access permissions should be scoped to the minimum required for the workload to function."
     },
     "AZ-IDN-002": {
-      "control_id": "A.9.4.2",
-      "control_name": "Secure log-on procedures",
-      "description": "MFA enforces secure log-on for privileged accounts. Where required by the access control policy, access to systems and applications should be controlled by a secure log-on procedure including multi-factor authentication."
+      "control_id": "PR.AC-7",
+      "control_name": "Users, devices, and other assets are authenticated",
+      "description": "MFA ensures privileged users are strongly authenticated before accessing Azure resources. Without MFA, a compromised password is sufficient for full administrative access."
     },
     "AZ-DB-001": {
-      "control_id": "A.13.1.1",
-      "control_name": "Network controls",
-      "description": "Public network access to PostgreSQL servers should be disabled. Database servers should only be accessible via private network connections with appropriate network controls in place."
+      "control_id": "PR.AC-3",
+      "control_name": "Remote access is managed",
+      "description": "Public network access to PostgreSQL servers should be disabled. Database access should be restricted to private networks to ensure remote access is managed and controlled."
     },
     "AZ-DB-002": {
-      "control_id": "A.12.4.1",
-      "control_name": "Event logging",
-      "description": "SQL Server auditing must be enabled to provide event logs. Event logs recording user activities, exceptions, faults and information security events should be produced, kept and regularly reviewed."
+      "control_id": "DE.AE-3",
+      "control_name": "Event data are aggregated and correlated",
+      "description": "SQL Server auditing must be enabled with sufficient retention to support threat detection and incident investigation. Audit logs provide the event data needed to detect and respond to anomalous database activity."
     },
     "AZ-CMP-001": {
-      "control_id": "A.13.1.1",
-      "control_name": "Network controls",
-      "description": "Virtual machines with public IPs and no NSG have unrestricted network access. Network controls should be applied to all compute resources accessible from the internet."
-    },
-    "AZ-CMP-002": {
-      "control_id": "A.10.1.1",
-      "control_name": "Policy on the use of cryptographic controls",
-      "description": "Virtual machine OS and data disks are using platform-managed encryption only (EncryptionAtRestWithPlatformKey). A.10.1.1 requires that a policy on the use of cryptographic controls is developed and implemented. Platform-managed encryption does not give the organisation control over the encryption keys. Customer-managed keys or Azure Disk Encryption are required to satisfy this control."
+      "control_id": "PR.AC-3",
+      "control_name": "Remote access is managed",
+      "description": "Virtual machines with public IPs and no NSG have unrestricted network access. NSGs should be attached to control inbound and outbound traffic and manage remote access to compute resources."
     },
     "AZ-KV-001": {
-      "control_id": "A.17.2.1",
-      "control_name": "Availability of information processing facilities",
-      "description": "Key Vault soft delete protects against loss of secrets, keys and certificates. Without soft delete, deleted vault objects cannot be recovered, reducing availability and recovery options for critical cryptographic material."
-    },
-    "AZ-STOR-003": {
-      "control_id": "A.8.3.1",
-      "control_name": "Management of removable media",
-      "description": "Storage accounts without lifecycle policies retain data indefinitely with no automated disposal mechanism. Lifecycle management supports formal retention, tiering, and disposal of information assets."
+      "control_id": "PR.IP-4",
+      "control_name": "Backups of information are conducted, maintained, and tested",
+      "description": "Key material in Azure Key Vault must be recoverable after accidental or malicious deletion. Soft delete provides a recoverable state for secrets, keys, and certificates, supporting backup and recovery requirements for critical cryptographic material."
     },
     "AZ-KV-002": {
-      "control_id": "A.13.1.1",
-      "control_name": "Network controls",
-      "description": "Networks should be managed and controlled to protect information systems and applications. Allowing public network access to Azure Key Vault increases exposure of sensitive secrets, keys, and certificates to external networks. Access should be restricted to trusted networks using private endpoints or network controls."
+      "control_id": "AC-17",
+      "control_name": "Remote access",
+      "description": "Key Vaults that allow public network access expose sensitive secrets, keys, and certificates to remote access attempts from outside trusted networks. Restricting access through private endpoints or trusted networks helps manage remote access paths."
+    },
+    "AZ-STOR-003": {
+      "control_id": "PR.DS-3",
+      "control_name": "Assets are formally managed throughout removal, transfers, and disposition",
+      "description": "NIST CSF PR.DS-3 requires that data assets are managed through their full lifecycle including secure disposal. Storage accounts without a lifecycle management policy have no automated mechanism for expiring or deleting aged data, meaning data subject to disposal requirements persists indefinitely and is never formally retired from the asset inventory."
     }
   }
 }

--- a/compliance/frameworks/nist_csf.json
+++ b/compliance/frameworks/nist_csf.json
@@ -1,112 +1,112 @@
 {
-  "framework": "NIST Cybersecurity Framework",
-  "version": "1.1",
-  "published": "2018-04",
+  "framework": "ISO/IEC 27001:2013",
+  "version": "2013",
+  "published": "2013-10",
   "controls": {
     "AZ-STOR-001": {
-      "control_id": "PR.AC-3",
-      "control_name": "Remote access is managed",
-      "description": "Public blob access enables unauthenticated remote access to storage resources. Disabling public access ensures remote access to storage is managed and authenticated."
+      "control_id": "A.9.4.1",
+      "control_name": "Information access restriction",
+      "description": "Public blob access allows unrestricted access to information stored in Azure Storage. Access to information and application system functions should be restricted in accordance with the access control policy."
     },
     "AZ-STOR-002": {
-      "control_id": "PR.DS-2",
-      "control_name": "Data-in-transit is protected",
-      "description": "Requiring secure transfer ensures data in transit between clients and Azure Storage is encrypted using HTTPS, protecting against interception and tampering."
-    },
-    "AZ-STOR-003": {
-      "control_id": "PR.DS-3",
-      "control_name": "Assets are formally managed throughout removal, transfers, and disposition",
-      "description": "NIST CSF PR.DS-3 requires that data assets are managed through their full lifecycle including secure disposal. Storage accounts without a lifecycle management policy have no automated mechanism for expiring or deleting aged data, meaning data subject to disposal requirements persists indefinitely and is never formally retired from the asset inventory."
+      "control_id": "A.10.1.1",
+      "control_name": "Policy on the use of cryptographic controls",
+      "description": "Requiring secure transfer ensures cryptographic controls are applied to data in transit. A policy on the use of cryptographic controls for protection of information should be developed and implemented."
     },
     "AZ-NET-001": {
-      "control_id": "PR.AC-3",
-      "control_name": "Remote access is managed",
-      "description": "Unrestricted SSH access from the internet allows unmanaged remote access. NSG rules should restrict SSH to known IP ranges to ensure remote access is controlled and monitored."
+      "control_id": "A.13.1.1",
+      "control_name": "Network controls",
+      "description": "Unrestricted SSH access from the internet violates network access controls. Networks should be managed and controlled to protect information in systems and applications."
     },
     "AZ-NET-002": {
-      "control_id": "PR.AC-3",
-      "control_name": "Remote access is managed",
-      "description": "Unrestricted RDP access from the internet allows unmanaged remote access. NSG rules should restrict RDP to known IP ranges or use Azure Bastion to ensure remote access is controlled."
+      "control_id": "A.13.1.1",
+      "control_name": "Network controls",
+      "description": "Unrestricted RDP access from the internet violates network access controls. Networks should be managed and controlled to protect information in systems and applications."
     },
     "AZ-NET-003": {
-      "control_id": "SC-7",
-      "control_name": "Boundary Protection",
-      "description": "Unrestricted inbound access on port 443 from the internet increases the attack surface. Public-facing HTTPS services should be fronted by a WAF-enabled Application Gateway rather than exposed directly via NSG rules."
+      "control_id": "A.13.1.1",
+      "control_name": "Network controls",
+      "description": "Unrestricted inbound access on port 443 from the internet increases exposure. Networks should be managed and controlled with appropriate restrictions on inbound traffic to protect information systems."
     },
     "AZ-NET-004": {
-      "control_id": "SC-7",
-      "control_name": "Boundary Protection",
-      "description": "NSGs with no custom rules provide no meaningful boundary protection. Explicit least-privilege rules should be defined to control inbound and outbound traffic at the network perimeter."
+      "control_id": "A.13.1.1",
+      "control_name": "Network controls",
+      "description": "NSGs with no rules provide no network controls. Networks should be managed and controlled with explicit rules that restrict traffic to what is required for the workload."
     },
     "AZ-NET-005": {
-      "control_id": "SC-5",
-      "control_name": "Denial of Service Protection",
-      "description": "Virtual networks without DDoS Protection Standard are vulnerable to volumetric denial of service attacks. DDoS Protection Standard provides enhanced mitigation for production workloads."
+      "control_id": "A.13.1.1",
+      "control_name": "Network controls",
+      "description": "Virtual networks without DDoS protection are vulnerable to availability attacks. Network controls should include protection against denial of service attacks to maintain availability of information systems."
     },
     "AZ-NET-006": {
-      "control_id": "CM-7",
-      "control_name": "Least Functionality",
-      "description": "Unassociated public IP addresses represent unnecessary functionality and attack surface. Resources that are no longer in use should be removed to maintain least functionality."
+      "control_id": "A.13.1.1",
+      "control_name": "Network controls",
+      "description": "Unassociated public IP addresses represent unnecessary network exposure. Network resources that are no longer required should be removed to minimise the attack surface."
     },
     "AZ-NET-007": {
-      "control_id": "SI-3",
-      "control_name": "Malicious Code Protection",
-      "description": "Application Gateways without WAF enabled provide no protection against web application attacks including OWASP Top 10 vulnerabilities. WAF in Prevention mode should be enabled on all public-facing Application Gateways."
+      "control_id": "A.13.1.1",
+      "control_name": "Network controls",
+      "description": "Application Gateways without WAF provide no protection against web application attacks. Network controls should include application layer filtering to protect against common web exploits."
     },
     "AZ-NET-008": {
-      "control_id": "CM-7",
-      "control_name": "Least Functionality",
-      "description": "Load balancers with no backend pool configured serve no function and represent unnecessary resources. Unused resources should be removed to maintain least functionality and reduce cost."
+      "control_id": "A.13.1.1",
+      "control_name": "Network controls",
+      "description": "Load balancers with no backend pool are unused resources. Unused network resources should be removed as part of regular network hygiene to maintain an accurate and minimal network topology."
     },
     "AZ-NET-009": {
-      "control_id": "SC-8",
-      "control_name": "Transmission Confidentiality and Integrity",
-      "description": "VPN connections using IKEv1 use an outdated protocol with known vulnerabilities. IKEv2 should be used for all VPN gateway connections to ensure transmission confidentiality and integrity."
+      "control_id": "A.13.2.1",
+      "control_name": "Information transfer policies and procedures",
+      "description": "VPN connections using IKEv1 use an outdated protocol. Information transfer policies should require the use of current secure protocols to protect data in transit between networks."
     },
     "AZ-NET-010": {
-      "control_id": "SC-7",
-      "control_name": "Boundary Protection",
-      "description": "Subnets without NSGs attached have no network layer access control. All production subnets should have NSGs with explicit rules to enforce boundary protection at the subnet level."
+      "control_id": "A.13.1.1",
+      "control_name": "Network controls",
+      "description": "Subnets without NSGs have no network layer access controls. All subnets should have NSGs attached with explicit rules to enforce network controls at the subnet boundary."
     },
     "AZ-IDN-001": {
-      "control_id": "PR.AC-4",
-      "control_name": "Access permissions and authorizations are managed",
-      "description": "Service principals with overly broad permissions violate least privilege. Access permissions should be scoped to the minimum required for the workload to function."
+      "control_id": "A.9.2.3",
+      "control_name": "Management of privileged access rights",
+      "description": "Service principals with overly broad permissions violate privileged access management. The allocation and use of privileged access rights should be restricted and controlled."
     },
     "AZ-IDN-002": {
-      "control_id": "PR.AC-7",
-      "control_name": "Users, devices, and other assets are authenticated",
-      "description": "MFA ensures privileged users are strongly authenticated before accessing Azure resources. Without MFA, a compromised password is sufficient for full administrative access."
+      "control_id": "A.9.4.2",
+      "control_name": "Secure log-on procedures",
+      "description": "MFA enforces secure log-on for privileged accounts. Where required by the access control policy, access to systems and applications should be controlled by a secure log-on procedure including multi-factor authentication."
     },
     "AZ-DB-001": {
-      "control_id": "PR.AC-3",
-      "control_name": "Remote access is managed",
-      "description": "Public network access to PostgreSQL servers should be disabled. Database access should be restricted to private networks to ensure remote access is managed and controlled."
+      "control_id": "A.13.1.1",
+      "control_name": "Network controls",
+      "description": "Public network access to PostgreSQL servers should be disabled. Database servers should only be accessible via private network connections with appropriate network controls in place."
     },
     "AZ-DB-002": {
-      "control_id": "DE.AE-3",
-      "control_name": "Event data are aggregated and correlated",
-      "description": "SQL Server auditing must be enabled with sufficient retention to support threat detection and incident investigation. Audit logs provide the event data needed to detect and respond to anomalous database activity."
+      "control_id": "A.12.4.1",
+      "control_name": "Event logging",
+      "description": "SQL Server auditing must be enabled to provide event logs. Event logs recording user activities, exceptions, faults and information security events should be produced, kept and regularly reviewed."
     },
     "AZ-CMP-001": {
-      "control_id": "PR.AC-3",
-      "control_name": "Remote access is managed",
-      "description": "Virtual machines with public IPs and no NSG have unrestricted network access. NSGs should be attached to control inbound and outbound traffic and manage remote access to compute resources."
+      "control_id": "A.13.1.1",
+      "control_name": "Network controls",
+      "description": "Virtual machines with public IPs and no NSG have unrestricted network access. Network controls should be applied to all compute resources accessible from the internet."
     },
     "AZ-CMP-002": {
-      "control_id": "PR.DS-1",
-      "control_name": "Data-at-rest is protected",
-      "description": "Virtual machine OS and data disks are using platform-managed encryption only (EncryptionAtRestWithPlatformKey). PR.DS-1 requires that data at rest is protected using appropriate controls. Platform-managed encryption does not give the organisation control over the encryption keys. Customer-managed keys or Azure Disk Encryption are required to satisfy this control."
+      "control_id": "A.10.1.1",
+      "control_name": "Policy on the use of cryptographic controls",
+      "description": "Virtual machine OS and data disks are using platform-managed encryption only (EncryptionAtRestWithPlatformKey). A.10.1.1 requires that a policy on the use of cryptographic controls is developed and implemented. Platform-managed encryption does not give the organisation control over the encryption keys. Customer-managed keys or Azure Disk Encryption are required to satisfy this control."
     },
     "AZ-KV-001": {
-      "control_id": "PR.IP-4",
-      "control_name": "Backups of information are conducted, maintained, and tested",
-      "description": "Key material in Azure Key Vault must be recoverable after accidental or malicious deletion. Soft delete provides a recoverable state for secrets, keys, and certificates supporting backup and recovery requirements for critical cryptographic material."
+      "control_id": "A.17.2.1",
+      "control_name": "Availability of information processing facilities",
+      "description": "Key Vault soft delete protects against loss of secrets, keys and certificates. Without soft delete, deleted vault objects cannot be recovered, reducing availability and recovery options for critical cryptographic material."
+    },
+    "AZ-STOR-003": {
+      "control_id": "A.8.3.1",
+      "control_name": "Management of removable media",
+      "description": "Storage accounts without lifecycle policies retain data indefinitely with no automated disposal mechanism. Lifecycle management supports formal retention, tiering, and disposal of information assets."
     },
     "AZ-KV-002": {
-      "control_id": "AC-17",
-      "control_name": "Remote access",
-      "description": "Key Vaults that allow public network access expose sensitive secrets, keys, and certificates to remote access attempts from outside trusted networks. Restricting access through private endpoints or trusted networks helps manage remote access paths."
+      "control_id": "A.13.1.1",
+      "control_name": "Network controls",
+      "description": "Networks should be managed and controlled to protect information systems and applications. Allowing public network access to Azure Key Vault increases exposure of sensitive secrets, keys, and certificates to external networks. Access should be restricted to trusted networks using private endpoints or network controls."
     }
   }
 }

--- a/compliance/frameworks/nist_csf.json
+++ b/compliance/frameworks/nist_csf.json
@@ -88,6 +88,11 @@
       "control_name": "Remote access is managed",
       "description": "Virtual machines with public IPs and no NSG have unrestricted network access. NSGs should be attached to control inbound and outbound traffic and manage remote access to compute resources."
     },
+    "AZ-CMP-002": {
+     "control_id": "PR.DS-1",
+     "control_name": "Data-at-rest is protected",
+    "description": "Virtual machine OS and data disks that are not encrypted with Azure Disk Encryption or customer-managed keys store data in plain text. PR.DS-1 requires that data at rest is protected. Enabling disk encryption ensures that disk contents are unreadable without the encryption key even if the disk is snapshotted or physically accessed."
+   },
     "AZ-KV-001": {
       "control_id": "PR.IP-4",
       "control_name": "Backups of information are conducted, maintained, and tested",

--- a/compliance/frameworks/nist_csf.json
+++ b/compliance/frameworks/nist_csf.json
@@ -88,6 +88,11 @@
       "control_name": "Remote access is managed",
       "description": "Virtual machines with public IPs and no NSG have unrestricted network access. NSGs should be attached to control inbound and outbound traffic and manage remote access to compute resources."
     },
+    "AZ-CMP-002": {
+      "control_id": "PR.DS-1",
+      "control_name": "Data-at-rest is protected",
+      "description": "Virtual machine OS and data disks are using platform-managed encryption only (EncryptionAtRestWithPlatformKey). PR.DS-1 requires that data at rest is protected using appropriate controls. Platform-managed encryption does not give the organisation control over the encryption keys. Customer-managed keys or Azure Disk Encryption are required to satisfy this control."
+    },
     "AZ-KV-001": {
       "control_id": "PR.IP-4",
       "control_name": "Backups of information are conducted, maintained, and tested",

--- a/compliance/frameworks/soc2.json
+++ b/compliance/frameworks/soc2.json
@@ -106,4 +106,7 @@
     "AZ-KV-002": {
       "control_id": "CC6.6",
       "control_name": "Restricts Access from Outside the Network Boundary",
-      "description": "A Key Vault accessible from the public internet allows any external party to attempt access to secrets, keys and certificates. CC6.6 requires that access from outside the network boundary is restricted and controlled. Locking Key Vault access to private endpoints o
+      "description": "A Key Vault accessible from the public internet allows any external party to attempt access to secrets, keys and certificates. CC6.6 requires that access from outside the network boundary is restricted and controlled. Locking Key Vault access to private endpoints or specific VNet service endpoints enforces this boundary and protects sensitive credentials from external exposure."
+    }
+  }
+}

--- a/compliance/frameworks/soc2.json
+++ b/compliance/frameworks/soc2.json
@@ -93,6 +93,11 @@
       "control_name": "Restricts Access from Outside the Network Boundary",
       "description": "A virtual machine with a public IP and no NSG has unrestricted inbound network access from the internet with no filtering in place. CC6.6 requires that logical access from outside the network perimeter is restricted and controlled. Attaching an NSG with explicit rules enforces the network boundary and controls what traffic can reach the VM."
     },
+    "AZ-CMP-002": {
+      "control_id": "CC6.7",
+      "control_name": "Protects Data in Transit and At Rest",
+      "description": "Virtual machine OS and data disks are using platform-managed encryption only (EncryptionAtRestWithPlatformKey). CC6.7 requires that data is protected using encryption. Platform-managed encryption does not give the organisation control over the encryption keys. Customer-managed keys or Azure Disk Encryption are required to satisfy this control."
+    },
     "AZ-KV-001": {
       "control_id": "A1.2",
       "control_name": "Environmental Threats and Recovery",
@@ -101,7 +106,4 @@
     "AZ-KV-002": {
       "control_id": "CC6.6",
       "control_name": "Restricts Access from Outside the Network Boundary",
-      "description": "A Key Vault accessible from the public internet allows any external party to attempt access to secrets, keys and certificates. CC6.6 requires that access from outside the network boundary is restricted and controlled. Locking Key Vault access to private endpoints or specific VNet service endpoints enforces this boundary and protects sensitive credentials from external exposure."
-    }
-  }
-}
+      "description": "A Key Vault accessible from the public internet allows any external party to attempt access to secrets, keys and certificates. CC6.6 requires that access from outside the network boundary is restricted and controlled. Locking Key Vault access to private endpoints o

--- a/compliance/frameworks/soc2.json
+++ b/compliance/frameworks/soc2.json
@@ -101,7 +101,7 @@
     "AZ-KV-001": {
       "control_id": "A1.2",
       "control_name": "Environmental Threats and Recovery",
-      "description": "Key Vault without soft delete enabled allows permanent deletion of secrets, keys and certificates with no recovery possible. A1.2 requires that environmental threats to availability are identified and mitigated including protection against accidental or malicious data loss. Enabling soft delete ensures deleted vault objects can be recovered within the retention period."
+      "description": "Virtual machine OS and data disks are using platform-managed encryption only. CC6.7 requires that data is protected using encryption. Platform-managed encryption does not give the organisation control over the encryption keys. Customer-managed keys or Azure Disk Encryption are required to satisfy this control."
     },
     "AZ-KV-002": {
       "control_id": "CC6.6",

--- a/compliance/frameworks/soc2.json
+++ b/compliance/frameworks/soc2.json
@@ -93,15 +93,10 @@
       "control_name": "Restricts Access from Outside the Network Boundary",
       "description": "A virtual machine with a public IP and no NSG has unrestricted inbound network access from the internet with no filtering in place. CC6.6 requires that logical access from outside the network perimeter is restricted and controlled. Attaching an NSG with explicit rules enforces the network boundary and controls what traffic can reach the VM."
     },
-    "AZ-CMP-002": {
-      "control_id": "CC6.7",
-      "control_name": "Protects Data in Transit and At Rest",
-      "description": "Virtual machine OS and data disks are using platform-managed encryption only (EncryptionAtRestWithPlatformKey). CC6.7 requires that data is protected using encryption. Platform-managed encryption does not give the organisation control over the encryption keys. Customer-managed keys or Azure Disk Encryption are required to satisfy this control."
-    },
     "AZ-KV-001": {
       "control_id": "A1.2",
       "control_name": "Environmental Threats and Recovery",
-      "description": "Virtual machine OS and data disks are using platform-managed encryption only. CC6.7 requires that data is protected using encryption. Platform-managed encryption does not give the organisation control over the encryption keys. Customer-managed keys or Azure Disk Encryption are required to satisfy this control."
+      "description": "Key Vault without soft delete enabled allows permanent deletion of secrets, keys and certificates with no recovery possible. A1.2 requires that environmental threats to availability are identified and mitigated including protection against accidental or malicious data loss. Enabling soft delete ensures deleted vault objects can be recovered within the retention period."
     },
     "AZ-KV-002": {
       "control_id": "CC6.6",

--- a/compliance/frameworks/soc2.json
+++ b/compliance/frameworks/soc2.json
@@ -93,6 +93,11 @@
       "control_name": "Restricts Access from Outside the Network Boundary",
       "description": "A virtual machine with a public IP and no NSG has unrestricted inbound network access from the internet with no filtering in place. CC6.6 requires that logical access from outside the network perimeter is restricted and controlled. Attaching an NSG with explicit rules enforces the network boundary and controls what traffic can reach the VM."
     },
+     "AZ-CMP-002": {
+     "control_id": "CC6.7",
+     "control_name": "Protects Data in Transit and At Rest",
+     "description": "Virtual machine OS and data disks that are not encrypted store data in plain text. CC6.7 requires that data is protected using encryption. Enabling Azure Disk Encryption or server-side encryption with customer-managed keys ensures disk contents are unreadable without the encryption key even if the disk is snapshotted or physically accessed."
+   },
     "AZ-KV-001": {
       "control_id": "A1.2",
       "control_name": "Environmental Threats and Recovery",

--- a/compliance/frameworks/soc2.json
+++ b/compliance/frameworks/soc2.json
@@ -93,11 +93,11 @@
       "control_name": "Restricts Access from Outside the Network Boundary",
       "description": "A virtual machine with a public IP and no NSG has unrestricted inbound network access from the internet with no filtering in place. CC6.6 requires that logical access from outside the network perimeter is restricted and controlled. Attaching an NSG with explicit rules enforces the network boundary and controls what traffic can reach the VM."
     },
-     "AZ-CMP-002": {
-     "control_id": "CC6.7",
-     "control_name": "Protects Data in Transit and At Rest",
-     "description": "Virtual machine OS and data disks that are not encrypted store data in plain text. CC6.7 requires that data is protected using encryption. Enabling Azure Disk Encryption or server-side encryption with customer-managed keys ensures disk contents are unreadable without the encryption key even if the disk is snapshotted or physically accessed."
-   },
+    "AZ-CMP-002": {
+      "control_id": "CC6.7",
+      "control_name": "Protects Data in Transit and At Rest",
+      "description": "Virtual machine OS and data disks are using platform-managed encryption only (EncryptionAtRestWithPlatformKey). CC6.7 requires that data is protected using encryption. Platform-managed encryption does not give the organisation control over the encryption keys. Customer-managed keys or Azure Disk Encryption are required to satisfy this control."
+    },
     "AZ-KV-001": {
       "control_id": "A1.2",
       "control_name": "Environmental Threats and Recovery",

--- a/playbooks/cli/fix_az_cmp_002.sh
+++ b/playbooks/cli/fix_az_cmp_002.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+# OpenShield Remediation Playbook
+# Rule: AZ-CMP-002 — Virtual machine without disk encryption enabled
+# Usage: ./fix_az_cmp_002.sh <resource-group> <vm-name> <keyvault-name>
+# Severity: HIGH
+
+set -e
+
+RESOURCE_GROUP=$1
+VM_NAME=$2
+KEYVAULT_NAME=$3
+
+if [ -z "$RESOURCE_GROUP" ] || [ -z "$VM_NAME" ] || [ -z "$KEYVAULT_NAME" ]; then
+  echo "Usage: $0 <resource-group> <vm-name> <keyvault-name>"
+  echo ""
+  echo "Prerequisites:"
+  echo "  1. Create a Key Vault if one does not exist:"
+  echo "     az keyvault create --resource-group <rg> --name <kv-name> --enabled-for-disk-encryption true"
+  echo "  2. Ensure the VM is running before enabling encryption"
+  exit 1
+fi
+
+echo "Enabling Azure Disk Encryption on VM '$VM_NAME'..."
+
+az vm encryption enable \
+  --resource-group "$RESOURCE_GROUP" \
+  --name "$VM_NAME" \
+  --disk-encryption-keyvault "$KEYVAULT_NAME" \
+  --volume-type All
+
+echo "Waiting for encryption to complete..."
+
+az vm encryption show \
+  --resource-group "$RESOURCE_GROUP" \
+  --name "$VM_NAME"
+
+echo "✅ Disk encryption enabled on all volumes for VM '$VM_NAME'."
+echo "⚠️  The VM may restart during the encryption process."
+echo "⚠️  Encryption of large disks can take several hours to complete."

--- a/playbooks/cli/fix_az_cmp_002.sh
+++ b/playbooks/cli/fix_az_cmp_002.sh
@@ -34,6 +34,6 @@ az vm encryption show \
   --resource-group "$RESOURCE_GROUP" \
   --name "$VM_NAME"
 
-echo "✅ Disk encryption enabled on all volumes for VM '$VM_NAME'."
-echo "⚠️  The VM may restart during the encryption process."
-echo "⚠️  Encryption of large disks can take several hours to complete."
+echo "Disk encryption enabled on all volumes for VM '$VM_NAME'."
+echo "The VM may restart during the encryption process."
+echo "Encryption of large disks can take several hours to complete."

--- a/scanner/rules/az_cmp_002.py
+++ b/scanner/rules/az_cmp_002.py
@@ -26,6 +26,32 @@ PLAYBOOK = "playbooks/cli/fix_az_cmp_002.sh"
 logger = logging.getLogger(__name__)
 
 
+def _disk_needs_flagging(managed_disk: Any) -> bool:
+    """Return True only if the disk uses platform-managed encryption.
+
+    Azure platform-managed encryption (EncryptionAtRestWithPlatformKey) is the
+    default for all managed disks and does not satisfy CIS 7.2, which requires
+    customer-managed keys (CMK) or Azure Disk Encryption (ADE).
+
+    Disks using EncryptionAtRestWithCustomerKey or
+    EncryptionAtRestWithPlatformAndCustomerKeys are compliant and should not
+    be flagged.
+    """
+    if managed_disk is None:
+        return False
+
+    encryption = getattr(managed_disk, "security_profile", None)
+    if encryption is None:
+        encryption = getattr(managed_disk, "encryption", None)
+
+    encryption_type = getattr(encryption, "type", None)
+
+    if encryption_type is None:
+        return False
+
+    return encryption_type == "EncryptionAtRestWithPlatformKey"
+
+
 def scan(azure_client: Any, subscription_id: str) -> List[Dict[str, Any]]:
     """Detect virtual machines with unencrypted OS or data disks."""
     findings: List[Dict[str, Any]] = []
@@ -50,23 +76,17 @@ def scan(azure_client: Any, subscription_id: str) -> List[Dict[str, Any]]:
         # Check OS disk
         os_disk = getattr(storage_profile, "os_disk", None)
         if os_disk:
-            encryption = getattr(os_disk, "managed_disk", None)
-            disk_encryption_set = getattr(
-                encryption, "disk_encryption_set_id", None
-            ) if encryption else None
-            security_profile = getattr(os_disk, "encryption_settings_collection", None)
-            if not disk_encryption_set and not security_profile:
-                unencrypted_disks.append(getattr(os_disk, "name", "os-disk"))
+            managed_disk = getattr(os_disk, "managed_disk", None)
+            if _disk_needs_flagging(managed_disk):
+                unencrypted_disks.append(
+                    getattr(os_disk, "name", "os-disk")
+                )
 
         # Check data disks
         data_disks = getattr(storage_profile, "data_disks", []) or []
         for disk in data_disks:
-            encryption = getattr(disk, "managed_disk", None)
-            disk_encryption_set = getattr(
-                encryption, "disk_encryption_set_id", None
-            ) if encryption else None
-            security_profile = getattr(disk, "encryption_settings_collection", None)
-            if not disk_encryption_set and not security_profile:
+            managed_disk = getattr(disk, "managed_disk", None)
+            if _disk_needs_flagging(managed_disk):
                 unencrypted_disks.append(
                     getattr(disk, "name", f"data-disk-{getattr(disk, 'lun', '?')}")
                 )

--- a/scanner/rules/az_cmp_002.py
+++ b/scanner/rules/az_cmp_002.py
@@ -1,0 +1,95 @@
+"""AZ-CMP-002: Virtual machine without disk encryption enabled."""
+
+import logging
+from typing import Any, Dict, List
+
+RULE_ID = "AZ-CMP-002"
+RULE_NAME = "Virtual machine without disk encryption enabled"
+SEVERITY = "HIGH"
+CATEGORY = "Compute"
+FRAMEWORKS = {"CIS": "7.2", "NIST": "PR.DS-1", "ISO27001": "A.10.1.1"}
+DESCRIPTION = (
+    "One or more disks attached to this virtual machine are not encrypted "
+    "using Azure Disk Encryption or server-side encryption with a "
+    "customer-managed key. An attacker who gains subscription-level access "
+    "can snapshot an unencrypted disk and mount it on another VM to read "
+    "all data without needing the original VM credentials."
+)
+REMEDIATION = (
+    "Enable Azure Disk Encryption on all OS and data disks attached to the "
+    "virtual machine. Navigate to: Virtual Machine > Disks > Additional settings "
+    "> Disk encryption. Alternatively, configure server-side encryption with "
+    "customer-managed keys via a Disk Encryption Set."
+)
+PLAYBOOK = "playbooks/cli/fix_az_cmp_002.sh"
+
+logger = logging.getLogger(__name__)
+
+
+def scan(azure_client: Any, subscription_id: str) -> List[Dict[str, Any]]:
+    """Detect virtual machines with unencrypted OS or data disks."""
+    findings: List[Dict[str, Any]] = []
+
+    for vm in azure_client.get_virtual_machines():
+        vm_id = getattr(vm, "id", "")
+        vm_name = getattr(vm, "name", "")
+        location = getattr(vm, "location", "")
+
+        if not vm_id or not vm_name:
+            continue
+
+        parsed = azure_client.parse_resource_id(vm_id)
+        resource_group = parsed.get("resource_group", "")
+
+        storage_profile = getattr(vm, "storage_profile", None)
+        if not storage_profile:
+            continue
+
+        unencrypted_disks = []
+
+        # Check OS disk
+        os_disk = getattr(storage_profile, "os_disk", None)
+        if os_disk:
+            encryption = getattr(os_disk, "managed_disk", None)
+            disk_encryption_set = getattr(
+                encryption, "disk_encryption_set_id", None
+            ) if encryption else None
+            security_profile = getattr(os_disk, "encryption_settings_collection", None)
+            if not disk_encryption_set and not security_profile:
+                unencrypted_disks.append(getattr(os_disk, "name", "os-disk"))
+
+        # Check data disks
+        data_disks = getattr(storage_profile, "data_disks", []) or []
+        for disk in data_disks:
+            encryption = getattr(disk, "managed_disk", None)
+            disk_encryption_set = getattr(
+                encryption, "disk_encryption_set_id", None
+            ) if encryption else None
+            security_profile = getattr(disk, "encryption_settings_collection", None)
+            if not disk_encryption_set and not security_profile:
+                unencrypted_disks.append(
+                    getattr(disk, "name", f"data-disk-{getattr(disk, 'lun', '?')}")
+                )
+
+        if unencrypted_disks:
+            findings.append({
+                "rule_id": RULE_ID,
+                "rule_name": RULE_NAME,
+                "severity": SEVERITY,
+                "category": CATEGORY,
+                "resource_id": vm_id,
+                "resource_name": vm_name,
+                "resource_type": "Microsoft.Compute/virtualMachines",
+                "description": DESCRIPTION,
+                "remediation": REMEDIATION,
+                "playbook": PLAYBOOK,
+                "frameworks": FRAMEWORKS,
+                "metadata": {
+                    "resource_group": resource_group,
+                    "location": location,
+                    "unencrypted_disks": unencrypted_disks,
+                    "unencrypted_disk_count": len(unencrypted_disks),
+                },
+            })
+
+    return findings

--- a/scanner/rules/az_cmp_002.py
+++ b/scanner/rules/az_cmp_002.py
@@ -1,25 +1,25 @@
-"""AZ-CMP-002: Virtual machine without disk encryption enabled."""
+"""AZ-CMP-002: Virtual machine OS or data disk using platform-managed encryption only."""
 
 import logging
 from typing import Any, Dict, List
 
 RULE_ID = "AZ-CMP-002"
-RULE_NAME = "Virtual machine without disk encryption enabled"
+RULE_NAME = "Virtual machine disk not protected by customer-managed key or ADE"
 SEVERITY = "HIGH"
 CATEGORY = "Compute"
-FRAMEWORKS = {"CIS": "7.2", "NIST": "PR.DS-1", "ISO27001": "A.10.1.1"}
+FRAMEWORKS = {"CIS": "7.2", "NIST": "PR.DS-1", "ISO27001": "A.10.1.1", "SOC2": "CC6.7"}
 DESCRIPTION = (
-    "One or more disks attached to this virtual machine are not encrypted "
-    "using Azure Disk Encryption or server-side encryption with a "
-    "customer-managed key. An attacker who gains subscription-level access "
-    "can snapshot an unencrypted disk and mount it on another VM to read "
-    "all data without needing the original VM credentials."
+    "One or more disks attached to this virtual machine are using platform-managed "
+    "encryption only (EncryptionAtRestWithPlatformKey). CIS 7.2 requires disks to be "
+    "protected using either Azure Disk Encryption (ADE) or server-side encryption with "
+    "a customer-managed key (CMK). Platform-managed encryption does not give the "
+    "organisation control over the encryption keys."
 )
 REMEDIATION = (
-    "Enable Azure Disk Encryption on all OS and data disks attached to the "
-    "virtual machine. Navigate to: Virtual Machine > Disks > Additional settings "
-    "> Disk encryption. Alternatively, configure server-side encryption with "
-    "customer-managed keys via a Disk Encryption Set."
+    "Configure server-side encryption with a customer-managed key via a Disk Encryption "
+    "Set, or enable Azure Disk Encryption on all OS and data disks. Navigate to: "
+    "Virtual Machine > Disks > Additional settings > Disk encryption set, or use "
+    "az vm encryption enable with a Key Vault."
 )
 PLAYBOOK = "playbooks/cli/fix_az_cmp_002.sh"
 
@@ -53,7 +53,7 @@ def _disk_needs_flagging(managed_disk: Any) -> bool:
 
 
 def scan(azure_client: Any, subscription_id: str) -> List[Dict[str, Any]]:
-    """Detect virtual machines with unencrypted OS or data disks."""
+    """Detect virtual machines whose disks use platform-managed encryption only."""
     findings: List[Dict[str, Any]] = []
 
     for vm in azure_client.get_virtual_machines():


### PR DESCRIPTION
Closes #27

Added scanner rule and remediation playbook for AZ-CMP-002 detecting virtual machines with unencrypted OS or data disks.

Files added:
- scanner/rules/az_cmp_002.py — detects VMs where OS or data disks are not encrypted using Azure Disk Encryption or customer-managed keys
- playbooks/cli/fix_az_cmp_002.sh — enables Azure Disk Encryption on all volumes via az vm encryption enable

Compliance mappings added to all four framework files:
- CIS 7.2
- NIST PR.DS-1
- ISO27001 A.10.1.1
- SOC2 CC6.7