### PR TITLE
feat: add AZ-DB-003 PostgreSQL Flexible Server SSL enforcement rule a…

### DIFF
--- a/compliance/frameworks/cis_azure_benchmark.json
+++ b/compliance/frameworks/cis_azure_benchmark.json
@@ -122,6 +122,11 @@
       "control_id": "6.5",
       "control_name": "Ensure that Network Watcher is enabled in all regions",
       "description": "Network Watcher should be enabled in all regions where Azure resources are deployed. Network Watcher provides network monitoring, diagnostics, and logging capabilities essential for investigating network-level incidents."
+    },
+    "AZ-DB-003": {
+      "control_id": "4.3.6",
+      "control_name": "Ensure SSL connection is enabled for PostgreSQL Flexible Server",
+      "description": "SSL enforcement should be enabled on PostgreSQL Flexible Server to ensure data in transit is encrypted. Without SSL, database connections transmit data in plaintext, exposing it to interception."
     }
   }
 }

--- a/compliance/frameworks/iso27001.json
+++ b/compliance/frameworks/iso27001.json
@@ -122,6 +122,11 @@
       "control_id": "A.12.4.1",
       "control_name": "Event logging",
       "description": "Network Watcher must be enabled in all regions where resources are deployed to ensure network events are logged and available for investigation. Event logs recording network activity should be produced and retained to support incident response."
+    },
+    "AZ-DB-003": {
+      "control_id": "A.10.1.1",
+      "control_name": "Policy on the use of cryptographic controls",
+      "description": "SSL enforcement on PostgreSQL Flexible Server applies cryptographic controls to data in transit. A policy on the use of cryptographic controls for protection of information should be developed and implemented."
     }
   }
 }

--- a/compliance/frameworks/nist_csf.json
+++ b/compliance/frameworks/nist_csf.json
@@ -122,6 +122,11 @@
       "control_id": "DE.CM-7",
       "control_name": "Monitoring for unauthorized personnel, connections, devices, and software is performed",
       "description": "Network Watcher must be enabled in all active regions to support continuous monitoring of network activity. Without it, unauthorized connections and anomalous network behaviour cannot be detected or investigated."
+    },
+    "AZ-DB-003": {
+      "control_id": "PR.DS-2",
+      "control_name": "Data-in-transit is protected",
+      "description": "SSL enforcement on PostgreSQL Flexible Server ensures data in transit between applications and the database is encrypted. Disabling SSL exposes database traffic to interception and tampering."
     }
   }
 }

--- a/compliance/frameworks/soc2.json
+++ b/compliance/frameworks/soc2.json
@@ -117,6 +117,11 @@
       "control_id": "CC7.2",
       "control_name": "System monitoring",
       "description": "Network Watcher must be enabled in all regions where resources are deployed to support continuous system monitoring. Without it, network-level events cannot be detected or investigated, violating the requirement for ongoing monitoring of system components."
+    },
+    "AZ-DB-003": {
+      "control_id": "CC6.1",
+      "control_name": "Logical and physical access controls",
+      "description": "SSL enforcement ensures database connections are encrypted, protecting data in transit from unauthorized access. Disabling SSL undermines logical access controls by exposing database traffic in plaintext."
     }
   }
 }

--- a/playbooks/cli/fix_az_db_003.sh
+++ b/playbooks/cli/fix_az_db_003.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+# Playbook: fix_az_db_003.sh
+# Rule: AZ-DB-003 — PostgreSQL Flexible Server SSL enforcement disabled
+
+set -euo pipefail
+
+if [[ $# -lt 1 ]]; then
+  echo "Usage: $0 <subscription_id>"
+  exit 1
+fi
+
+SUBSCRIPTION_ID="$1"
+
+echo "Setting subscription..."
+az account set --subscription "$SUBSCRIPTION_ID"
+
+echo "Fetching PostgreSQL Flexible Servers..."
+SERVERS=$(az postgres flexible-server list   --subscription "$SUBSCRIPTION_ID"   --query "[].{name:name, rg:resourceGroup}"   --output tsv)
+
+if [[ -z "$SERVERS" ]]; then
+  echo "No PostgreSQL Flexible Servers found."
+  exit 0
+fi
+
+while IFS=$'\t' read -r SERVER_NAME RESOURCE_GROUP; do
+  echo "Checking $SERVER_NAME in $RESOURCE_GROUP..."
+  SSL_VALUE=$(az postgres flexible-server parameter show     --resource-group "$RESOURCE_GROUP"     --server-name "$SERVER_NAME"     --name require_secure_transport     --query "value" --output tsv 2>/dev/null || echo "on")
+
+  if [[ "${SSL_VALUE,,}" == "off" ]]; then
+    echo "  [FIX] Enabling SSL on $SERVER_NAME..."
+    az postgres flexible-server parameter set       --resource-group "$RESOURCE_GROUP"       --server-name "$SERVER_NAME"       --name require_secure_transport       --value ON       --output none
+    echo "        Done."
+  else
+    echo "  [SKIP] $SERVER_NAME — SSL already enabled"
+  fi
+done <<< "$SERVERS"
+
+echo "Done! Verify with:"
+echo "  az postgres flexible-server parameter show --name require_secure_transport --server-name <name> --resource-group <rg>"

--- a/playbooks/cli/fix_az_db_003.sh
+++ b/playbooks/cli/fix_az_db_003.sh
@@ -27,13 +27,13 @@ while IFS=$'\t' read -r SERVER_NAME RESOURCE_GROUP; do
   SSL_VALUE=$(az postgres flexible-server parameter show     --resource-group "$RESOURCE_GROUP"     --server-name "$SERVER_NAME"     --name require_secure_transport     --query "value" --output tsv 2>/dev/null || echo "on")
 
   if [[ "${SSL_VALUE,,}" == "off" ]]; then
-    echo "  [FIX] Enabling SSL on $SERVER_NAME..."
+    echo "Enabling SSL on $SERVER_NAME..."
     az postgres flexible-server parameter set       --resource-group "$RESOURCE_GROUP"       --server-name "$SERVER_NAME"       --name require_secure_transport       --value ON       --output none
-    echo "        Done."
+    echo "Done."
   else
-    echo "  [SKIP] $SERVER_NAME — SSL already enabled"
+    echo "$SERVER_NAME already has SSL enabled, skipping."
   fi
 done <<< "$SERVERS"
 
-echo "Done! Verify with:"
+echo "Done. Verify with:"
 echo "  az postgres flexible-server parameter show --name require_secure_transport --server-name <name> --resource-group <rg>"

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,4 +18,4 @@ requests==2.31.0
 pyyaml==6.0.1
 gunicorn==21.2.0
 cryptography==42.0.5
-msrest==0.7.1
+msrest==0.7.1azure-mgmt-postgresqlflexibleserver==1.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,4 +18,5 @@ requests==2.31.0
 pyyaml==6.0.1
 gunicorn==21.2.0
 cryptography==42.0.5
-msrest==0.7.1azure-mgmt-postgresqlflexibleserver==1.0.0
+msrest==0.7.1
+azure-mgmt-postgresqlflexibleserver==1.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,4 +19,4 @@ pyyaml==6.0.1
 gunicorn==21.2.0
 cryptography==42.0.5
 msrest==0.7.1
-azure-mgmt-postgresqlflexibleserver==1.0.0
+azure-mgmt-postgresqlflexibleservers==1.0.0b1

--- a/scanner/azure_client.py
+++ b/scanner/azure_client.py
@@ -330,6 +330,28 @@ class AzureClient:
             logger.error("get_service_principals failed: %s", exc)
             return []
 
+
+    def get_postgresql_flexible_servers(self) -> List[Any]:
+        """List all PostgreSQL Flexible Server instances in the subscription."""
+        try:
+            from azure.mgmt.postgresqlflexibleservers import PostgreSQLManagementClient as FlexClient
+            client = FlexClient(self.credential, self.subscription_id)
+            return list(client.servers.list())
+        except Exception as exc:
+            logger.error("get_postgresql_flexible_servers failed: %s", exc)
+            return []
+
+
+    def get_postgresql_flexible_server_parameters(self, resource_group: str, server_name: str) -> List[Any]:
+        """List all configuration parameters for a PostgreSQL Flexible Server."""
+        try:
+            from azure.mgmt.postgresqlflexibleservers import PostgreSQLManagementClient as FlexClient
+            client = FlexClient(self.credential, self.subscription_id)
+            return list(client.configurations.list_by_server(resource_group, server_name))
+        except Exception as exc:
+            logger.error("get_postgresql_flexible_server_parameters(%s) failed: %s", server_name, exc)
+            return []
+
     def get_conditional_access_policies(self) -> List[Any]:
         """Fetch Conditional Access policies from the Microsoft Graph API.
 

--- a/scanner/rules/az_db_003.py
+++ b/scanner/rules/az_db_003.py
@@ -1,5 +1,8 @@
 """AZ-DB-003: PostgreSQL Flexible Server SSL enforcement disabled."""
 from typing import Any, Dict, List
+import logging
+
+logger = logging.getLogger(__name__)
 
 RULE_ID = "AZ-DB-003"
 RULE_NAME = "PostgreSQL Flexible Server SSL Enforcement Disabled"
@@ -27,18 +30,35 @@ def scan(azure_client: Any, subscription_id: str) -> List[Dict[str, Any]]:
     for server in azure_client.get_postgresql_flexible_servers():
         parsed = azure_client.parse_resource_id(server.id)
         resource_group = parsed.get("resource_group", "")
-        require_ssl = True
 
         params = azure_client.get_postgresql_flexible_server_parameters(
             resource_group, server.name
         )
-        for param in params:
-            if getattr(param, "name", "") == "require_secure_transport":
-                if str(getattr(param, "value", "on")).lower() in ("off", "false", "0"):
-                    require_ssl = False
-                break
 
-        if not require_ssl:
+        if not params:
+            # Cannot determine SSL state — skip to avoid false positives
+            logger.warning(
+                "az_db_003: skipping %s — get_postgresql_flexible_server_parameters "
+                "returned empty (permission or API failure)",
+                server.name,
+            )
+            continue
+
+        ssl_param = next(
+            (p for p in params if getattr(p, "name", "") == "require_secure_transport"),
+            None,
+        )
+
+        if ssl_param is None:
+            # Parameter not found — cannot determine compliance, skip
+            logger.warning(
+                "az_db_003: skipping %s — require_secure_transport parameter not found",
+                server.name,
+            )
+            continue
+
+        ssl_value = str(getattr(ssl_param, "value", "on")).lower()
+        if ssl_value in ("off", "false", "0"):
             findings.append({
                 "rule_id": RULE_ID,
                 "rule_name": RULE_NAME,
@@ -54,6 +74,7 @@ def scan(azure_client: Any, subscription_id: str) -> List[Dict[str, Any]]:
                 "metadata": {
                     "resource_group": resource_group,
                     "location": getattr(server, "location", ""),
+                    "ssl_value": ssl_value,
                 },
             })
 

--- a/scanner/rules/az_db_003.py
+++ b/scanner/rules/az_db_003.py
@@ -1,0 +1,60 @@
+"""AZ-DB-003: PostgreSQL Flexible Server SSL enforcement disabled."""
+from typing import Any, Dict, List
+
+RULE_ID = "AZ-DB-003"
+RULE_NAME = "PostgreSQL Flexible Server SSL Enforcement Disabled"
+SEVERITY = "HIGH"
+CATEGORY = "Database"
+FRAMEWORKS = {"CIS": "4.3.6", "NIST": "PR.DS-2", "ISO27001": "A.10.1.1", "SOC2": "CC6.1"}
+DESCRIPTION = (
+    "The Azure Database for PostgreSQL Flexible Server has SSL enforcement disabled. "
+    "Without SSL, data in transit between the application and database is transmitted "
+    "in plaintext and is vulnerable to interception and man-in-the-middle attacks."
+)
+REMEDIATION = (
+    "Enable SSL enforcement on the PostgreSQL Flexible Server by setting "
+    "require_secure_transport to ON. "
+    "Run: az postgres flexible-server parameter set --resource-group <rg> "
+    "--server-name <server> --name require_secure_transport --value ON"
+)
+PLAYBOOK = "playbooks/cli/fix_az_db_003.sh"
+
+
+def scan(azure_client: Any, subscription_id: str) -> List[Dict[str, Any]]:
+    """Detect PostgreSQL Flexible Servers with SSL enforcement disabled."""
+    findings: List[Dict[str, Any]] = []
+
+    for server in azure_client.get_postgresql_flexible_servers():
+        parsed = azure_client.parse_resource_id(server.id)
+        resource_group = parsed.get("resource_group", "")
+        require_ssl = True
+
+        params = azure_client.get_postgresql_flexible_server_parameters(
+            resource_group, server.name
+        )
+        for param in params:
+            if getattr(param, "name", "") == "require_secure_transport":
+                if str(getattr(param, "value", "on")).lower() in ("off", "false", "0"):
+                    require_ssl = False
+                break
+
+        if not require_ssl:
+            findings.append({
+                "rule_id": RULE_ID,
+                "rule_name": RULE_NAME,
+                "severity": SEVERITY,
+                "category": CATEGORY,
+                "resource_id": server.id,
+                "resource_name": server.name,
+                "resource_type": "Microsoft.DBforPostgreSQL/flexibleServers",
+                "description": DESCRIPTION,
+                "remediation": REMEDIATION,
+                "playbook": PLAYBOOK,
+                "frameworks": FRAMEWORKS,
+                "metadata": {
+                    "resource_group": resource_group,
+                    "location": getattr(server, "location", ""),
+                },
+            })
+
+    return findings


### PR DESCRIPTION
## What does this PR do?
Adds AZ-DB-003 scanner rule to detect PostgreSQL Flexible Server instances where SSL enforcement is disabled, along with a remediation playbook and compliance mappings.

## Type of change
- [x] New scan rule
- [x] Remediation playbook
- [ ] Bug fix
- [ ] Dashboard/front-end work
- [ ] API endpoint
- [ ] Documentation
- [x] Compliance mapping

## Rule details (if applicable)
- Rule ID: AZ-DB-003
- Severity: HIGH
- Category: Database
- Frameworks mapped: CIS / NIST / ISO 27001 / SOC2

## Testing
- [ ] Tested against a real Azure free trial subscription
- [x] Returns correct JSON output
- [ ] All seven CI checks pass
- [x] No hardcoded credentials or secrets

## Related issue
Closes #25