### PR TITLE
feat(scanner): add AZ-NET-014 VNet peering gateway transit rule

### DIFF
--- a/compliance/frameworks/cis_azure_benchmark.json
+++ b/compliance/frameworks/cis_azure_benchmark.json
@@ -162,6 +162,11 @@
       "control_id": "8.5",
       "control_name": "Ensure that the expiration date is set on all certificates",
       "description": "A certificate stored in Azure Key Vault is expiring within 30 days and does not have auto-renewal configured. CIS 8.5 requires that expiration dates are monitored and certificates are renewed before expiry to prevent service outages and broken authentication flows."
+    },
+    "AZ-NET-014": {
+      "control_id": "6.4",
+      "control_name": "Ensure that Azure Firewall is enabled on Virtual Networks",
+      "description": "VNet peering connections with allowGatewayTransit or useRemoteGateways enabled allow traffic to route between network segments through shared gateways. This can break network segmentation and enable lateral movement between zones that should remain isolated. Peering connections should be reviewed and gateway transit disabled unless explicitly required and documented."
     }
   }
 }

--- a/compliance/frameworks/iso27001.json
+++ b/compliance/frameworks/iso27001.json
@@ -167,6 +167,11 @@
       "control_id": "A.9.2.3",
       "control_name": "Management of privileged access rights",
       "description": "The allocation and use of privileged access rights should be restricted and controlled. PIM enforces just-in-time access with time limits and approval workflows, ensuring privileged access rights are tightly managed and not permanently assigned."
+    },
+    "AZ-NET-014": {
+      "control_id": "A.13.1.1",
+      "control_name": "Network controls",
+      "description": "VNet peering connections with gateway transit enabled allow traffic to flow between network segments through shared gateways, potentially bypassing network controls. Networks should be managed and controlled to protect information in systems and applications. Gateway transit on peering connections should be disabled unless explicitly required."
     }
   }
 }

--- a/compliance/frameworks/nist_csf.json
+++ b/compliance/frameworks/nist_csf.json
@@ -162,6 +162,11 @@
       "control_id": "PR.AC-4",
       "control_name": "Access permissions and authorizations are managed",
       "description": "PIM ensures privileged access permissions are managed with time-bound activation and approval workflows. Without PIM, permanently assigned admin roles violate the principle of least privilege and increase the blast radius of compromised accounts."
+    },
+    "AZ-NET-014": {
+      "control_id": "PR.AC-5",
+      "control_name": "Network integrity is protected",
+      "description": "VNet peering with gateway transit enabled allows traffic to cross network boundaries through shared gateways, undermining network segmentation. PR.AC-5 requires that network integrity is protected. Disabling gateway transit on peering connections enforces boundary integrity between network zones."
     }
   }
 }

--- a/compliance/frameworks/soc2.json
+++ b/compliance/frameworks/soc2.json
@@ -162,6 +162,11 @@
       "control_id": "CC6.3",
       "control_name": "Role-based access control",
       "description": "PIM provides role-based access control with time-bound activation for privileged roles. Without PIM, admin roles are permanently assigned with no controls, violating the requirement for managed and restricted privileged access."
+    },
+    "AZ-NET-014": {
+      "control_id": "CC6.6",
+      "control_name": "Restricts Access from Outside the Network Boundary",
+      "description": "VNet peering with allowGatewayTransit or useRemoteGateways enabled allows traffic to cross network boundaries through shared gateways, weakening the logical separation between network zones. CC6.6 requires that logical access from outside the network boundary is restricted and controlled. Gateway transit on peering connections should be disabled to enforce boundary separation."
     }
   }
 }

--- a/playbooks/cli/fix_az_net_014.sh
+++ b/playbooks/cli/fix_az_net_014.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+set -euo pipefail
+
+RESOURCE_GROUP=$1
+VNET_NAME=$2
+PEERING_NAME=$3
+
+if [ -z "$RESOURCE_GROUP" ] || [ -z "$VNET_NAME" ] || [ -z "$PEERING_NAME" ]; then
+  echo "Usage: $0 <resource-group> <vnet-name> <peering-name>"
+  exit 1
+fi
+
+echo "Disabling gateway transit on peering: $PEERING_NAME"
+
+az network vnet peering update \
+  --resource-group "$RESOURCE_GROUP" \
+  --vnet-name "$VNET_NAME" \
+  --name "$PEERING_NAME" \
+  --set allowGatewayTransit=false useRemoteGateways=false
+
+echo "Done. Gateway transit disabled on peering: $PEERING_NAME"
+echo "Note: Verify that disabling gateway transit does not break any intended routing before applying to production."

--- a/scanner/azure_client.py
+++ b/scanner/azure_client.py
@@ -240,7 +240,6 @@ class AzureClient:
             logger.error("get_virtual_networks failed: %s", exc)
             return []
 
-    
     def get_public_ip_addresses(self) -> List[Any]:
         """List all public IP addresses in the subscription."""
         try:
@@ -248,6 +247,24 @@ class AzureClient:
             return list(client.public_ip_addresses.list_all())
         except Exception as exc:
             logger.error("get_public_ip_addresses failed: %s", exc)
+            return []
+
+    def get_azure_firewalls(self, resource_group: str) -> List[Any]:
+        """List all Azure Firewalls in a resource group."""
+        try:
+            client = NetworkManagementClient(self.credential, self.subscription_id)
+            return list(client.azure_firewalls.list(resource_group))
+        except Exception as exc:
+            logger.error("get_azure_firewalls(%s) failed: %s", resource_group, exc)
+            return []
+
+    def get_vnet_peerings(self, resource_group: str, vnet_name: str) -> List[Any]:
+        """List all peering connections for a Virtual Network."""
+        try:
+            client = NetworkManagementClient(self.credential, self.subscription_id)
+            return list(client.virtual_network_peerings.list(resource_group, vnet_name))
+        except Exception as exc:
+            logger.error("get_vnet_peerings(%s) failed: %s", vnet_name, exc)
             return []
 
     # ------------------------------------------------------------------ #

--- a/scanner/rules/az_net_014.py
+++ b/scanner/rules/az_net_014.py
@@ -1,0 +1,58 @@
+"""AZ-NET-014: VNet peering configured without gateway transit restrictions."""
+from typing import Any, Dict, List
+
+RULE_ID = "AZ-NET-014"
+RULE_NAME = "VNet Peering Configured Without Gateway Transit Restrictions"
+SEVERITY = "MEDIUM"
+CATEGORY = "Network"
+FRAMEWORKS = {
+    "CIS": "6.4",
+    "NIST": "PR.AC-5",
+    "ISO27001": "A.13.1.1",
+    "SOC2": "CC6.6"
+}
+DESCRIPTION = (
+    "A Virtual Network peering connection has gateway transit enabled. "
+    "Enabling allowGatewayTransit or useRemoteGateways on a peering "
+    "connection allows traffic to flow between network segments through "
+    "shared gateways, potentially enabling lateral movement between "
+    "network zones that should be isolated from each other."
+)
+REMEDIATION = (
+    "Review all VNet peering connections and disable allowGatewayTransit "
+    "and useRemoteGateways unless explicitly required and documented. "
+    "Ensure peering connections follow the principle of least privilege "
+    "and only permit the minimum required traffic between networks."
+)
+PLAYBOOK = "playbooks/cli/fix_az_net_014.sh"
+
+
+def scan(azure_client: Any, subscription_id: str) -> List[Dict[str, Any]]:
+    findings: List[Dict[str, Any]] = []
+    for vnet in azure_client.get_virtual_networks():
+        parsed = azure_client.parse_resource_id(vnet.id)
+        resource_group = parsed["resource_group"]
+        vnet_name = parsed["name"]
+        peerings = azure_client.get_vnet_peerings(resource_group, vnet_name)
+        for peering in peerings:
+            allow_gateway_transit = getattr(peering, "allow_gateway_transit", False)
+            use_remote_gateways = getattr(peering, "use_remote_gateways", False)
+            if allow_gateway_transit or use_remote_gateways:
+                findings.append({
+                    "rule_id": RULE_ID,
+                    "rule_name": RULE_NAME,
+                    "severity": SEVERITY,
+                    "category": CATEGORY,
+                    "resource_id": vnet.id,
+                    "resource_name": vnet_name,
+                    "resource_type": "Microsoft.Network/virtualNetworks",
+                    "description": DESCRIPTION,
+                    "remediation": REMEDIATION,
+                    "playbook": PLAYBOOK,
+                    "frameworks": FRAMEWORKS,
+                    "metadata": {
+                        "resource_group": resource_group,
+                        "peering_name": getattr(peering, "name", "unknown")
+                    }
+                })
+    return findings


### PR DESCRIPTION
## Summary
Adds a new CSPM scanner rule to detect Virtual Network peering connections with gateway transit enabled, which can break network segmentation and allow lateral movement between isolated network zones.

## Changes
- `scanner/rules/az_net_014.py` — detects peerings with `allowGatewayTransit` or `useRemoteGateways` enabled
- `scanner/azure_client.py` — adds `get_vnet_peerings()` and `get_azure_firewalls()` methods
- `playbooks/cli/fix_az_net_014.sh` — CLI remediation script to disable gateway transit
- All 4 compliance framework JSONs updated with AZ-NET-014 mappings (CIS 6.4, NIST PR.AC-5, ISO A.13.1.1, SOC2 CC6.6)

## Test
- `python -m py_compile scanner/rules/az_net_014.py` ✅
- `python -m py_compile scanner/azure_client.py` ✅
- All 4 compliance JSONs validated ✅

## Related Issue
Closes #93