### PR TITLE
[RULE] AZ-CMP-004: VM without automatic OS patching enabled

### DIFF
--- a/compliance/frameworks/cis_azure_benchmark.json
+++ b/compliance/frameworks/cis_azure_benchmark.json
@@ -107,8 +107,7 @@
       "control_id": "8.3",
       "control_name": "Ensure that 'OS patching' is enabled for virtual machines",
       "description": "The virtual machine does not have automatic OS patching enabled. CIS 8.3 requires that OS patches are applied in a timely manner. Unpatched VMs are vulnerable to known exploits targeting unpatched OS vulnerabilities."
-},
-    
+    },  
     "AZ-KV-001": {
       "control_id": "8.5",
       "control_name": "Ensure the Key Vault is Recoverable",

--- a/compliance/frameworks/cis_azure_benchmark.json
+++ b/compliance/frameworks/cis_azure_benchmark.json
@@ -103,6 +103,12 @@
       "control_name": "Ensure that 'Endpoint protection solution' is installed on VMs",
       "description": "The virtual machine does not have a recognised endpoint protection extension installed. CIS 8.2 requires that an approved endpoint protection solution is installed and running on all virtual machines. Without endpoint protection, malware and ransomware can execute without detection."
     },
+    "AZ-CMP-004": {
+      "control_id": "8.3",
+      "control_name": "Ensure that 'OS patching' is enabled for virtual machines",
+      "description": "The virtual machine does not have automatic OS patching enabled. CIS 8.3 requires that OS patches are applied in a timely manner. Unpatched VMs are vulnerable to known exploits targeting unpatched OS vulnerabilities."
+},
+    
     "AZ-KV-001": {
       "control_id": "8.5",
       "control_name": "Ensure the Key Vault is Recoverable",

--- a/compliance/frameworks/iso27001.json
+++ b/compliance/frameworks/iso27001.json
@@ -103,6 +103,11 @@
       "control_name": "Controls against malware",
       "description": "The virtual machine does not have a recognised endpoint protection extension installed. A.12.2.1 requires that detection, prevention and recovery controls are implemented to protect against malware. Without endpoint protection, malware executing on the VM will not be detected or prevented."
     },
+    "AZ-CMP-004": {
+      "control_id": "A.12.6.1",
+      "control_name": "Management of technical vulnerabilities",
+      "description": "The virtual machine does not have automatic OS patching enabled. A.12.6.1 requires that information about technical vulnerabilities is obtained and the organisation's exposure evaluated. Without automatic patching, known OS vulnerabilities remain unmitigated."
+    },
     "AZ-KV-001": {
       "control_id": "A.17.2.1",
       "control_name": "Availability of information processing facilities",

--- a/compliance/frameworks/nist_csf.json
+++ b/compliance/frameworks/nist_csf.json
@@ -103,6 +103,11 @@
       "control_name": "Malicious code is detected",
       "description": "The virtual machine does not have a recognised endpoint protection extension installed. DE.CM-4 requires that malicious code is detected on organisational systems. Without endpoint protection, malware and ransomware executing on the VM will not be detected or blocked."
     },
+    "AZ-CMP-004": {
+      "control_id": "PR.IP-12",
+      "control_name": "A vulnerability management plan is developed and implemented",
+      "description": "The virtual machine does not have automatic OS patching enabled. PR.IP-12 requires that a vulnerability management plan is developed and implemented. Without automatic patching, known OS vulnerabilities remain unmitigated and exploitable."
+},
     "AZ-KV-001": {
       "control_id": "PR.IP-4",
       "control_name": "Backups of information are conducted, maintained, and tested",

--- a/compliance/frameworks/nist_csf.json
+++ b/compliance/frameworks/nist_csf.json
@@ -107,7 +107,7 @@
       "control_id": "PR.IP-12",
       "control_name": "A vulnerability management plan is developed and implemented",
       "description": "The virtual machine does not have automatic OS patching enabled. PR.IP-12 requires that a vulnerability management plan is developed and implemented. Without automatic patching, known OS vulnerabilities remain unmitigated and exploitable."
-},
+    },
     "AZ-KV-001": {
       "control_id": "PR.IP-4",
       "control_name": "Backups of information are conducted, maintained, and tested",

--- a/compliance/frameworks/soc2.json
+++ b/compliance/frameworks/soc2.json
@@ -108,6 +108,11 @@
       "control_name": "Prevents or Detects Unauthorized or Malicious Software",
       "description": "The virtual machine does not have a recognised endpoint protection extension installed. CC6.8 requires that controls are implemented to prevent or detect and act upon the introduction of unauthorized or malicious software. Without endpoint protection, malicious code executing on the VM will not be detected or blocked."
     },
+    "AZ-CMP-004": {
+      "control_id": "CC7.1",
+      "control_name": "System Vulnerabilities are Identified and Managed",
+      "description": "The virtual machine does not have automatic OS patching enabled. CC7.1 requires that vulnerabilities in system components are identified and managed through a defined process. Without automatic patching, known OS vulnerabilities are left unmitigated and exploitable."
+    },
     "AZ-KV-001": {
       "control_id": "A1.2",
       "control_name": "Environmental Threats and Recovery",

--- a/playbooks/cli/fix_az_cmp_004.sh
+++ b/playbooks/cli/fix_az_cmp_004.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+# fix_az_cmp_004.sh
+# Enables automatic OS patching on a VM (Windows or Linux)
+# Usage: ./fix_az_cmp_004.sh <resource-group> <vm-name> [windows|linux]
+# Defaults to windows if OS type is not passed
+
+set -e
+
+RG=$1
+VM=$2
+OS=${3:-windows}
+
+if [ -z "$RG" ] || [ -z "$VM" ]; then
+  echo "Usage: $0 <resource-group> <vm-name> [windows|linux]"
+  exit 1
+fi
+
+if [ "${OS,,}" = "linux" ]; then
+  echo "Enabling AutomaticByPlatform patching on Linux VM $VM..."
+
+  az vm update \
+    --resource-group "$RG" \
+    --name "$VM" \
+    --set osProfile.linuxConfiguration.patchSettings.patchMode=AutomaticByPlatform
+
+  echo "Done. Linux VM $VM will now receive automatic OS patches."
+else
+  echo "Enabling automatic updates on Windows VM $VM..."
+
+  az vm update \
+    --resource-group "$RG" \
+    --name "$VM" \
+    --set osProfile.windowsConfiguration.enableAutomaticUpdates=true \
+    --set osProfile.windowsConfiguration.patchSettings.patchMode=AutomaticByPlatform
+
+  echo "Done. Windows VM $VM will now receive automatic OS patches."
+fi

--- a/playbooks/cli/fix_az_cmp_004.sh
+++ b/playbooks/cli/fix_az_cmp_004.sh
@@ -4,7 +4,7 @@
 # Usage: ./fix_az_cmp_004.sh <resource-group> <vm-name> [windows|linux]
 # Defaults to windows if OS type is not passed
 
-set -e
+set -euo pipefail
 
 RG=$1
 VM=$2

--- a/scanner/rules/az_cmp_004.py
+++ b/scanner/rules/az_cmp_004.py
@@ -49,7 +49,7 @@ def scan(azure_client: Any, subscription_id: str) -> List[Dict[str, Any]]:
             auto_updates = getattr(win_config, "enable_automatic_updates", False)
             patch_settings = getattr(win_config, "patch_settings", None)
             patch_mode = getattr(patch_settings, "patch_mode", "") if patch_settings else ""
-           if auto_updates or (patch_mode or "").lower() == "automaticbyplatform":
+            if auto_updates or (patch_mode or "").lower() == "automaticbyplatform":
                 patching_ok = True
 
         linux_config = getattr(os_profile, "linux_configuration", None)

--- a/scanner/rules/az_cmp_004.py
+++ b/scanner/rules/az_cmp_004.py
@@ -49,7 +49,7 @@ def scan(azure_client: Any, subscription_id: str) -> List[Dict[str, Any]]:
             auto_updates = getattr(win_config, "enable_automatic_updates", False)
             patch_settings = getattr(win_config, "patch_settings", None)
             patch_mode = getattr(patch_settings, "patch_mode", "") if patch_settings else ""
-            if auto_updates or (patch_mode or "").lower() in ("automaticbyplatform", "automaticbyos"):
+           if auto_updates or (patch_mode or "").lower() == "automaticbyplatform":
                 patching_ok = True
 
         linux_config = getattr(os_profile, "linux_configuration", None)

--- a/scanner/rules/az_cmp_004.py
+++ b/scanner/rules/az_cmp_004.py
@@ -1,0 +1,80 @@
+"""AZ-CMP-004: VM without automatic OS patching enabled."""
+
+import logging
+from typing import Any, Dict, List
+
+RULE_ID = "AZ-CMP-004"
+RULE_NAME = "VM Without Automatic OS Patching Enabled"
+SEVERITY = "HIGH"
+CATEGORY = "Compute"
+FRAMEWORKS = {
+    "CIS": "8.3",
+    "NIST": "PR.IP-12",
+    "ISO27001": "A.12.6.1",
+    "SOC2": "CC7.1",
+}
+DESCRIPTION = (
+    "VM does not have automatic OS patching enabled. "
+    "Unpatched VMs are vulnerable to known exploits. "
+    "CIS 8.3 requires OS patches are applied in a timely manner."
+)
+REMEDIATION = (
+    "For Windows VMs enable automatic updates via osProfile.windowsConfiguration "
+    "or set patchMode to AutomaticByPlatform. "
+    "For Linux VMs set patchMode to AutomaticByPlatform."
+)
+PLAYBOOK = "playbooks/cli/fix_az_cmp_004.sh"
+
+logger = logging.getLogger(__name__)
+
+
+def scan(azure_client: Any, subscription_id: str) -> List[Dict[str, Any]]:
+    findings: List[Dict[str, Any]] = []
+
+    for vm in azure_client.get_virtual_machines():
+        parsed = azure_client.parse_resource_id(getattr(vm, "id", ""))
+        rg = parsed.get("resource_group", "")
+        vm_name = parsed.get("name", "")
+        if not rg or not vm_name:
+            continue
+
+        os_profile = getattr(vm, "os_profile", None)
+        if not os_profile:
+            continue
+
+        patching_ok = False
+
+        win_config = getattr(os_profile, "windows_configuration", None)
+        if win_config is not None:
+            auto_updates = getattr(win_config, "enable_automatic_updates", False)
+            patch_settings = getattr(win_config, "patch_settings", None)
+            patch_mode = getattr(patch_settings, "patch_mode", "") if patch_settings else ""
+            if auto_updates or (patch_mode or "").lower() in ("automaticbyplatform", "automaticbyos"):
+                patching_ok = True
+
+        linux_config = getattr(os_profile, "linux_configuration", None)
+        if linux_config is not None:
+            patch_settings = getattr(linux_config, "patch_settings", None)
+            patch_mode = getattr(patch_settings, "patch_mode", "") if patch_settings else ""
+            if (patch_mode or "").lower() == "automaticbyplatform":
+                patching_ok = True
+
+        if not patching_ok:
+            findings.append({
+                "rule_id": RULE_ID,
+                "rule_name": RULE_NAME,
+                "severity": SEVERITY,
+                "category": CATEGORY,
+                "resource_id": vm.id,
+                "resource_name": vm_name,
+                "resource_type": "Microsoft.Compute/virtualMachines",
+                "description": DESCRIPTION,
+                "remediation": REMEDIATION,
+                "playbook": PLAYBOOK,
+                "frameworks": FRAMEWORKS,
+                "metadata": {
+                    "resource_group": rg,
+                },
+            })
+
+    return findings


### PR DESCRIPTION
## What does this PR do?
Adds scanner rule AZ-CMP-004 to detect virtual machines that do not have automatic OS patching enabled, along with the remediation playbook and compliance mappings for all four frameworks.

## Type of change
- [x] New scan rule
- [x] Remediation playbook
- [x] Compliance mapping

## Rule details (if applicable)
- Rule ID: AZ-CMP-004
- Severity: HIGH
- Category: Compute
- Frameworks mapped: CIS 8.3, NIST PR.IP-12, ISO 27001 A.12.6.1, SOC 2 CC7.1

## Testing
- [ ] Tested against a real Azure free trial subscription
- [x] Returns correct JSON output
- [x] All seven CI checks pass
- [x] No hardcoded credentials or secrets

## Related issue
Closes #58

## Checklist
- [x] My code follows the rule template in CONTRIBUTING.md
- [x] I added or updated the matching CLI playbook
- [x] I added or updated all four compliance framework mappings
- [x] I have not committed any real Azure credentials
- [x] My branch name follows the convention: feat/description