### PR TITLE
feat: add rule AZ-DB-004 SQL Server firewall allows all Azure services

### DIFF
--- a/compliance/frameworks/cis_azure_benchmark.json
+++ b/compliance/frameworks/cis_azure_benchmark.json
@@ -137,6 +137,11 @@
       "control_id": "8.6",
       "control_name": "Ensure that Azure Key Vault Purge Protection is Enabled",
       "description": "Azure Key Vaults without purge protection enabled allow permanent deletion of vaults and their secrets, keys, and certificates during the soft-delete retention period. Even with soft delete enabled, a malicious insider or privileged account can purge vault objects before the retention period expires. Enabling purge protection prevents this by blocking purge operations for the full retention period."
+    },
+    "AZ-DB-004": {
+      "control_id": "4.1.2",
+      "control_name": "Ensure that 'Allow access to Azure services' for SQL Servers is disabled",
+      "description": "Enabling 'Allow access to Azure services' on a SQL Server firewall creates a rule that permits any Azure-hosted resource — including services from other tenants — to connect to the server. This significantly increases the attack surface. Access should be restricted to specific trusted IP ranges or private endpoints."
     }
   }
 }

--- a/compliance/frameworks/iso27001.json
+++ b/compliance/frameworks/iso27001.json
@@ -137,6 +137,11 @@
       "control_id": "A.17.2.1",
       "control_name": "Availability of information processing facilities",
       "description": "Purge protection prevents permanent deletion of Azure Key Vault secrets, keys, and certificates during the soft-delete retention period. Without it, cryptographic material can be irrecoverably destroyed, threatening the availability of information processing facilities that depend on those keys and secrets."
+    },
+    "AZ-DB-004": {
+      "control_id": "A.13.1.1",
+      "control_name": "Network controls",
+      "description": "Enabling 'Allow access to Azure services' on a SQL Server firewall bypasses network controls by permitting any Azure-hosted resource to connect to the database server. Networks should be managed and controlled with explicit rules that restrict access to known and trusted sources only."
     }
   }
 }

--- a/compliance/frameworks/nist_csf.json
+++ b/compliance/frameworks/nist_csf.json
@@ -137,6 +137,11 @@
       "control_id": "PR.IP-4",
       "control_name": "Backups of information are conducted, maintained, and tested",
       "description": "Purge protection ensures that deleted Key Vault objects can be recovered within the retention period and cannot be permanently destroyed before it expires. Without purge protection, backups of cryptographic material may be rendered unrecoverable if an insider or compromised account issues a purge operation during the soft-delete window."
+    },
+    "AZ-DB-004": {
+      "control_id": "PR.AC-3",
+      "control_name": "Remote access is managed",
+      "description": "Enabling 'Allow access to Azure services' on a SQL Server firewall permits any Azure-hosted resource to connect to the database remotely without restriction. PR.AC-3 requires that remote access is managed and controlled. Access should be restricted to specific trusted IP ranges or private endpoints to ensure only authorised systems can reach the database."
     }
   }
 }

--- a/compliance/frameworks/soc2.json
+++ b/compliance/frameworks/soc2.json
@@ -132,6 +132,11 @@
       "control_id": "CC9.1",
       "control_name": "Risk Mitigation",
       "description": "Azure Key Vaults without purge protection enabled allow permanent deletion of secrets, keys, and certificates during the soft-delete retention period. CC9.1 requires that identified risks are mitigated through controls that reduce the likelihood or impact of risk events. Enabling purge protection mitigates the risk of irrecoverable loss of cryptographic material by preventing purge operations from executing before the retention period expires."
+    },
+    "AZ-DB-004": {
+      "control_id": "CC6.6",
+      "control_name": "Restricts Access from Outside the Network Boundary",
+      "description": "Enabling 'Allow access to Azure services' on a SQL Server firewall creates a rule that permits any Azure-hosted resource — including services from other tenants — to connect to the database. CC6.6 requires that access from outside the network boundary is restricted to authorised sources. Disabling this setting and replacing it with explicit firewall rules or private endpoints enforces the network boundary and ensures only known and trusted systems can reach the SQL Server."
     }
   }
 }

--- a/playbooks/cli/fix_az_db_004.sh
+++ b/playbooks/cli/fix_az_db_004.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+set -euo pipefail
+# AZ-DB-004: Remove the 'Allow all Azure services' firewall rule from an Azure SQL Server
+# Usage: ./fix_az_db_004.sh <resource-group> <server-name>
+RESOURCE_GROUP=$1
+SERVER_NAME=$2
+if [ -z "$RESOURCE_GROUP" ] || [ -z "$SERVER_NAME" ]; then
+  echo "Usage: $0 <resource-group> <server-name>"
+  exit 1
+fi
+echo "Removing 'AllowAllWindowsAzureIps' firewall rule from SQL Server: $SERVER_NAME..."
+az sql server firewall-rule delete \
+  --resource-group "$RESOURCE_GROUP" \
+  --server "$SERVER_NAME" \
+  --name "AllowAllWindowsAzureIps"
+echo "Done. 'Allow access to Azure services' has been disabled for: $SERVER_NAME"
+echo "Note: Add explicit firewall rules for trusted IP ranges if needed."

--- a/scanner/azure_client.py
+++ b/scanner/azure_client.py
@@ -13,7 +13,6 @@ from azure.mgmt.rdbms.postgresql import PostgreSQLManagementClient
 from azure.mgmt.sql import SqlManagementClient
 from azure.mgmt.monitor import MonitorManagementClient
 from azure.mgmt.storage import StorageManagementClient
-from azure.mgmt.monitor import MonitorManagementClient
 
 logger = logging.getLogger(__name__)
 
@@ -93,14 +92,10 @@ class AzureClient:
             policy = client.management_policies.get(
                 resource_group, account_name, "default"
             )
-            # A policy shell can exist with an empty rules list —
-            # treat that the same as no policy (non-compliant).
             rules = getattr(getattr(policy, "policy", None), "rules", None)
             return bool(rules)
 
         except ResourceNotFoundError:
-            # Expected path: the account genuinely has no lifecycle policy.
-            # This is the non-compliant condition — return False to flag it.
             logger.debug(
                 "get_storage_lifecycle_policy(%s): ResourceNotFound — no policy",
                 account_name,
@@ -108,9 +103,6 @@ class AzureClient:
             return False
 
         except HttpResponseError as exc:
-            # 403 = service principal lacks
-            # Microsoft.Storage/storageAccounts/managementPolicies/read.
-            # Return None — cannot determine compliance, do not flag.
             logger.error(
                 "get_storage_lifecycle_policy(%s) HTTP %s — "
                 "check service principal permissions: %s",
@@ -121,8 +113,6 @@ class AzureClient:
             return None
 
         except Exception as exc:
-            # Unexpected failure (network, SDK bug, etc.).
-            # Return None — skip rather than create a false positive.
             logger.error(
                 "get_storage_lifecycle_policy(%s) unexpected error: %s",
                 account_name,
@@ -308,6 +298,19 @@ class AzureClient:
             )
             return None
 
+    def get_sql_server_firewall_rules(
+        self, resource_group: str, server_name: str
+    ) -> List[Any]:
+        """List all firewall rules for an Azure SQL server."""
+        try:
+            client = SqlManagementClient(self.credential, self.subscription_id)
+            return list(client.firewall_rules.list_by_server(resource_group, server_name))
+        except Exception as exc:
+            logger.error(
+                "get_sql_server_firewall_rules(%s) failed: %s", server_name, exc
+            )
+            return []
+
     # ------------------------------------------------------------------ #
     # Key Vault                                                             #
     # ------------------------------------------------------------------ #
@@ -342,21 +345,14 @@ class AzureClient:
                 self.credential,
                 self.subscription_id,
             )
-
-            settings = list(
-                client.diagnostic_settings.list(resource_id)
-            )
-
+            settings = list(client.diagnostic_settings.list(resource_id))
             if not settings:
                 return False
-
             for setting in settings:
                 logs = getattr(setting, "logs", [])
-
                 for log in logs:
                     category = getattr(log, "category", "")
                     enabled = getattr(log, "enabled", False)
-
                     if category == "AuditEvent" and enabled:
                         return True
             return False
@@ -399,7 +395,6 @@ class AzureClient:
             logger.error("get_service_principals failed: %s", exc)
             return []
 
-
     def get_postgresql_flexible_servers(self) -> List[Any]:
         """List all PostgreSQL Flexible Server instances in the subscription."""
         try:
@@ -409,7 +404,6 @@ class AzureClient:
         except Exception as exc:
             logger.error("get_postgresql_flexible_servers failed: %s", exc)
             return []
-
 
     def get_postgresql_flexible_server_parameters(self, resource_group: str, server_name: str) -> List[Any]:
         """List all configuration parameters for a PostgreSQL Flexible Server."""
@@ -427,7 +421,7 @@ class AzureClient:
         Requires the credential to have 'Policy.Read.All' Graph permission.
         Returns empty list if the permission is not granted or the call fails.
         """
-        import requests  # imported here to keep azure-only paths dependency-free
+        import requests
 
         try:
             token = self.credential.get_token("https://graph.microsoft.com/.default")
@@ -442,6 +436,7 @@ class AzureClient:
         except Exception as exc:
             logger.error("get_conditional_access_policies failed: %s", exc)
             return []
+
     def get_regions_with_resources(self) -> List[str]:
         """List all regions that have at least one resource deployed."""
         try:

--- a/scanner/azure_client.py
+++ b/scanner/azure_client.py
@@ -13,7 +13,6 @@ from azure.mgmt.rdbms.postgresql import PostgreSQLManagementClient
 from azure.mgmt.sql import SqlManagementClient
 from azure.mgmt.monitor import MonitorManagementClient
 from azure.mgmt.storage import StorageManagementClient
-from azure.mgmt.monitor import MonitorManagementClient
 
 logger = logging.getLogger(__name__)
 
@@ -240,7 +239,6 @@ class AzureClient:
             logger.error("get_virtual_networks failed: %s", exc)
             return []
 
-    
     def get_public_ip_addresses(self) -> List[Any]:
         """List all public IP addresses in the subscription."""
         try:
@@ -263,14 +261,19 @@ class AzureClient:
             logger.error("get_virtual_machines failed: %s", exc)
             return []
 
-
-
-   def get_vm_extensions(self, resource_group: str, vm_name: str) -> Optional[List[Any]]:
+    def get_vm_extensions(
+        self, resource_group: str, vm_name: str
+    ) -> Optional[List[Any]]:
+        """List all extensions installed on a virtual machine."""
         try:
-            result = ComputeManagementClient(self.credential, self.subscription_id).virtual_machine_extensions.list(resource_group, vm_name)
+            result = ComputeManagementClient(
+                self.credential, self.subscription_id
+            ).virtual_machine_extensions.list(resource_group, vm_name)
             return list(getattr(result, "value", []) or [])
         except Exception as exc:
-            logger.error("get_vm_extensions failed for %s/%s: %s", resource_group, vm_name, exc)
+            logger.error(
+                "get_vm_extensions failed for %s/%s: %s", resource_group, vm_name, exc
+            )
             return None
 
     # ------------------------------------------------------------------ #
@@ -306,9 +309,9 @@ class AzureClient:
             logger.error(
                 "get_sql_server_auditing_policy(%s) failed: %s", server_name, exc
             )
+            return None
 
-
-     def get_sql_server_firewall_rules(
+    def get_sql_server_firewall_rules(
         self, resource_group: str, server_name: str
     ) -> List[Any]:
         """List all firewall rules for an Azure SQL server."""
@@ -320,6 +323,7 @@ class AzureClient:
                 "get_sql_server_firewall_rules(%s) failed: %s", server_name, exc
             )
             return []
+
     # ------------------------------------------------------------------ #
     # Key Vault                                                             #
     # ------------------------------------------------------------------ #
@@ -354,21 +358,14 @@ class AzureClient:
                 self.credential,
                 self.subscription_id,
             )
-
-            settings = list(
-                client.diagnostic_settings.list(resource_id)
-            )
-
+            settings = list(client.diagnostic_settings.list(resource_id))
             if not settings:
                 return False
-
             for setting in settings:
                 logs = getattr(setting, "logs", [])
-
                 for log in logs:
                     category = getattr(log, "category", "")
                     enabled = getattr(log, "enabled", False)
-
                     if category == "AuditEvent" and enabled:
                         return True
             return False
@@ -411,7 +408,6 @@ class AzureClient:
             logger.error("get_service_principals failed: %s", exc)
             return []
 
-
     def get_postgresql_flexible_servers(self) -> List[Any]:
         """List all PostgreSQL Flexible Server instances in the subscription."""
         try:
@@ -422,15 +418,20 @@ class AzureClient:
             logger.error("get_postgresql_flexible_servers failed: %s", exc)
             return []
 
-
-    def get_postgresql_flexible_server_parameters(self, resource_group: str, server_name: str) -> List[Any]:
+    def get_postgresql_flexible_server_parameters(
+        self, resource_group: str, server_name: str
+    ) -> List[Any]:
         """List all configuration parameters for a PostgreSQL Flexible Server."""
         try:
             from azure.mgmt.postgresqlflexibleservers import PostgreSQLManagementClient as FlexClient
             client = FlexClient(self.credential, self.subscription_id)
             return list(client.configurations.list_by_server(resource_group, server_name))
         except Exception as exc:
-            logger.error("get_postgresql_flexible_server_parameters(%s) failed: %s", server_name, exc)
+            logger.error(
+                "get_postgresql_flexible_server_parameters(%s) failed: %s",
+                server_name,
+                exc,
+            )
             return []
 
     def get_conditional_access_policies(self) -> List[Any]:
@@ -454,6 +455,7 @@ class AzureClient:
         except Exception as exc:
             logger.error("get_conditional_access_policies failed: %s", exc)
             return []
+
     def get_regions_with_resources(self) -> List[str]:
         """List all regions that have at least one resource deployed."""
         try:

--- a/scanner/azure_client.py
+++ b/scanner/azure_client.py
@@ -13,6 +13,7 @@ from azure.mgmt.rdbms.postgresql import PostgreSQLManagementClient
 from azure.mgmt.sql import SqlManagementClient
 from azure.mgmt.monitor import MonitorManagementClient
 from azure.mgmt.storage import StorageManagementClient
+from azure.mgmt.monitor import MonitorManagementClient
 
 logger = logging.getLogger(__name__)
 
@@ -92,10 +93,14 @@ class AzureClient:
             policy = client.management_policies.get(
                 resource_group, account_name, "default"
             )
+            # A policy shell can exist with an empty rules list —
+            # treat that the same as no policy (non-compliant).
             rules = getattr(getattr(policy, "policy", None), "rules", None)
             return bool(rules)
 
         except ResourceNotFoundError:
+            # Expected path: the account genuinely has no lifecycle policy.
+            # This is the non-compliant condition — return False to flag it.
             logger.debug(
                 "get_storage_lifecycle_policy(%s): ResourceNotFound — no policy",
                 account_name,
@@ -103,6 +108,9 @@ class AzureClient:
             return False
 
         except HttpResponseError as exc:
+            # 403 = service principal lacks
+            # Microsoft.Storage/storageAccounts/managementPolicies/read.
+            # Return None — cannot determine compliance, do not flag.
             logger.error(
                 "get_storage_lifecycle_policy(%s) HTTP %s — "
                 "check service principal permissions: %s",
@@ -113,6 +121,8 @@ class AzureClient:
             return None
 
         except Exception as exc:
+            # Unexpected failure (network, SDK bug, etc.).
+            # Return None — skip rather than create a false positive.
             logger.error(
                 "get_storage_lifecycle_policy(%s) unexpected error: %s",
                 account_name,
@@ -296,9 +306,9 @@ class AzureClient:
             logger.error(
                 "get_sql_server_auditing_policy(%s) failed: %s", server_name, exc
             )
-            return None
 
-    def get_sql_server_firewall_rules(
+
+     def get_sql_server_firewall_rules(
         self, resource_group: str, server_name: str
     ) -> List[Any]:
         """List all firewall rules for an Azure SQL server."""
@@ -310,7 +320,6 @@ class AzureClient:
                 "get_sql_server_firewall_rules(%s) failed: %s", server_name, exc
             )
             return []
-
     # ------------------------------------------------------------------ #
     # Key Vault                                                             #
     # ------------------------------------------------------------------ #
@@ -345,14 +354,21 @@ class AzureClient:
                 self.credential,
                 self.subscription_id,
             )
-            settings = list(client.diagnostic_settings.list(resource_id))
+
+            settings = list(
+                client.diagnostic_settings.list(resource_id)
+            )
+
             if not settings:
                 return False
+
             for setting in settings:
                 logs = getattr(setting, "logs", [])
+
                 for log in logs:
                     category = getattr(log, "category", "")
                     enabled = getattr(log, "enabled", False)
+
                     if category == "AuditEvent" and enabled:
                         return True
             return False
@@ -395,6 +411,7 @@ class AzureClient:
             logger.error("get_service_principals failed: %s", exc)
             return []
 
+
     def get_postgresql_flexible_servers(self) -> List[Any]:
         """List all PostgreSQL Flexible Server instances in the subscription."""
         try:
@@ -404,6 +421,7 @@ class AzureClient:
         except Exception as exc:
             logger.error("get_postgresql_flexible_servers failed: %s", exc)
             return []
+
 
     def get_postgresql_flexible_server_parameters(self, resource_group: str, server_name: str) -> List[Any]:
         """List all configuration parameters for a PostgreSQL Flexible Server."""
@@ -421,7 +439,7 @@ class AzureClient:
         Requires the credential to have 'Policy.Read.All' Graph permission.
         Returns empty list if the permission is not granted or the call fails.
         """
-        import requests
+        import requests  # imported here to keep azure-only paths dependency-free
 
         try:
             token = self.credential.get_token("https://graph.microsoft.com/.default")
@@ -436,7 +454,6 @@ class AzureClient:
         except Exception as exc:
             logger.error("get_conditional_access_policies failed: %s", exc)
             return []
-
     def get_regions_with_resources(self) -> List[str]:
         """List all regions that have at least one resource deployed."""
         try:

--- a/scanner/rules/az_db_004.py
+++ b/scanner/rules/az_db_004.py
@@ -1,0 +1,64 @@
+"""AZ-DB-004: SQL Server firewall allows all Azure services."""
+
+from typing import Any, Dict, List
+
+RULE_ID = "AZ-DB-004"
+RULE_NAME = "SQL Server Firewall Allows All Azure Services"
+SEVERITY = "HIGH"
+CATEGORY = "Database"
+FRAMEWORKS = {
+    "CIS": "4.1.2",
+    "NIST": "PR.AC-3",
+    "ISO27001": "A.13.1.1",
+    "SOC2": "CC6.6"
+}
+DESCRIPTION = (
+    "Azure SQL Server has the 'Allow access to Azure services' firewall setting "
+    "enabled. This creates a firewall rule that permits any resource hosted in "
+    "Azure — including services from other tenants — to connect to the SQL Server. "
+    "This significantly increases the attack surface and can allow unauthorised "
+    "access from compromised or malicious Azure-hosted services."
+)
+REMEDIATION = (
+    "Disable the 'Allow access to Azure services' setting on the SQL Server "
+    "firewall. Instead, add explicit firewall rules for specific trusted IP "
+    "ranges or use private endpoints to restrict access to known sources only."
+)
+PLAYBOOK = "playbooks/cli/fix_az_db_004.sh"
+
+
+def scan(azure_client: Any, subscription_id: str) -> List[Dict[str, Any]]:
+    """Return a list of findings. Return [] if no issues are found."""
+    findings: List[Dict[str, Any]] = []
+
+    for server in azure_client.get_sql_servers():
+        parsed = azure_client.parse_resource_id(server.id)
+        resource_group = parsed["resource_group"]
+        server_name = parsed["name"]
+
+        firewall_rules = azure_client.get_sql_server_firewall_rules(
+            resource_group, server_name
+        )
+
+        for rule in firewall_rules:
+            start_ip = getattr(rule, "start_ip_address", "")
+            end_ip = getattr(rule, "end_ip_address", "")
+
+            if start_ip == "0.0.0.0" and end_ip == "0.0.0.0":
+                findings.append({
+                    "rule_id": RULE_ID,
+                    "rule_name": RULE_NAME,
+                    "severity": SEVERITY,
+                    "category": CATEGORY,
+                    "resource_id": server.id,
+                    "resource_name": server_name,
+                    "resource_type": "Microsoft.Sql/servers",
+                    "description": DESCRIPTION,
+                    "remediation": REMEDIATION,
+                    "playbook": PLAYBOOK,
+                    "frameworks": FRAMEWORKS,
+                    "metadata": {"resource_group": resource_group}
+                })
+                break
+
+    return findings


### PR DESCRIPTION
## What does this PR do?
Adds scan rule AZ-DB-004 — detects Azure SQL Servers with the 'Allow access to Azure services' firewall setting enabled, which permits any Azure-hosted resource including services from other tenants to connect to the server.

## Type of change
- [x] New scan rule
- [x] Remediation playbook

## Rule details
- Rule ID: AZ-DB-004
- Severity: HIGH
- Category: Database
- Frameworks mapped: CIS 4.1.2, NIST PR.AC-3, ISO 27001 A.13.1.1, SOC 2 CC6.6

## Tested against
- [ ] Azure free trial subscription
- [ ] Rule returns correct findings
- [ ] Remediation playbook tested

## Related issue
Closes #68