### PR TITLE
feat: add AZ-STOR-005 geo-redundant storage rule

### DIFF
--- a/compliance/frameworks/cis_azure_benchmark.json
+++ b/compliance/frameworks/cis_azure_benchmark.json
@@ -118,6 +118,11 @@
       "control_name": "Ensure Storage logging is enabled for Blob, Queue, and Table services for read, write, and delete requests",
       "description": "Enabling diagnostic logging for Azure Storage blob, queue, and table services records read, write, and delete operations. Without logging, unauthorized access, data exfiltration, or destructive operations on storage services cannot be detected or investigated."
     },
+    "AZ-STOR-005": {
+      "control_id": "3.1",
+      "control_name": "Ensure that storage accounts use geo-redundant replication",
+      "description": "Storage accounts configured with locally redundant (LRS) or zone-redundant (ZRS) replication do not replicate data outside the primary region. A regional disaster or prolonged outage could result in data unavailability or data loss. Geo-redundant storage (GRS or GZRS) replicates data asynchronously to a secondary Azure region, protecting against region-wide failures."
+    },
     "AZ-KV-002": {
       "control_id": "8.3",
       "control_name": "Ensure that public network access to Key Vault is disabled",

--- a/compliance/frameworks/iso27001.json
+++ b/compliance/frameworks/iso27001.json
@@ -118,6 +118,11 @@
       "control_name": "Event logging",
       "description": "Diagnostic logging must be enabled on Azure Storage blob, queue, and table services to produce event logs for read, write, and delete operations. Event logs recording user activities, exceptions, and information security events should be produced, kept, and regularly reviewed."
     },
+    "AZ-STOR-005": {
+      "control_id": "A.17.2.1",
+      "control_name": "Availability of information processing facilities",
+      "description": "Storage accounts using LRS or ZRS replication retain data only within a single region, providing no protection against regional outages or disasters. A regional disaster could result in data unavailability or data loss. A.17.2.1 requires that redundancy is implemented to meet availability requirements. Configuring geo-redundant replication (GRS or GZRS) ensures information processing facilities remain available by maintaining a secondary copy of data in a geographically separate region."
+    },
     "AZ-KV-002": {
       "control_id": "A.13.1.1",
       "control_name": "Network controls",

--- a/compliance/frameworks/nist_csf.json
+++ b/compliance/frameworks/nist_csf.json
@@ -123,6 +123,11 @@
       "control_name": "Monitoring for unauthorized personnel, connections, devices, and software is performed",
       "description": "Diagnostic logging on Azure Storage services provides the audit trail needed to monitor for unauthorized or anomalous read, write, and delete operations. Without logging, detection of data exfiltration or unauthorized access to blob, queue, or table services is not possible."
     },
+    "AZ-STOR-005": {
+      "control_id": "PR.IP-4",
+      "control_name": "Backups of information are conducted, maintained, and tested",
+      "description": "Storage accounts configured with LRS or ZRS replicate data only within a single region. A regional outage or disaster could result in data unavailability or data loss. PR.IP-4 requires that backups and redundant copies of information are maintained. Geo-redundant replication (GRS or GZRS) ensures a secondary copy of data is maintained in a separate Azure region, satisfying backup and recovery requirements."
+    },
     "AZ-NET-011": {
       "control_id": "DE.CM-7",
       "control_name": "Monitoring for unauthorized personnel, connections, devices, and software is performed",

--- a/compliance/frameworks/soc2.json
+++ b/compliance/frameworks/soc2.json
@@ -18,6 +18,11 @@
       "control_name": "Change Management",
       "description": "A storage account with no lifecycle management policy allows data to accumulate indefinitely with no automatic expiry or tiering. CC8.1 requires that infrastructure and data are managed through formal processes. Implementing a lifecycle policy ensures data retention is controlled and old data is automatically moved or deleted according to organisational policy."
     },
+    "AZ-STOR-005": {
+      "control_id": "A1.2",
+      "control_name": "Environmental Threats and Recovery",
+      "description": "Storage accounts configured with LRS or ZRS replication do not protect against environmental threats at the regional level. A regional outage or disaster could result in data unavailability or data loss. A1.2 requires that environmental threats to availability are identified and that recovery measures are implemented. Geo-redundant replication (GRS or GZRS) provides a secondary copy of storage data in a separate Azure region, enabling recovery from regional disasters and protecting availability commitments."
+    },
     "AZ-NET-001": {
       "control_id": "CC6.6",
       "control_name": "Restricts Access from Outside the Network Boundary",

--- a/playbooks/cli/fix_az_stor_005.sh
+++ b/playbooks/cli/fix_az_stor_005.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+# OpenShield Remediation Playbook
+# Rule: AZ-STOR-005 — Storage Account Not Using Geo-Redundant Replication
+# Usage: ./fix_az_stor_005.sh <resource-group> <storage-account-name> [target-sku]
+# Severity: MEDIUM
+
+set -euo pipefail
+
+RESOURCE_GROUP="${1:-}"
+RESOURCE_NAME="${2:-}"
+TARGET_SKU="${3:-Standard_GRS}"
+
+if [ -z "$RESOURCE_GROUP" ] || [ -z "$RESOURCE_NAME" ]; then
+  echo "Usage: $0 <resource-group> <storage-account-name> [target-sku]"
+  echo "  target-sku defaults to Standard_GRS"
+  echo "  Valid geo-redundant options: Standard_GRS, Standard_RAGRS, Standard_GZRS, Standard_RAGZRS"
+  exit 1
+fi
+
+case "$TARGET_SKU" in
+  Standard_GRS|Standard_RAGRS|Standard_GZRS|Standard_RAGZRS)
+    ;;
+  *)
+    echo "Error: '$TARGET_SKU' is not a supported geo-redundant SKU."
+    echo "Valid options: Standard_GRS, Standard_RAGRS, Standard_GZRS, Standard_RAGZRS"
+    exit 1
+    ;;
+esac
+
+echo "Checking current SKU for $RESOURCE_NAME..."
+CURRENT_SKU=$(az storage account show \
+  --name "$RESOURCE_NAME" \
+  --resource-group "$RESOURCE_GROUP" \
+  --query "sku.name" \
+  --output tsv)
+echo "Current SKU: $CURRENT_SKU"
+
+echo "Remediating AZ-STOR-005 for $RESOURCE_NAME — updating replication to $TARGET_SKU..."
+az storage account update \
+  --name "$RESOURCE_NAME" \
+  --resource-group "$RESOURCE_GROUP" \
+  --sku "$TARGET_SKU"
+
+echo "Updated SKU for $RESOURCE_NAME:"
+az storage account show \
+  --name "$RESOURCE_NAME" \
+  --resource-group "$RESOURCE_GROUP" \
+  --query "sku.name" \
+  --output tsv
+
+echo "Remediation complete for $RESOURCE_NAME — replication is now $TARGET_SKU."

--- a/scanner/rules/az_stor_005.py
+++ b/scanner/rules/az_stor_005.py
@@ -1,0 +1,93 @@
+"""AZ-STOR-005: Storage account not using geo-redundant replication."""
+
+import logging
+from typing import Any, Dict, List
+
+logger = logging.getLogger(__name__)
+
+RULE_ID = "AZ-STOR-005"
+RULE_NAME = "Storage Account Not Using Geo-Redundant Replication"
+SEVERITY = "MEDIUM"
+CATEGORY = "Storage"
+FRAMEWORKS = {
+    "CIS":      "3.1",
+    "NIST":     "PR.IP-4",
+    "ISO27001": "A.17.2.1",
+    "SOC2":     "A1.2",
+}
+DESCRIPTION = (
+    "This storage account is configured with a non-geo-redundant replication "
+    "SKU ({sku_name}). Locally redundant (LRS) and zone-redundant (ZRS) "
+    "storage replicate data only within a single region. A regional outage or "
+    "disaster could result in data unavailability or data loss. Geo-redundant "
+    "storage (GRS or GZRS) replicates data asynchronously to a secondary "
+    "Azure region, protecting against region-wide failures."
+)
+REMEDIATION = (
+    "Change the storage account replication to a geo-redundant SKU such as "
+    "Standard_GRS or Standard_GZRS. Navigate to Storage Account > "
+    "Configuration > Replication and select Geo-redundant storage (GRS) or "
+    "Geo-zone-redundant storage (GZRS). Alternatively, run the remediation "
+    "playbook."
+)
+PLAYBOOK = "playbooks/cli/fix_az_stor_005.sh"
+
+_GEO_REDUNDANT_SKUS = {
+    "Standard_GRS",
+    "Standard_RAGRS",
+    "Standard_GZRS",
+    "Standard_RAGZRS",
+    "StandardV2_GRS",
+    "StandardV2_GZRS",
+}
+
+
+def scan(azure_client: Any, subscription_id: str) -> List[Dict[str, Any]]:
+    """Detect storage accounts not configured with geo-redundant replication."""
+    findings: List[Dict[str, Any]] = []
+
+    for account in azure_client.get_storage_accounts():
+        resource_id = getattr(account, "id", "")
+        account_name = getattr(account, "name", "")
+        location = getattr(account, "location", "")
+
+        if not resource_id or not account_name:
+            continue
+
+        sku = getattr(account, "sku", None)
+        sku_name = getattr(sku, "name", "") if sku else ""
+
+        if not sku_name:
+            logger.warning(
+                "AZ-STOR-005: Could not determine SKU for %s — skipping.",
+                account_name,
+            )
+            continue
+
+        if sku_name in _GEO_REDUNDANT_SKUS:
+            continue
+
+        parsed = azure_client.parse_resource_id(resource_id)
+        resource_group = parsed.get("resource_group", "")
+
+        findings.append({
+            "rule_id":       RULE_ID,
+            "rule_name":     RULE_NAME,
+            "severity":      SEVERITY,
+            "category":      CATEGORY,
+            "resource_id":   resource_id,
+            "resource_name": account_name,
+            "resource_type": "Microsoft.Storage/storageAccounts",
+            "description":   DESCRIPTION.format(sku_name=sku_name),
+            "remediation":   REMEDIATION,
+            "playbook":      PLAYBOOK,
+            "frameworks":    FRAMEWORKS,
+            "metadata": {
+                "resource_group":  resource_group,
+                "location":        location,
+                "current_sku":     sku_name,
+                "recommended_sku": "Standard_GRS",
+            },
+        })
+
+    return findings


### PR DESCRIPTION
## What does this PR do?
Adds scanner rule AZ-STOR-005 to detect Azure Storage Accounts not configured with geo-redundant replication, along with a CLI remediation playbook and compliance mappings across all four frameworks.

## Type of change
- [x] New scan rule
- [x] Remediation playbook
- [ ] Bug fix
- [ ] Dashboard/front-end work
- [ ] API endpoint
- [ ] Documentation
- [x] Compliance mapping

## Rule details (if applicable)
- Rule ID: AZ-STOR-005
- Severity: MEDIUM
- Category: Storage
- Frameworks mapped: CIS / NIST / ISO 27001 / SOC 2

## Testing
- [ ] Tested against a real Azure free trial subscription
- [ ] Returns correct JSON output
- [x] All seven CI checks pass
- [x] No hardcoded credentials or secrets

## Related issue
Closes #71

## Checklist
- [x] My code follows the rule template in CONTRIBUTING.md
- [x] I added or updated the matching CLI playbook
- [x] I added or updated all four compliance framework mappings
- [x] I have not committed any real Azure credentials
- [x] My branch name follows the convention: feat/description