### PR TITLE
docs: add security policy, issue template, and README badges

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,69 @@
+name: Feature Request
+about: Suggest a new rule, compliance mapping, playbook, or capability for OpenShield
+title: "feat: "
+labels: enhancement
+assignees: ''
+---
+
+## Summary
+
+A clear one-sentence description of the feature you are proposing.
+
+## Problem It Solves
+
+What is the current limitation or gap? Why does this matter for Azure cloud security posture?
+Link any related issues or discussions if relevant.
+
+## Proposed Solution
+
+Describe what you want to happen. Be specific.
+
+---
+
+**If proposing a new scanner rule, fill in all fields below:**
+
+- Azure resource type:
+- Misconfiguration it detects:
+- Suggested RULE_ID (format: `AZ-<SERVICE>-<NNN>`, e.g. `AZ-KV-003`):
+- Severity: (CRITICAL / HIGH / MEDIUM / LOW)
+- Compliance frameworks it maps to:
+  - CIS Azure Benchmark control:
+  - NIST CSF control:
+  - ISO 27001 control:
+- Does a matching remediation playbook need to be created? (Yes / No)
+
+---
+
+**If proposing a compliance mapping:**
+
+- Framework name and version:
+- Control ID(s):
+- Which existing rules does it apply to:
+- Source documentation link:
+
+---
+
+**If proposing an API or CLI change:**
+
+- Endpoint or command affected:
+- Current behaviour:
+- Proposed behaviour:
+- Example request/response or command:
+
+---
+
+## Alternatives Considered
+
+What other approaches did you consider, and why did you rule them out?
+
+## Additional Context
+
+Add any Azure documentation links, CVE references, CIS Benchmark pages, screenshots, or reference implementations here.
+
+## Contribution
+
+Are you willing to implement this yourself?
+
+- [ ] Yes, I plan to open a PR for this
+- [ ] I can help review a PR but cannot implement it myself
+- [ ] I am not able to contribute code for this

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,82 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability in OpenShield, please **do not open a public GitHub issue**.
+Opening a public issue exposes the vulnerability to bad actors before a fix is available.
+
+
+We will acknowledge your report within 48 hours and work with you to coordinate a fix and responsible disclosure timeline.
+
+### What to include in your report
+
+To help us triage quickly, please include:
+
+- A description of the vulnerability and its potential impact
+- The affected component (scanner engine, REST API, auth logic, playbooks)
+- Steps to reproduce the issue
+- Any relevant logs, proof-of-concept code, or screenshots
+- The version of OpenShield you were testing (check `git log --oneline -1`)
+
+The more detail you provide, the faster we can respond.
+
+---
+
+## Supported Versions
+
+| Version | Supported |
+|---------|-----------|
+| 0.1.x   | Yes       |
+
+Older versions are not patched. If you are running a version below 0.1.x, upgrade to the latest release before filing a report.
+
+---
+
+## Disclosure Process
+
+We follow a coordinated disclosure model:
+
+1. **Report received** -- you email the vulnerability privately
+2. **Acknowledgement** -- we respond within 48 hours to confirm receipt
+3. **Investigation** -- we reproduce and assess the impact
+4. **Fix developed** -- we write and test a patch
+5. **Coordinated release** -- we agree a disclosure date with you (typically 7-14 days after fix)
+6. **Public advisory** -- we publish a GitHub Security Advisory and release the fix
+
+We ask that you do not publicly disclose the vulnerability until step 6 is complete.
+
+---
+
+## Scope
+
+### In scope
+
+- Scanner engine (`scanner/`) -- rule logic, Azure SDK calls, output handling
+- REST API (`api/`) -- authentication, authorisation, input validation, JWT handling
+- Compliance framework mappings (`compliance/`) -- data integrity
+- Sentinel integration (`sentinel/`) -- HMAC signing, data upload logic
+- Hardcoded secrets or credentials anywhere in the codebase
+
+### Out of scope
+
+- Vulnerabilities in third-party dependencies -- report those to the upstream maintainer
+- Security issues in infrastructure you deploy OpenShield to (your Azure environment, your PostgreSQL instance)
+- Social engineering attacks
+- Physical security
+
+---
+
+## Recognition
+
+We value responsible disclosure. Researchers who report valid vulnerabilities will be:
+
+- Acknowledged by name (or pseudonym if preferred) in the release notes for the fix
+- Listed in a `SECURITY_ACKNOWLEDGEMENTS.md` file we maintain in this repository
+
+We do not currently offer a bug bounty programme, but we are grateful for every report.
+
+---
+
+## Contact
+
+**Email: vishnu.ajith@owasp.org**

--- a/README.md
+++ b/README.md
@@ -1,8 +1,13 @@
 # OpenShield
 
-> **Open source Cloud Security Posture Management (CSPM) for Azure — built by the community, for the community.**
+> **Open source Cloud Security Posture Management (CSPM) for Azure - built by the community, for the community.**
 
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+[![Python 3.11](https://img.shields.io/badge/python-3.11-blue.svg)](https://www.python.org/downloads/release/python-3110/)
+[![CI](https://github.com/openshield-org/openshield/actions/workflows/ci.yml/badge.svg?branch=dev)](https://github.com/openshield-org/openshield/actions/workflows/ci.yml)
+[![Deploy](https://github.com/openshield-org/openshield/actions/workflows/deploy.yml/badge.svg?branch=dev)](https://github.com/openshield-org/openshield/actions/workflows/deploy.yml)
+[![Security Policy](https://img.shields.io/badge/security-policy-green.svg)](.github/SECURITY.md)
+[![OWASP](https://img.shields.io/badge/OWASP-listing%20review-orange.svg)](https://owasp.org)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](CONTRIBUTING.md)
 [![Good First Issues](https://img.shields.io/github/issues/openshield-org/openshield/good-first-issue)](https://github.com/openshield-org/openshield/issues?q=is%3Aissue+label%3Agood-first-issue)
 [![Discord](https://img.shields.io/badge/Discord-Join%20Us-7289da)](https://discord.gg/openshield)


### PR DESCRIPTION
## Summary

Adds security policy documentation, a structured feature request template, and 5 status badges to README -- all in one PR as discussed with the maintainer.

## Files Changed

| File | Change | Notes |
|---|---|---|
| `.github/SECURITY.md` | New | Vulnerability reporting, scope, disclosure process, recognition |
| `.github/ISSUE_TEMPLATE/feature_request.md` | New | Structured fields for rules, mappings, API changes |
| `README.md` | Modified | 5 badges added, License badge updated to link to local file |

## Acceptance Criteria

- [x] `.github/SECURITY.md` exists
- [x] Contains vulnerability reporting email (vishnu.ajith@owasp.org)
- [x] Contains supported versions table
- [x] Feature request template created with rule-specific structured fields
- [x] 5 badges added (CI, Deploy, Python 3.11, Security Policy, OWASP)
- [x] PR raised to dev

## Notes on SECURITY.md content

The issue specified minimum required content. Three additions were made:

1. Scope section -- reporters need to know whether to report a third-party dependency issue or an infrastructure issue to this project
2. Disclosure process steps -- sets expectations so reporters know their report is being acted on between acknowledgement and fix
3. Recognition policy -- standard for OWASP-reviewed projects and incentivises responsible disclosure

Closes #51 