### PR TITLE
feat: add rule AZ-IDN-003 Adds scanner rule AZ-IDN-003 detecting Entra ID 

### DIFF
--- a/compliance/frameworks/cis_azure_benchmark.json
+++ b/compliance/frameworks/cis_azure_benchmark.json
@@ -73,6 +73,11 @@
       "control_name": "Ensure that 'Multi-Factor Authentication Status' is 'Enabled' for all Privileged Users",
       "description": "Multi-Factor Authentication requires an individual to present a minimum of two separate forms of authentication before access is granted. MFA should be enforced for all users with administrative privileges via Conditional Access policies."
     },
+    "AZ-IDN-003": {
+      "control_id": "1.15",
+      "control_name": "Ensure that 'Guest invite restrictions' is set to 'Only users assigned to specific admin roles can invite guest users'",
+      "description": "Unrestricted guest user invitation settings allow any member of the organisation to invite external users into the tenant without administrative review. This bypasses centralised approval for external identity provisioning and increases the risk of unauthorised access by untrusted parties."
+    },
     "AZ-DB-001": {
       "control_id": "4.3.1",
       "control_name": "Ensure 'Allow access to Azure services' for PostgreSQL Database Server is disabled",

--- a/compliance/frameworks/iso27001.json
+++ b/compliance/frameworks/iso27001.json
@@ -73,6 +73,11 @@
       "control_name": "Secure log-on procedures",
       "description": "MFA enforces secure log-on for privileged accounts. Where required by the access control policy, access to systems and applications should be controlled by a secure log-on procedure including multi-factor authentication."
     },
+    "AZ-IDN-003": {
+      "control_id": "A.9.2.1",
+      "control_name": "User registration and de-registration",
+      "description": "Unrestricted guest user invitations allow any organisation member to register external identities into the tenant without centralised review or approval. A.9.2.1 requires that a formal user registration and de-registration process is implemented. Restricting guest invitations to administrators ensures external identity registration is formally controlled and audited."
+    },
     "AZ-DB-001": {
       "control_id": "A.13.1.1",
       "control_name": "Network controls",

--- a/compliance/frameworks/nist_csf.json
+++ b/compliance/frameworks/nist_csf.json
@@ -73,6 +73,11 @@
       "control_name": "Users, devices, and other assets are authenticated",
       "description": "MFA ensures privileged users are strongly authenticated before accessing Azure resources. Without MFA, a compromised password is sufficient for full administrative access."
     },
+    "AZ-IDN-003": {
+      "control_id": "PR.AC-1",
+      "control_name": "Identities and credentials are issued, managed, verified, revoked, and audited",
+      "description": "Unrestricted guest user invitations allow any organisation member to introduce external identities into the tenant without centralised review. PR.AC-1 requires that identities and credentials are managed and verified. Restricting guest invitations to administrators ensures external identity provisioning is controlled and audited."
+    },
     "AZ-DB-001": {
       "control_id": "PR.AC-3",
       "control_name": "Remote access is managed",

--- a/compliance/frameworks/soc2.json
+++ b/compliance/frameworks/soc2.json
@@ -78,6 +78,11 @@
       "control_name": "Logical Access Security Measures",
       "description": "Without MFA enforced on privileged accounts, a single compromised password grants full administrative access to the Azure environment. CC6.1 requires that logical access controls include strong authentication mechanisms. Enforcing MFA via Conditional Access policies ensures privileged access requires multiple factors of authentication."
     },
+    "AZ-IDN-003": {
+      "control_id": "CC6.1",
+      "control_name": "Logical Access Security Measures",
+      "description": "Unrestricted guest user invitations allow any organisation member to introduce unreviewed external identities into the tenant. CC6.1 requires that logical access to information assets is restricted to authorised users. Restricting guest invitations to administrators ensures external identity provisioning is formally controlled and authorised."
+    },
     "AZ-DB-001": {
       "control_id": "CC6.7",
       "control_name": "Protects Data in Transit",

--- a/playbooks/cli/fix_az_idn_003.sh
+++ b/playbooks/cli/fix_az_idn_003.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# OpenShield Remediation Playbook
+# Rule: AZ-IDN-003 — Guest user invitations not restricted to admins in Entra ID
+# Usage: ./fix_az_idn_003.sh
+# Severity: MEDIUM
+#
+# Prerequisites:
+#   - Azure CLI logged in with a Global Administrator or User Administrator role
+#   - Microsoft Graph or az rest permissions
+
+set -e
+
+echo "Restricting guest user invitations to admins only..."
+
+az rest \
+  --method PATCH \
+  --uri "https://graph.microsoft.com/v1.0/policies/authorizationPolicy" \
+  --headers "Content-Type=application/json" \
+  --body '{
+    "allowInvitesFrom": "adminsAndGuestInviters"
+  }'
+
+echo "Remediation complete."
+echo "allowInvitesFrom is now set to: adminsAndGuestInviters"
+echo "Only users assigned to the Guest Inviter role or admins can now invite external users."
+echo "Review existing guest accounts to ensure they are still required."

--- a/scanner/rules/az_idn_003.py
+++ b/scanner/rules/az_idn_003.py
@@ -1,0 +1,83 @@
+"""AZ-IDN-003: Guest user invitations not restricted to admins in Entra ID."""
+
+import logging
+from typing import Any, Dict, List
+
+RULE_ID = "AZ-IDN-003"
+RULE_NAME = "Guest user invitations not restricted to admins in Entra ID"
+SEVERITY = "MEDIUM"
+CATEGORY = "Identity"
+FRAMEWORKS = {"CIS": "1.15", "NIST": "PR.AC-1", "ISO27001": "A.9.2.1"}
+DESCRIPTION = (
+    "Guest user invitations in Entra ID are not restricted to administrators. "
+    "Any organisation member can invite external users into the tenant without "
+    "centralised review or approval. This bypasses formal external identity "
+    "provisioning controls and increases the risk of unauthorised access by "
+    "untrusted parties."
+)
+REMEDIATION = (
+    "Restrict guest invitations to admins only by setting the "
+    "'allowInvitesFrom' policy to 'adminsAndGuestInviters' or 'admins' "
+    "in Entra ID. Navigate to: Entra ID > External Identities > "
+    "External collaboration settings > Guest invite settings. "
+    "Set to 'Only users assigned to specific admin roles can invite guest users'."
+)
+PLAYBOOK = "playbooks/cli/fix_az_idn_003.sh"
+
+logger = logging.getLogger(__name__)
+
+
+def scan(azure_client: Any, subscription_id: str) -> List[Dict[str, Any]]:
+    """Detect unrestricted guest user invitation settings in Entra ID."""
+    findings: List[Dict[str, Any]] = []
+
+    try:
+        import requests
+
+        token = azure_client.credential.get_token(
+            "https://graph.microsoft.com/.default"
+        )
+        headers = {"Authorization": f"Bearer {token.token}"}
+
+        response = requests.get(
+            "https://graph.microsoft.com/v1.0/policies/authorizationPolicy",
+            headers=headers,
+            timeout=30,
+        )
+        response.raise_for_status()
+        policy = response.json()
+
+    except Exception as exc:
+        logger.error(
+            "AZ-IDN-003: Failed to fetch authorization policy from Graph API: %s", exc
+        )
+        logger.warning(
+            "AZ-IDN-003: Ensure the service principal has "
+            "Directory.Read.All permission on Microsoft Graph."
+        )
+        return findings
+
+    allow_invites_from = policy.get("allowInvitesFrom", "everyone")
+
+    restricted_values = {"admins", "adminsAndGuestInviters"}
+    if allow_invites_from not in restricted_values:
+        findings.append({
+            "rule_id": RULE_ID,
+            "rule_name": RULE_NAME,
+            "severity": SEVERITY,
+            "category": CATEGORY,
+            "resource_id": f"/tenants/{policy.get('id', 'unknown')}/policies/authorizationPolicy",
+            "resource_name": "authorizationPolicy",
+            "resource_type": "Microsoft.Graph/authorizationPolicy",
+            "description": DESCRIPTION,
+            "remediation": REMEDIATION,
+            "playbook": PLAYBOOK,
+            "frameworks": FRAMEWORKS,
+            "metadata": {
+                "allow_invites_from": allow_invites_from,
+                "policy_id": policy.get("id", ""),
+                "display_name": policy.get("displayName", ""),
+            },
+        })
+
+    return findings


### PR DESCRIPTION
Closes #20

Adds scanner rule AZ-IDN-003 detects Entra ID tenants where guest user invitations are not restricted to administrators. Any organization member can invite external users without centralized review, bypassing formal external identity provisioning controls.

Files added:
1: scanner/rules/az_idn_003.py calls Microsoft Graph /v1.0/policies/authorizationPolicy and flags if Allow Invites From is not set to admins or invitees.
2: playbooks/cli/fix_az_idn_003.sh patches authorizationPolicy via az rest to set allow Invites From the inviters

Compliance mappings added:
1: CIS 1.15
2: NIST PR.AC-1
3: ISO27001 A.9.2.1
4:  SOC2 CC6.1