### PR TITLE
feat: add rule AZ-KV-004 Key Vault purge protection disabled

### DIFF
--- a/compliance/frameworks/cis_azure_benchmark.json
+++ b/compliance/frameworks/cis_azure_benchmark.json
@@ -127,6 +127,11 @@
       "control_id": "4.3.6",
       "control_name": "Ensure SSL connection is enabled for PostgreSQL Flexible Server",
       "description": "SSL enforcement should be enabled on PostgreSQL Flexible Server to ensure data in transit is encrypted. Without SSL, database connections transmit data in plaintext, exposing it to interception."
+    },
+    "AZ-KV-004": {
+      "control_id": "8.6",
+      "control_name": "Ensure that Azure Key Vault Purge Protection is Enabled",
+      "description": "Azure Key Vaults without purge protection enabled allow permanent deletion of vaults and their secrets, keys, and certificates during the soft-delete retention period. Even with soft delete enabled, a malicious insider or privileged account can purge vault objects before the retention period expires. Enabling purge protection prevents this by blocking purge operations for the full retention period."
     }
   }
 }

--- a/compliance/frameworks/iso27001.json
+++ b/compliance/frameworks/iso27001.json
@@ -127,6 +127,11 @@
       "control_id": "A.10.1.1",
       "control_name": "Policy on the use of cryptographic controls",
       "description": "SSL enforcement on PostgreSQL Flexible Server applies cryptographic controls to data in transit. A policy on the use of cryptographic controls for protection of information should be developed and implemented."
+    },
+    "AZ-KV-004": {
+      "control_id": "A.17.2.1",
+      "control_name": "Availability of information processing facilities",
+      "description": "Purge protection prevents permanent deletion of Azure Key Vault secrets, keys, and certificates during the soft-delete retention period. Without it, cryptographic material can be irrecoverably destroyed, threatening the availability of information processing facilities that depend on those keys and secrets."
     }
   }
 }

--- a/compliance/frameworks/nist_csf.json
+++ b/compliance/frameworks/nist_csf.json
@@ -127,6 +127,11 @@
       "control_id": "PR.DS-2",
       "control_name": "Data-in-transit is protected",
       "description": "SSL enforcement on PostgreSQL Flexible Server ensures data in transit between applications and the database is encrypted. Disabling SSL exposes database traffic to interception and tampering."
+    },
+    "AZ-KV-004": {
+      "control_id": "PR.IP-4",
+      "control_name": "Backups of information are conducted, maintained, and tested",
+      "description": "Purge protection ensures that deleted Key Vault objects can be recovered within the retention period and cannot be permanently destroyed before it expires. Without purge protection, backups of cryptographic material may be rendered unrecoverable if an insider or compromised account issues a purge operation during the soft-delete window."
     }
   }
 }

--- a/compliance/frameworks/soc2.json
+++ b/compliance/frameworks/soc2.json
@@ -122,6 +122,11 @@
       "control_id": "CC6.1",
       "control_name": "Logical and physical access controls",
       "description": "SSL enforcement ensures database connections are encrypted, protecting data in transit from unauthorized access. Disabling SSL undermines logical access controls by exposing database traffic in plaintext."
+    },
+    "AZ-KV-004": {
+      "control_id": "CC9.1",
+      "control_name": "Risk Mitigation",
+      "description": "Azure Key Vaults without purge protection enabled allow permanent deletion of secrets, keys, and certificates during the soft-delete retention period. CC9.1 requires that identified risks are mitigated through controls that reduce the likelihood or impact of risk events. Enabling purge protection mitigates the risk of irrecoverable loss of cryptographic material by preventing purge operations from executing before the retention period expires."
     }
   }
 }

--- a/playbooks/cli/fix_az_kv_004.sh
+++ b/playbooks/cli/fix_az_kv_004.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# AZ-KV-004: Enable purge protection on an Azure Key Vault
+# Usage: ./fix_az_kv_004.sh <resource-group> <vault-name>
+
+RESOURCE_GROUP=$1
+VAULT_NAME=$2
+
+if [ -z "$RESOURCE_GROUP" ] || [ -z "$VAULT_NAME" ]; then
+  echo "Usage: $0 <resource-group> <vault-name>"
+  exit 1
+fi
+
+echo "Enabling purge protection on Key Vault: $VAULT_NAME..."
+
+az keyvault update \
+  --resource-group "$RESOURCE_GROUP" \
+  --name "$VAULT_NAME" \
+  --enable-purge-protection true
+
+echo "Purge protection enabled for Key Vault: $VAULT_NAME"
+echo "Note: Purge protection cannot be disabled once enabled."

--- a/playbooks/cli/fix_az_kv_004.sh
+++ b/playbooks/cli/fix_az_kv_004.sh
@@ -1,21 +1,17 @@
 #!/bin/bash
+set -euo pipefail
 # AZ-KV-004: Enable purge protection on an Azure Key Vault
 # Usage: ./fix_az_kv_004.sh <resource-group> <vault-name>
-
 RESOURCE_GROUP=$1
 VAULT_NAME=$2
-
 if [ -z "$RESOURCE_GROUP" ] || [ -z "$VAULT_NAME" ]; then
   echo "Usage: $0 <resource-group> <vault-name>"
   exit 1
 fi
-
 echo "Enabling purge protection on Key Vault: $VAULT_NAME..."
-
 az keyvault update \
   --resource-group "$RESOURCE_GROUP" \
   --name "$VAULT_NAME" \
   --enable-purge-protection true
-
 echo "Purge protection enabled for Key Vault: $VAULT_NAME"
 echo "Note: Purge protection cannot be disabled once enabled."

--- a/scanner/rules/az_kv_004.py
+++ b/scanner/rules/az_kv_004.py
@@ -1,0 +1,57 @@
+"""AZ-KV-004: Key Vault purge protection disabled."""
+
+from typing import Any, Dict, List
+
+RULE_ID = "AZ-KV-004"
+RULE_NAME = "Key Vault Purge Protection Disabled"
+SEVERITY = "MEDIUM"
+CATEGORY = "Key Vault"
+FRAMEWORKS = {
+    "CIS": "8.6",
+    "NIST": "PR.IP-4",
+    "ISO27001": "A.17.2.1"
+}
+DESCRIPTION = (
+    "Azure Key Vaults without purge protection enabled allow permanent "
+    "deletion of vaults and their secrets, keys, and certificates during "
+    "the soft-delete retention period. Without purge protection, a "
+    "malicious insider or accidental deletion can result in irrecoverable "
+    "loss of cryptographic material."
+)
+REMEDIATION = (
+    "Enable purge protection on the Key Vault. Note: once enabled, "
+    "purge protection cannot be disabled. Ensure soft delete is also "
+    "enabled as purge protection requires it."
+)
+PLAYBOOK = "playbooks/cli/fix_az_kv_004.sh"
+
+
+def scan(azure_client: Any, subscription_id: str) -> List[Dict[str, Any]]:
+    """Return a list of findings. Return [] if no issues are found."""
+    findings: List[Dict[str, Any]] = []
+
+    for vault in azure_client.get_key_vaults():
+        parsed = azure_client.parse_resource_id(vault.id)
+        resource_group = parsed["resource_group"]
+        vault_name = parsed["name"]
+
+        properties = getattr(vault, "properties", None)
+        purge_protection = getattr(properties, "enable_purge_protection", False)
+
+        if not purge_protection:
+            findings.append({
+                "rule_id": RULE_ID,
+                "rule_name": RULE_NAME,
+                "severity": SEVERITY,
+                "category": CATEGORY,
+                "resource_id": vault.id,
+                "resource_name": vault_name,
+                "resource_type": "Microsoft.KeyVault/vaults",
+                "description": DESCRIPTION,
+                "remediation": REMEDIATION,
+                "playbook": PLAYBOOK,
+                "frameworks": FRAMEWORKS,
+                "metadata": {}
+            })
+
+    return findings

--- a/scanner/rules/az_kv_004.py
+++ b/scanner/rules/az_kv_004.py
@@ -9,7 +9,8 @@ CATEGORY = "Key Vault"
 FRAMEWORKS = {
     "CIS": "8.6",
     "NIST": "PR.IP-4",
-    "ISO27001": "A.17.2.1"
+    "ISO27001": "A.17.2.1",
+    "SOC2": "CC9.1"
 }
 DESCRIPTION = (
     "Azure Key Vaults without purge protection enabled allow permanent "
@@ -51,7 +52,7 @@ def scan(azure_client: Any, subscription_id: str) -> List[Dict[str, Any]]:
                 "remediation": REMEDIATION,
                 "playbook": PLAYBOOK,
                 "frameworks": FRAMEWORKS,
-                "metadata": {}
+                "metadata": {"resource_group": resource_group}
             })
 
     return findings


### PR DESCRIPTION
## What does this PR do?
Adds scan rule AZ-KV-004 — detects Azure Key Vaults that do not have purge protection enabled, which can lead to permanent, irrecoverable loss of secrets, keys, and certificates.

## Type of change
- [x] New scan rule
- [x] Remediation playbook

## Rule details (if applicable)
- Rule ID: AZ-KV-004
- Severity: MEDIUM
- Category: Key Vault
- Frameworks mapped: CIS 8.6, NIST PR.IP-4, ISO 27001 A.17.2.1, SOC 2 CC9.1

## Tested against
- [ ] Azure free trial subscription
- [ ] Rule returns correct findings
- [ ] Remediation playbook tested

## Related issue
Closes #53