### PR TITLE
feat: add rule AZ-IDN-003 — guest user access without restriction in Entra ID

### DIFF
--- a/compliance/frameworks/cis_azure_benchmark.json
+++ b/compliance/frameworks/cis_azure_benchmark.json
@@ -80,9 +80,9 @@
     },
     "AZ-IDN-003": {
       "control_id": "1.15",
-      "control_name": "Ensure that 'Guest users access restrictions' is set to 'Guest user access is restricted to properties and memberships of their own directory objects'",
-      "description": "Restricting guest user access prevents external users from enumerating internal directory objects such as users, groups and other resources. Unrestricted guest access increases the risk of information disclosure and lateral movement by external parties invited into the tenant."
-    },
+      "control_name": "Ensure that 'Guest invite restrictions' is set to 'Only users assigned to specific admin roles can invite guest users'",
+      "description": "Unrestricted guest user invitation settings allow any member of the organisation to invite external users into the tenant without administrative review. This bypasses centralised approval for external identity provisioning and increases the risk of unauthorised access by inviting untrusted parties."
+   },
     "AZ-DB-001": {
       "control_id": "4.3.1",
       "control_name": "Ensure 'Allow access to Azure services' for PostgreSQL Database Server is disabled",

--- a/compliance/frameworks/cis_azure_benchmark.json
+++ b/compliance/frameworks/cis_azure_benchmark.json
@@ -13,6 +13,11 @@
       "control_name": "Ensure that 'Secure transfer required' is set to 'Enabled'",
       "description": "Enabling 'Secure transfer required' on a storage account ensures that all requests made to the storage account use HTTPS. Any requests using HTTP are rejected, protecting data in transit from eavesdropping and man-in-the-middle attacks."
     },
+    "AZ-STOR-003": {
+      "control_id": "3.7",
+      "control_name": "Ensure that storage accounts have lifecycle management policies configured",
+      "description": "Storage accounts without lifecycle management policies retain data indefinitely. This increases storage costs, expands the attack surface through accumulation of stale data, and may violate data retention compliance requirements. Lifecycle policies automate the transition and deletion of blobs based on age and access patterns."
+    },
     "AZ-NET-001": {
       "control_id": "6.2",
       "control_name": "Ensure that SSH access from the Internet is evaluated and restricted",
@@ -73,6 +78,11 @@
       "control_name": "Ensure that 'Multi-Factor Authentication Status' is 'Enabled' for all Privileged Users",
       "description": "Multi-Factor Authentication requires an individual to present a minimum of two separate forms of authentication before access is granted. MFA should be enforced for all users with administrative privileges via Conditional Access policies."
     },
+    "AZ-IDN-003": {
+      "control_id": "1.15",
+      "control_name": "Ensure that 'Guest users access restrictions' is set to 'Guest user access is restricted to properties and memberships of their own directory objects'",
+      "description": "Restricting guest user access prevents external users from enumerating internal directory objects such as users, groups and other resources. Unrestricted guest access increases the risk of information disclosure and lateral movement by external parties invited into the tenant."
+    },
     "AZ-DB-001": {
       "control_id": "4.3.1",
       "control_name": "Ensure 'Allow access to Azure services' for PostgreSQL Database Server is disabled",
@@ -88,15 +98,15 @@
       "control_name": "Ensure that 'OS disk' are encrypted",
       "description": "Virtual machines that are reachable from the internet should have Network Security Groups attached to their network interfaces to control and restrict inbound and outbound traffic, reducing the attack surface."
     },
+    "AZ-CMP-002": {
+      "control_id": "7.2",
+      "control_name": "Ensure that 'OS disk' are encrypted",
+      "description": "Virtual machine OS and data disks should be encrypted using Azure Disk Encryption or server-side encryption with customer-managed keys. Unencrypted disks can be snapshotted and read by an attacker who gains subscription access without needing VM credentials."
+    },
     "AZ-KV-001": {
       "control_id": "8.5",
       "control_name": "Ensure the Key Vault is Recoverable",
       "description": "Azure Key Vault soft delete should be enabled on all Key Vaults. The soft delete feature allows recovery of deleted vaults and vault objects (keys, secrets, certificates) for a configurable retention period (7–90 days), protecting against accidental or malicious deletion."
-    },
-    "AZ-STOR-003": {
-      "control_id": "3.7",
-      "control_name": "Ensure that storage accounts have lifecycle management policies configured",
-      "description": "Storage accounts without lifecycle management policies retain data indefinitely. This increases storage costs, expands the attack surface through accumulation of stale data, and may violate data retention compliance requirements. Lifecycle policies automate the transition and deletion of blobs based on age and access patterns."
     },
     "AZ-KV-002": {
       "control_id": "8.3",

--- a/compliance/frameworks/cis_azure_benchmark.json
+++ b/compliance/frameworks/cis_azure_benchmark.json
@@ -98,11 +98,6 @@
       "control_name": "Ensure that 'OS disk' are encrypted",
       "description": "Virtual machines that are reachable from the internet should have Network Security Groups attached to their network interfaces to control and restrict inbound and outbound traffic, reducing the attack surface."
     },
-    "AZ-CMP-002": {
-      "control_id": "7.2",
-      "control_name": "Ensure that 'OS disk' are encrypted",
-      "description": "Virtual machine OS and data disks should be encrypted using Azure Disk Encryption or server-side encryption with customer-managed keys. Unencrypted disks can be snapshotted and read by an attacker who gains subscription access without needing VM credentials."
-    },
     "AZ-KV-001": {
       "control_id": "8.5",
       "control_name": "Ensure the Key Vault is Recoverable",

--- a/compliance/frameworks/iso27001.json
+++ b/compliance/frameworks/iso27001.json
@@ -98,11 +98,6 @@
       "control_name": "Network controls",
       "description": "Virtual machines with public IPs and no NSG have unrestricted network access. Network controls should be applied to all compute resources accessible from the internet."
     },
-    "AZ-CMP-002": {
-      "control_id": "A.10.1.1",
-      "control_name": "Policy on the use of cryptographic controls",
-      "description": "Virtual machine OS and data disks that are not encrypted store data in plain text on disk. A.10.1.1 requires that a policy on the use of cryptographic controls is developed and implemented for protection of information. Enabling Azure Disk Encryption or server-side encryption with customer-managed keys ensures data at rest on VM disks is protected using cryptographic controls."
-    },
     "AZ-KV-001": {
       "control_id": "A.17.2.1",
       "control_name": "Availability of information processing facilities",

--- a/compliance/frameworks/iso27001.json
+++ b/compliance/frameworks/iso27001.json
@@ -13,6 +13,11 @@
       "control_name": "Policy on the use of cryptographic controls",
       "description": "Requiring secure transfer ensures cryptographic controls are applied to data in transit. A policy on the use of cryptographic controls for protection of information should be developed and implemented."
     },
+    "AZ-STOR-003": {
+      "control_id": "A.8.3.1",
+      "control_name": "Management of removable media",
+      "description": "Storage accounts without lifecycle policies retain data indefinitely with no automated disposal mechanism. Lifecycle management supports formal retention, tiering, and disposal of information assets."
+    },
     "AZ-NET-001": {
       "control_id": "A.13.1.1",
       "control_name": "Network controls",
@@ -73,6 +78,11 @@
       "control_name": "Secure log-on procedures",
       "description": "MFA enforces secure log-on for privileged accounts. Where required by the access control policy, access to systems and applications should be controlled by a secure log-on procedure including multi-factor authentication."
     },
+    "AZ-IDN-003": {
+      "control_id": "A.9.2.1",
+      "control_name": "User registration and de-registration",
+      "description": "Unrestricted guest user invitations allow any organisation member to register external identities into the tenant without centralised review or approval. A.9.2.1 requires that a formal user registration and de-registration process is implemented. Restricting guest invitations to administrators ensures external identity registration is formally controlled and audited."
+    },
     "AZ-DB-001": {
       "control_id": "A.13.1.1",
       "control_name": "Network controls",
@@ -88,15 +98,15 @@
       "control_name": "Network controls",
       "description": "Virtual machines with public IPs and no NSG have unrestricted network access. Network controls should be applied to all compute resources accessible from the internet."
     },
+    "AZ-CMP-002": {
+      "control_id": "A.10.1.1",
+      "control_name": "Policy on the use of cryptographic controls",
+      "description": "Virtual machine OS and data disks that are not encrypted store data in plain text on disk. A.10.1.1 requires that a policy on the use of cryptographic controls is developed and implemented for protection of information. Enabling Azure Disk Encryption or server-side encryption with customer-managed keys ensures data at rest on VM disks is protected using cryptographic controls."
+    },
     "AZ-KV-001": {
       "control_id": "A.17.2.1",
       "control_name": "Availability of information processing facilities",
       "description": "Key Vault soft delete protects against loss of secrets, keys and certificates. Without soft delete, deleted vault objects cannot be recovered, reducing availability and recovery options for critical cryptographic material."
-    },
-    "AZ-STOR-003": {
-      "control_id": "A.8.3.1",
-      "control_name": "Management of removable media",
-      "description": "Storage accounts without lifecycle policies retain data indefinitely with no automated disposal mechanism. Lifecycle management supports formal retention, tiering, and disposal of information assets."
     },
     "AZ-KV-002": {
       "control_id": "A.13.1.1",

--- a/compliance/frameworks/iso27001.json
+++ b/compliance/frameworks/iso27001.json
@@ -98,11 +98,11 @@
       "control_name": "Network controls",
       "description": "Virtual machines with public IPs and no NSG have unrestricted network access. Network controls should be applied to all compute resources accessible from the internet."
     },
-    "AZ-KV-001": {
-      "control_id": "A.17.2.1",
-      "control_name": "Availability of information processing facilities",
-      "description": "Key Vault soft delete protects against loss of secrets, keys and certificates. Without soft delete, deleted vault objects cannot be recovered, reducing availability and recovery options for critical cryptographic material."
-    },
+   "AZ-KV-001": {
+      "control_id": "PR.IP-4",
+      "control_name": "Backups of information are conducted, maintained, and tested",
+      "description": "Key material in Azure Key Vault must be recoverable after accidental or malicious deletion. Soft delete provides a recoverable state for secrets, keys, and certificates supporting backup and recovery requirements for critical cryptographic material."
+},
     "AZ-KV-002": {
       "control_id": "A.13.1.1",
       "control_name": "Network controls",

--- a/compliance/frameworks/nist_csf.json
+++ b/compliance/frameworks/nist_csf.json
@@ -101,8 +101,8 @@
     "AZ-KV-001": {
       "control_id": "PR.IP-4",
       "control_name": "Backups of information are conducted, maintained, and tested",
-      "description": "Key material in Azure Key Vault must be recoverable after accidental or malicious deletion. Soft delete provides a recoverable state for secrets, keys, and certificates, supporting backup and recovery requirements for critical cryptographic material."
-    },
+      "description": "Key material in Azure Key Vault must be recoverable after accidental or malicious deletion. Soft delete provides a recoverable state for secrets, keys, and certificates supporting backup and recovery requirements for critical cryptographic material."
+},
     "AZ-KV-002": {
       "control_id": "AC-17",
       "control_name": "Remote access",

--- a/compliance/frameworks/nist_csf.json
+++ b/compliance/frameworks/nist_csf.json
@@ -98,11 +98,6 @@
       "control_name": "Remote access is managed",
       "description": "Virtual machines with public IPs and no NSG have unrestricted network access. NSGs should be attached to control inbound and outbound traffic and manage remote access to compute resources."
     },
-    "AZ-CMP-002": {
-      "control_id": "PR.DS-1",
-      "control_name": "Data-at-rest is protected",
-      "description": "Virtual machine OS and data disks that are not encrypted with Azure Disk Encryption or customer-managed keys store data in plain text. PR.DS-1 requires that data at rest is protected. Enabling disk encryption ensures that disk contents are unreadable without the encryption key even if the disk is snapshotted or physically accessed."
-    },
     "AZ-KV-001": {
       "control_id": "PR.IP-4",
       "control_name": "Backups of information are conducted, maintained, and tested",

--- a/compliance/frameworks/nist_csf.json
+++ b/compliance/frameworks/nist_csf.json
@@ -13,6 +13,11 @@
       "control_name": "Data-in-transit is protected",
       "description": "Requiring secure transfer ensures data in transit between clients and Azure Storage is encrypted using HTTPS, protecting against interception and tampering."
     },
+    "AZ-STOR-003": {
+      "control_id": "PR.DS-3",
+      "control_name": "Assets are formally managed throughout removal, transfers, and disposition",
+      "description": "NIST CSF PR.DS-3 requires that data assets are managed through their full lifecycle including secure disposal. Storage accounts without a lifecycle management policy have no automated mechanism for expiring or deleting aged data, meaning data subject to disposal requirements persists indefinitely and is never formally retired from the asset inventory."
+    },
     "AZ-NET-001": {
       "control_id": "PR.AC-3",
       "control_name": "Remote access is managed",
@@ -73,6 +78,11 @@
       "control_name": "Users, devices, and other assets are authenticated",
       "description": "MFA ensures privileged users are strongly authenticated before accessing Azure resources. Without MFA, a compromised password is sufficient for full administrative access."
     },
+    "AZ-IDN-003": {
+      "control_id": "PR.AC-1",
+      "control_name": "Identities and credentials are issued, managed, verified, revoked, and audited",
+      "description": "Unrestricted guest user invitations allow any organisation member to introduce external identities into the tenant without centralised review. PR.AC-1 requires that identities and credentials are managed and verified. Restricting guest invitations to administrators ensures external identity provisioning is controlled and audited."
+    },
     "AZ-DB-001": {
       "control_id": "PR.AC-3",
       "control_name": "Remote access is managed",
@@ -88,6 +98,11 @@
       "control_name": "Remote access is managed",
       "description": "Virtual machines with public IPs and no NSG have unrestricted network access. NSGs should be attached to control inbound and outbound traffic and manage remote access to compute resources."
     },
+    "AZ-CMP-002": {
+      "control_id": "PR.DS-1",
+      "control_name": "Data-at-rest is protected",
+      "description": "Virtual machine OS and data disks that are not encrypted with Azure Disk Encryption or customer-managed keys store data in plain text. PR.DS-1 requires that data at rest is protected. Enabling disk encryption ensures that disk contents are unreadable without the encryption key even if the disk is snapshotted or physically accessed."
+    },
     "AZ-KV-001": {
       "control_id": "PR.IP-4",
       "control_name": "Backups of information are conducted, maintained, and tested",
@@ -97,11 +112,6 @@
       "control_id": "AC-17",
       "control_name": "Remote access",
       "description": "Key Vaults that allow public network access expose sensitive secrets, keys, and certificates to remote access attempts from outside trusted networks. Restricting access through private endpoints or trusted networks helps manage remote access paths."
-    },
-    "AZ-STOR-003": {
-      "control_id": "PR.DS-3",
-      "control_name": "Assets are formally managed throughout removal, transfers, and disposition",
-      "description": "NIST CSF PR.DS-3 requires that data assets are managed through their full lifecycle including secure disposal. Storage accounts without a lifecycle management policy have no automated mechanism for expiring or deleting aged data, meaning data subject to disposal requirements persists indefinitely and is never formally retired from the asset inventory."
     }
   }
 }

--- a/compliance/frameworks/soc2.json
+++ b/compliance/frameworks/soc2.json
@@ -98,11 +98,6 @@
       "control_name": "Restricts Access from Outside the Network Boundary",
       "description": "A virtual machine with a public IP and no NSG has unrestricted inbound network access from the internet with no filtering in place. CC6.6 requires that logical access from outside the network perimeter is restricted and controlled. Attaching an NSG with explicit rules enforces the network boundary and controls what traffic can reach the VM."
     },
-    "AZ-CMP-002": {
-      "control_id": "CC6.7",
-      "control_name": "Protects Data in Transit and At Rest",
-      "description": "Virtual machine OS and data disks that are not encrypted store data in plain text. CC6.7 requires that data is protected using encryption. Enabling Azure Disk Encryption or server-side encryption with customer-managed keys ensures disk contents are unreadable without the encryption key even if the disk is snapshotted or physically accessed."
-    },
     "AZ-KV-001": {
       "control_id": "A1.2",
       "control_name": "Environmental Threats and Recovery",

--- a/compliance/frameworks/soc2.json
+++ b/compliance/frameworks/soc2.json
@@ -78,6 +78,11 @@
       "control_name": "Logical Access Security Measures",
       "description": "Without MFA enforced on privileged accounts, a single compromised password grants full administrative access to the Azure environment. CC6.1 requires that logical access controls include strong authentication mechanisms. Enforcing MFA via Conditional Access policies ensures privileged access requires multiple factors of authentication."
     },
+    "AZ-IDN-003": {
+      "control_id": "CC6.1",
+      "control_name": "Logical Access Security Measures",
+      "description": "Unrestricted guest user invitations allow any organisation member to introduce unreviewed external identities into the tenant. CC6.1 requires that logical access to information assets is restricted to authorised users. Restricting guest invitations to administrators ensures external identity provisioning is formally controlled and authorised."
+    },
     "AZ-DB-001": {
       "control_id": "CC6.7",
       "control_name": "Protects Data in Transit",
@@ -92,6 +97,11 @@
       "control_id": "CC6.6",
       "control_name": "Restricts Access from Outside the Network Boundary",
       "description": "A virtual machine with a public IP and no NSG has unrestricted inbound network access from the internet with no filtering in place. CC6.6 requires that logical access from outside the network perimeter is restricted and controlled. Attaching an NSG with explicit rules enforces the network boundary and controls what traffic can reach the VM."
+    },
+    "AZ-CMP-002": {
+      "control_id": "CC6.7",
+      "control_name": "Protects Data in Transit and At Rest",
+      "description": "Virtual machine OS and data disks that are not encrypted store data in plain text. CC6.7 requires that data is protected using encryption. Enabling Azure Disk Encryption or server-side encryption with customer-managed keys ensures disk contents are unreadable without the encryption key even if the disk is snapshotted or physically accessed."
     },
     "AZ-KV-001": {
       "control_id": "A1.2",

--- a/playbooks/cli/fix_az_idn_003.sh
+++ b/playbooks/cli/fix_az_idn_003.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# OpenShield Remediation Playbook
+# Rule: AZ-IDN-003 — Guest user access enabled without restriction in Entra ID
+# Usage: ./fix_az_idn_003.sh
+# Severity: MEDIUM
+#
+# Prerequisites:
+#   - Azure CLI logged in with a Global Administrator or User Administrator role
+#   - Microsoft Graph PowerShell or az rest permissions
+
+set -e
+
+echo "Restricting guest user invitations to admins only..."
+
+az rest \
+  --method PATCH \
+  --uri "https://graph.microsoft.com/v1.0/policies/authorizationPolicy" \
+  --headers "Content-Type=application/json" \
+  --body '{
+    "allowInvitesFrom": "adminsAndGuestInviters"
+  }'
+
+echo "✅ Guest invitation policy updated."
+echo "   allowInvitesFrom is now set to: adminsAndGuestInviters"
+echo "⚠️  Only users assigned to the Guest Inviter role or admins can now invite external users."
+echo "⚠️  Review existing guest accounts to ensure they are still required."

--- a/playbooks/cli/fix_az_idn_003.sh
+++ b/playbooks/cli/fix_az_idn_003.sh
@@ -6,7 +6,7 @@
 #
 # Prerequisites:
 #   - Azure CLI logged in with a Global Administrator or User Administrator role
-#   - Microsoft Graph PowerShell or az rest permissions
+#   - Microsoft Graph or az rest permissions
 
 set -e
 
@@ -20,7 +20,7 @@ az rest \
     "allowInvitesFrom": "adminsAndGuestInviters"
   }'
 
-echo "✅ Guest invitation policy updated."
-echo "   allowInvitesFrom is now set to: adminsAndGuestInviters"
-echo "⚠️  Only users assigned to the Guest Inviter role or admins can now invite external users."
-echo "⚠️  Review existing guest accounts to ensure they are still required."
+echo "Remediation complete."
+echo "allowInvitesFrom is now set to: adminsAndGuestInviters"
+echo "Only users assigned to the Guest Inviter role or admins can now invite external users."
+echo "Review existing guest accounts to ensure they are still required."

--- a/scanner/rules/az_idn_003.py
+++ b/scanner/rules/az_idn_003.py
@@ -1,0 +1,84 @@
+"""AZ-IDN-003: Guest user access enabled without restriction in Entra ID."""
+
+import logging
+from typing import Any, Dict, List
+
+RULE_ID = "AZ-IDN-003"
+RULE_NAME = "Guest user access enabled without restriction in Entra ID"
+SEVERITY = "MEDIUM"
+CATEGORY = "Identity"
+FRAMEWORKS = {"CIS": "1.15", "NIST": "PR.AC-1", "ISO27001": "A.9.2.1"}
+DESCRIPTION = (
+    "Guest user invitations in Entra ID are not restricted, allowing any "
+    "member of the organisation to invite external users into the tenant. "
+    "Unrestricted guest access can expose internal resources, applications "
+    "and data to outside parties without centralised review or approval. "
+    "External guest accounts that are no longer needed may persist "
+    "indefinitely, increasing the attack surface."
+)
+REMEDIATION = (
+    "Restrict guest invitations to admins only by setting the "
+    "'allowInvitesFrom' policy to 'adminsAndGuestInviters' or 'admins' "
+    "in Entra ID. Navigate to: Entra ID > External Identities > "
+    "External collaboration settings > Guest invite settings. "
+    "Set to 'Only users assigned to specific admin roles can invite guest users'."
+)
+PLAYBOOK = "playbooks/cli/fix_az_idn_003.sh"
+
+logger = logging.getLogger(__name__)
+
+
+def scan(azure_client: Any, subscription_id: str) -> List[Dict[str, Any]]:
+    """Detect unrestricted guest user invitation settings in Entra ID."""
+    findings: List[Dict[str, Any]] = []
+
+    try:
+        import requests
+
+        token = azure_client.credential.get_token(
+            "https://graph.microsoft.com/.default"
+        )
+        headers = {"Authorization": f"Bearer {token.token}"}
+
+        response = requests.get(
+            "https://graph.microsoft.com/v1.0/policies/authorizationPolicy",
+            headers=headers,
+            timeout=30,
+        )
+        response.raise_for_status()
+        policy = response.json()
+
+    except Exception as exc:
+        logger.error(
+            "AZ-IDN-003: Failed to fetch authorization policy from Graph API: %s", exc
+        )
+        logger.warning(
+            "AZ-IDN-003: Ensure the service principal has "
+            "Directory.Read.All permission on Microsoft Graph."
+        )
+        return findings
+
+    allow_invites_from = policy.get("allowInvitesFrom", "everyone")
+
+    restricted_values = {"admins", "adminsAndGuestInviters"}
+    if allow_invites_from not in restricted_values:
+        findings.append({
+            "rule_id": RULE_ID,
+            "rule_name": RULE_NAME,
+            "severity": SEVERITY,
+            "category": CATEGORY,
+            "resource_id": f"/tenants/{policy.get('id', 'unknown')}/policies/authorizationPolicy",
+            "resource_name": "authorizationPolicy",
+            "resource_type": "Microsoft.Graph/authorizationPolicy",
+            "description": DESCRIPTION,
+            "remediation": REMEDIATION,
+            "playbook": PLAYBOOK,
+            "frameworks": FRAMEWORKS,
+            "metadata": {
+                "allow_invites_from": allow_invites_from,
+                "policy_id": policy.get("id", ""),
+                "display_name": policy.get("displayName", ""),
+            },
+        })
+
+    return findings


### PR DESCRIPTION
Closes #24

Added scanner rule and remediation playbook for AZ-IDN-003 detecting unrestricted guest user invitation settings in Entra ID.

Files added:
- scanner/rules/az_idn_003.py — detects when guest invitations are not restricted to admins via Microsoft Graph API authorizationPolicy endpoint
- playbooks/cli/fix_az_idn_003.sh — restricts guest invitations to adminsAndGuestInviters via az rest

Compliance mappings added to all four framework files:
- CIS 1.15
- NIST PR.AC-1
- ISO27001 A.9.2.1
- SOC2 CC6.1

Note: requires Directory.Read.All permission on Microsoft Graph for the service principal.