### PR TITLE
[DOCS] Add OpenShield learning and onboarding portal

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ openshield/
 
 ---
 
+
 ## Quick Start
 
 ```bash
@@ -169,3 +170,18 @@ MIT — free to use, modify, and distribute.
 ---
 
 > Built with ❤️ by security engineers and students who believe cloud security tooling should be accessible to everyone.
+
+---
+
+## 📚 Learn OpenShield
+
+Explore the OpenShield learning portal to understand:
+
+- Azure CSPM fundamentals
+- OpenShield architecture
+- Compliance mappings
+- Remediation workflows
+- Contributor onboarding
+- Documentation navigation
+
+👉 [OpenShield Learn](docs/learn/index.html)

--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ MIT — free to use, modify, and distribute.
 
 ---
 
-## 📚 Learn OpenShield
+## Learn OpenShield
 
 Explore the OpenShield learning portal to understand:
 

--- a/docs/learn/index.html
+++ b/docs/learn/index.html
@@ -1,0 +1,479 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>OpenShield Learn</title>
+  <style>
+    :root {
+      --bg: #020617;
+      --panel: #0f172a;
+      --panel-2: #111827;
+      --text: #f8fafc;
+      --muted: #94a3b8;
+      --accent: #38bdf8;
+      --success: #22c55e;
+      --warning: #f97316;
+      --border: #334155;
+    }
+
+    * {
+      box-sizing: border-box;
+      margin: 0;
+      padding: 0;
+      font-family: Arial, Helvetica, sans-serif;
+    }
+
+    body {
+      background: radial-gradient(circle at top left, #0f172a, #020617 55%);
+      color: var(--text);
+      line-height: 1.6;
+      min-height: 100vh;
+    }
+
+    a {
+      color: inherit;
+    }
+
+    header {
+      padding: 56px 8% 40px;
+      border-bottom: 1px solid var(--border);
+    }
+
+    .badge {
+      display: inline-block;
+      padding: 6px 12px;
+      border: 1px solid var(--accent);
+      color: var(--accent);
+      border-radius: 999px;
+      font-size: 13px;
+      margin-bottom: 18px;
+      letter-spacing: 0.3px;
+    }
+
+    h1 {
+      font-size: clamp(38px, 6vw, 70px);
+      line-height: 1.05;
+      margin-bottom: 18px;
+    }
+
+    .subtitle {
+      color: var(--muted);
+      max-width: 900px;
+      font-size: 19px;
+      margin-bottom: 26px;
+    }
+
+    .hero-actions {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 12px;
+    }
+
+    .button {
+      display: inline-block;
+      text-decoration: none;
+      color: #020617;
+      background: var(--accent);
+      padding: 10px 15px;
+      border-radius: 10px;
+      font-weight: bold;
+      font-size: 14px;
+      transition: transform 0.15s ease, opacity 0.15s ease;
+    }
+
+    .button:hover {
+      transform: translateY(-1px);
+      opacity: 0.92;
+    }
+
+    .button.secondary {
+      background: var(--success);
+    }
+
+    .button.dark {
+      background: transparent;
+      color: var(--text);
+      border: 1px solid var(--border);
+    }
+
+    main {
+      padding: 38px 8% 70px;
+    }
+
+    section {
+      margin-top: 44px;
+    }
+
+    .section-title {
+      font-size: 28px;
+      margin-bottom: 12px;
+      border-left: 4px solid var(--accent);
+      padding-left: 12px;
+    }
+
+    .section-intro {
+      color: var(--muted);
+      max-width: 900px;
+      margin-bottom: 20px;
+    }
+
+    .grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+      gap: 18px;
+    }
+
+    .card {
+      background: rgba(15, 23, 42, 0.9);
+      border: 1px solid var(--border);
+      border-radius: 18px;
+      padding: 22px;
+      box-shadow: 0 12px 30px rgba(0, 0, 0, 0.24);
+    }
+
+    .card h3 {
+      font-size: 20px;
+      margin-bottom: 9px;
+    }
+
+    .card p,
+    .card li {
+      color: var(--muted);
+      font-size: 15px;
+    }
+
+    .card ul,
+    .card ol {
+      padding-left: 19px;
+      margin-top: 8px;
+    }
+
+    .tag {
+      display: inline-block;
+      background: var(--panel-2);
+      border: 1px solid var(--border);
+      color: #cbd5e1;
+      padding: 4px 9px;
+      border-radius: 999px;
+      font-size: 12px;
+      margin: 10px 4px 0 0;
+    }
+
+    .flow {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+      gap: 12px;
+      margin-top: 18px;
+    }
+
+    .flow-step {
+      background: rgba(17, 24, 39, 0.9);
+      border: 1px solid var(--border);
+      border-radius: 14px;
+      padding: 16px;
+      text-align: center;
+      color: #dbeafe;
+      font-weight: bold;
+    }
+
+    .resource-list {
+      display: grid;
+      gap: 14px;
+    }
+
+    .resource-item {
+      background: rgba(17, 24, 39, 0.9);
+      border: 1px solid var(--border);
+      border-radius: 14px;
+      padding: 18px;
+      display: flex;
+      justify-content: space-between;
+      gap: 18px;
+      align-items: center;
+      flex-wrap: wrap;
+    }
+
+    .resource-item strong {
+      display: block;
+      margin-bottom: 4px;
+    }
+
+    .resource-item span {
+      color: var(--muted);
+      font-size: 14px;
+    }
+
+    .notice {
+      background: rgba(249, 115, 22, 0.1);
+      border: 1px solid rgba(249, 115, 22, 0.5);
+      color: #fed7aa;
+      padding: 18px;
+      border-radius: 14px;
+      margin-top: 34px;
+    }
+
+    footer {
+      padding: 28px 8%;
+      border-top: 1px solid var(--border);
+      color: var(--muted);
+      font-size: 14px;
+    }
+
+    @media (max-width: 640px) {
+      header,
+      main,
+      footer {
+        padding-left: 6%;
+        padding-right: 6%;
+      }
+
+      .resource-item {
+        align-items: flex-start;
+      }
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <div class="badge">Open Source Azure CSPM Platform</div>
+    <h1>OpenShield Learn</h1>
+    <p class="subtitle">
+      A practical learning hub for understanding OpenShield, Azure cloud security posture management,
+      misconfiguration detection, compliance mapping, drift detection, and remediation workflows.
+    </p>
+    <div class="hero-actions">
+      <a class="button" href="#architecture">Architecture</a>
+      <a class="button secondary" href="#cspm">Learn CSPM</a>
+      <a class="button dark" href="#contributing">Contributing</a>
+      <a class="button dark" href="#resources">Docs</a>
+    </div>
+  </header>
+
+  <main>
+    <section id="overview">
+      <h2 class="section-title">What is OpenShield?</h2>
+      <p class="section-intro">
+        OpenShield is an open-source Azure CSPM platform designed to identify cloud misconfigurations,
+        map findings to compliance frameworks, monitor posture drift, and provide remediation guidance. It helps users understand
+        what is insecure, why it matters, and how to fix it.
+      </p>
+      <div class="grid">
+        <div class="card">
+          <h3>Misconfiguration Scanning</h3>
+          <p>Checks Azure resources for risky settings that can expose data, weaken access control, or reduce security visibility.</p>
+        </div>
+        <div class="card">
+          <h3>Compliance Mapping</h3>
+          <p>Connects security findings to frameworks such as CIS, NIST, and ISO so issues can be understood in a governance context.</p>
+        </div>
+        <div class="card">
+          <h3>Remediation Guidance</h3>
+          <p>Provides practical fix guidance using Azure CLI, ARM templates, Terraform, and validation checks where applicable.</p>
+        </div>
+        <div class="card">
+          <h3>Drift Detection</h3>
+          <p>Tracks changes in cloud security posture so teams can identify when previously safe configurations become risky.</p>
+        </div>
+      </div>
+    </section>
+
+    <section id="workflow">
+      <h2 class="section-title">How OpenShield Works</h2>
+      <p class="section-intro">
+        OpenShield follows a simple scanning pipeline: collect Azure resource configuration, evaluate rules,
+        generate findings, map them to controls, and expose results through the platform.
+      </p>
+      <div class="flow">
+        <div class="flow-step">Azure Subscription</div>
+        <div class="flow-step">Scanner Engine</div>
+        <div class="flow-step">Rule Evaluation</div>
+        <div class="flow-step">Findings</div>
+        <div class="flow-step">Compliance Mapping</div>
+        <div class="flow-step">Drift Detection</div>
+        <div class="flow-step">Dashboard & Reporting</div>
+      </div>
+    </section>
+
+    <section id="architecture">
+      <h2 class="section-title">Core Components</h2>
+      <p class="section-intro">
+        OpenShield is built with a simple MVP-friendly architecture: Python scanner, Flask API,
+        PostgreSQL storage, React frontend, compliance mapping, Sentinel integration, and supporting remediation playbooks.
+      </p>
+      <div class="grid">
+        <div class="card">
+          <h3>Scanner Engine</h3>
+          <p>Python-based scanner that uses Azure SDK clients to inspect Azure resource configuration and evaluate security rules.</p>
+          <span class="tag">Python</span><span class="tag">Azure SDK</span>
+        </div>
+        <div class="card">
+          <h3>Flask API</h3>
+          <p>Backend API layer responsible for exposing scan results, findings, metadata, and platform data to the frontend.</p>
+          <span class="tag">Flask</span><span class="tag">REST API</span>
+        </div>
+        <div class="card">
+          <h3>PostgreSQL</h3>
+          <p>Stores scan findings, rule metadata, compliance mappings, and remediation-related information.</p>
+          <span class="tag">Database</span><span class="tag">Persistence</span>
+        </div>
+        <div class="card">
+          <h3>React Dashboard</h3>
+          <p>Frontend dashboard for viewing findings, severity, affected resources, and security posture information.</p>
+          <span class="tag">React</span><span class="tag">Dashboard</span>
+        </div>
+        <div class="card">
+          <h3>Playbooks</h3>
+          <p>Remediation documents that explain how to fix detected issues using CLI, ARM templates, Terraform, and validation steps.</p>
+          <span class="tag">Azure CLI</span><span class="tag">ARM</span><span class="tag">Terraform</span>
+        </div>
+        <div class="card">
+          <h3>Sentinel</h3>
+          <p>Supports security monitoring and SIEM-focused documentation where OpenShield findings connect with detection workflows.</p>
+          <span class="tag">SIEM</span><span class="tag">Detection</span>
+        </div>
+      </div>
+    </section>
+
+    <section id="cspm">
+      <h2 class="section-title">CSPM Basics</h2>
+      <p class="section-intro">
+        Cloud Security Posture Management focuses on continuously identifying insecure cloud configurations.
+        In Azure, common examples include public storage exposure, weak network rules, missing logging,
+        overly permissive identities, and disabled security protections.
+      </p>
+      <div class="grid">
+        <div class="card">
+          <h3>Why It Matters</h3>
+          <p>Cloud breaches often happen because resources are misconfigured, not because the cloud provider itself failed.</p>
+        </div>
+        <div class="card">
+          <h3>Example Issues</h3>
+          <ul>
+            <li>Public blob access</li>
+            <li>Weak network security groups</li>
+            <li>Missing monitoring or logging</li>
+            <li>Over-permissive access policies</li>
+          </ul>
+        </div>
+        <div class="card">
+          <h3>OpenShield Role</h3>
+          <p>OpenShield helps surface these issues, explain their impact, and guide users toward safer Azure configurations.</p>
+        </div>
+      </div>
+    </section>
+
+    <section id="compliance">
+      <h2 class="section-title">Compliance Mapping</h2>
+      <p class="section-intro">
+        A single security finding can map to multiple compliance controls. OpenShield uses mappings to connect
+        technical misconfigurations with security frameworks such as CIS Benchmarks, NIST CSF, ISO 27001, and SOC 2.
+      </p>
+      <div class="grid">
+        <div class="card"><h3>CIS</h3><p>Maps findings to cloud security benchmarks and configuration recommendations.</p></div>
+        <div class="card"><h3>NIST</h3><p>Connects findings to broader cybersecurity controls and risk management practices.</p></div>
+        <div class="card"><h3>ISO 27001</h3><p>Supports governance, information security controls, and audit-oriented reporting context.</p></div>
+        <div class="card"><h3>SOC 2</h3><p>Connects relevant findings to trust-service control areas such as security, availability, and confidentiality.</p></div>
+      </div>
+    </section>
+
+    <section id="remediation">
+      <h2 class="section-title">Remediation Philosophy</h2>
+      <p class="section-intro">
+        Detection alone is not enough. A useful CSPM tool should explain the risk, provide fix guidance,
+        and help validate whether the issue has actually been resolved.
+      </p>
+      <div class="grid">
+        <div class="card"><h3>Detect</h3><p>Identify insecure Azure configuration accurately with minimal false positives.</p></div>
+        <div class="card"><h3>Explain</h3><p>Show why the finding matters, what resource is affected, and what the risk is.</p></div>
+        <div class="card"><h3>Fix</h3><p>Provide Azure CLI, ARM template, or Terraform-based remediation steps that users can apply safely.</p></div>
+        <div class="card"><h3>Validate</h3><p>Re-run checks or confirm settings to verify the misconfiguration is resolved.</p></div>
+      </div>
+    </section>
+
+    <section id="contributing">
+      <h2 class="section-title">Contributor Learning Path</h2>
+      <p class="section-intro">
+        New contributors should understand the security problem first, then the OpenShield architecture,
+        then the rule and remediation workflow.
+      </p>
+      <div class="grid">
+        <div class="card">
+          <h3>Suggested Path</h3>
+          <ol>
+            <li>Understand CSPM fundamentals</li>
+            <li>Review the OpenShield architecture</li>
+            <li>Explore existing documentation and rules</li>
+            <li>Understand findings, mappings, and remediation playbooks</li>
+            <li>Add or improve rules and playbooks</li>
+            <li>Test changes against Azure safely</li>
+          </ol>
+        </div>
+        <div class="card">
+          <h3>Contribution Focus</h3>
+          <p>Good contributions improve detection accuracy, remediation quality, documentation clarity, or platform reliability.</p>
+        </div>
+      </div>
+    </section>
+
+    <section id="resources">
+      <h2 class="section-title">Documentation Links</h2>
+      <p class="section-intro">
+        Use these links as the starting point for understanding and contributing to OpenShield.
+      </p>
+      <div class="resource-list">
+        <div class="resource-item">
+          <div><strong>Architecture</strong><span>System design, platform components, and scanning workflow.</span></div>
+          <a class="button" href="../architecture.md">Open</a>
+        </div>
+        <div class="resource-item">
+          <div><strong>API Reference</strong><span>Backend API documentation for working with OpenShield data.</span></div>
+          <a class="button" href="../api-reference.md">Open</a>
+        </div>
+        <div class="resource-item">
+          <div><strong>Azure Setup</strong><span>Required Azure setup and configuration before running scans.</span></div>
+          <a class="button" href="../azure-setup.md">Open</a>
+        </div>
+        <div class="resource-item">
+          <div><strong>Rules Reference</strong><span>Rule documentation and expected structure for security checks.</span></div>
+          <a class="button" href="../rules-reference.md">Open</a>
+        </div>
+        <div class="resource-item">
+          <div><strong>Adding a Rule</strong><span>Contributor guide for creating and testing new scan rules.</span></div>
+          <a class="button secondary" href="../adding-a-rule.md">Open</a>
+        </div>
+      </div>
+    </section>
+
+    <section id="goals">
+      <h2 class="section-title">Open Source Goals</h2>
+      <p class="section-intro">
+        OpenShield aims to make Azure security posture management easier to understand, easier to test,
+        and easier to improve through community contribution.
+      </p>
+      <div class="grid">
+        <div class="card"><h3>Security Research</h3><p>Encourage practical Azure misconfiguration research and rule development.</p></div>
+        <div class="card"><h3>Education</h3><p>Help learners understand CSPM, cloud controls, and secure Azure configuration.</p></div>
+        <div class="card"><h3>Community</h3><p>Build a contributor-friendly platform where improvements are clear and reviewable.</p></div>
+      </div>
+    </section>
+
+    <section id="future">
+      <h2 class="section-title">Future Scope</h2>
+      <p class="section-intro">
+        OpenShield can grow over time with richer dashboards, stronger compliance reports,
+        automated remediation workflows, and eventually broader cloud coverage.
+      </p>
+    </section>
+
+    <div class="notice">
+      <strong>Note:</strong> This page is a static documentation hub. Do not add fake file upload buttons here.
+      Real uploads require backend storage, authentication, authorization, file validation, and access control.
+    </div>
+  </main>
+
+  <footer>
+    OpenShield — Open Source Azure CSPM Platform | Learn, Contribute, Improve Azure Security
+  </footer>
+</body>
+</html>


### PR DESCRIPTION
## What does this PR do?
Adds a centralized OpenShield learning portal under docs/learn/index.html along with README navigation updates for improved onboarding and documentation discoverability.

## Type of change
- [ ] New scan rule
- [ ] Remediation playbook
- [ ] Bug fix
- [ ] Dashboard/front-end work
- [ ] API endpoint
- [x] Documentation
- [ ] Compliance mapping

## Rule details (if applicable)
- Rule ID: N/A
- Severity: N/A
- Category: N/A
- Frameworks mapped: N/A

## Testing
- [ ] Tested against a real Azure free trial subscription
- [ ] Returns correct JSON output
- [ ] All seven CI checks pass
- [x] No hardcoded credentials or secrets

## Related issue
Closes #52 

## Checklist
- [x] My code follows the rule template in CONTRIBUTING.md
- [ ] I added or updated the matching CLI playbook
- [ ] I added or updated all four compliance framework mappings
- [x] I have not committed any real Azure credentials
- [x] My branch name follows the convention: docs/add-learn-portal-clean

## Additional Notes
This PR introduces:
- OpenShield overview
- Azure CSPM fundamentals
- Architecture explanation
- Compliance mapping overview
- Remediation workflow concepts
- Contributor learning path
- Documentation navigation hub

This is a static documentation page only and does not introduce backend functionality or upload handling.