### PR TITLE
Implement AI Q&A over scan findings (Issue #82)

### DIFF
--- a/api/routes/ai.py
+++ b/api/routes/ai.py
@@ -41,6 +41,33 @@ def _build_summary_prompt(findings: list) -> str:
     )
 
 
+def _build_question_prompt(sorted_findings: list, question: str) -> str:
+    lines = []
+    for f in sorted_findings:
+        rule_id = f.get("rule_id", "")
+        title = f.get("title", "Untitled")
+        severity = f.get("severity", "UNKNOWN")
+        description = f.get("description", "No description provided.")
+        remediation = f.get("remediation", "No remediation detail provided.")
+        label = f"{rule_id} — {title}" if rule_id else title
+        lines.append(
+            f"- [{severity}] {label}: {description} Remediation: {remediation}"
+        )
+    findings_text = "\n".join(lines)
+    return (
+        "You are a cloud security assistant.\n"
+        "Answer the user's question using only the scan findings provided below.\n"
+        "Do not invent facts or assume scan results that are not listed.\n"
+        "Prioritise high severity, exploitable, and compliance-impacting findings, "
+        "and consider remediation urgency.\n"
+        "Be concise but useful. If the findings are insufficient to answer "
+        "confidently, say what evidence is missing.\n\n"
+        f"Question: {question}\n\n"
+        f"Findings (severity order):\n{findings_text}\n\n"
+        "Answer:"
+    )
+
+
 def _build_remediation_prompt(sorted_findings: list) -> str:
     lines = []
     for f in sorted_findings:
@@ -71,6 +98,7 @@ def insights():
     provider = str(data.get("provider") or "").strip().lower()
     api_key = str(data.get("api_key") or "").strip()
     findings = data.get("findings")
+    question = str(data.get("question") or "").strip()
 
     if not provider:
         return jsonify({"error": "Missing required field: provider"}), 400
@@ -93,11 +121,19 @@ def insights():
     try:
         executive_summary = get_completion(provider, api_key, summary_prompt)
         remediation_plan = get_completion(provider, api_key, remediation_prompt)
+        answer = None
+        if question:
+            question_prompt = _build_question_prompt(sorted_findings, question)
+            answer = get_completion(provider, api_key, question_prompt)
     except Exception:
         logger.warning("AI provider request failed for provider=%s", provider)
         return jsonify({"error": "AI provider request failed"}), 502
 
-    return jsonify({
+    response = {
         "executive_summary": executive_summary,
         "remediation_plan": remediation_plan,
-    })
+    }
+    if question:
+        response["answer"] = answer
+
+    return jsonify(response)

--- a/tests/test_ai_insights.py
+++ b/tests/test_ai_insights.py
@@ -167,6 +167,123 @@ def test_gemini_provider_supported(mock_gc, client, auth_headers):
 
 
 @patch("api.routes.ai.get_completion")
+def test_no_question_omits_answer_field(mock_gc, client, auth_headers):
+    mock_gc.side_effect = ["summary", "plan"]
+    resp = _post(client, VALID_PAYLOAD, auth_headers)
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert "answer" not in body
+    assert mock_gc.call_count == 2
+
+
+@patch("api.routes.ai.get_completion")
+def test_blank_question_treated_as_absent(mock_gc, client, auth_headers):
+    mock_gc.side_effect = ["summary", "plan"]
+    payload = {**VALID_PAYLOAD, "question": "   "}
+    resp = _post(client, payload, auth_headers)
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert "answer" not in body
+    assert mock_gc.call_count == 2
+
+
+@patch("api.routes.ai.get_completion")
+def test_question_returns_answer(mock_gc, client, auth_headers):
+    mock_gc.side_effect = ["summary", "plan", "Fix the MFA finding first."]
+    payload = {**VALID_PAYLOAD, "question": "Which findings should I fix first?"}
+    resp = _post(client, payload, auth_headers)
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["executive_summary"] == "summary"
+    assert body["remediation_plan"] == "plan"
+    assert body["answer"] == "Fix the MFA finding first."
+    assert mock_gc.call_count == 3
+
+
+@patch("api.routes.ai.get_completion")
+def test_question_prompt_includes_question_and_findings(mock_gc, client, auth_headers):
+    mock_gc.side_effect = ["summary", "plan", "answer"]
+    question = "What is the fastest path to CIS compliance?"
+    payload = {**VALID_PAYLOAD, "question": question}
+    _post(client, payload, auth_headers)
+
+    question_prompt = mock_gc.call_args_list[2][0][2]
+    assert question in question_prompt
+    assert "AZ-IAM-001" in question_prompt
+
+
+@patch("api.routes.ai.get_completion")
+def test_question_answer_works_for_anthropic(mock_gc, client, auth_headers):
+    mock_gc.side_effect = ["summary", "plan", "answer"]
+    payload = {
+        **VALID_PAYLOAD,
+        "provider": "anthropic",
+        "question": "Which finding is most exploitable?",
+    }
+    resp = _post(client, payload, auth_headers)
+    assert resp.status_code == 200
+    assert resp.get_json()["answer"] == "answer"
+
+
+@patch("api.routes.ai.get_completion")
+def test_question_answer_works_for_groq(mock_gc, client, auth_headers):
+    mock_gc.side_effect = ["summary", "plan", "answer"]
+    payload = {
+        **VALID_PAYLOAD,
+        "provider": "groq",
+        "question": "Which finding is most exploitable?",
+    }
+    resp = _post(client, payload, auth_headers)
+    assert resp.status_code == 200
+    assert resp.get_json()["answer"] == "answer"
+
+
+@patch("api.routes.ai.get_completion")
+def test_question_answer_works_for_gemini(mock_gc, client, auth_headers):
+    mock_gc.side_effect = ["summary", "plan", "answer"]
+    payload = {
+        **VALID_PAYLOAD,
+        "provider": "gemini",
+        "question": "Which finding is most exploitable?",
+    }
+    resp = _post(client, payload, auth_headers)
+    assert resp.status_code == 200
+    assert resp.get_json()["answer"] == "answer"
+
+
+@patch("api.routes.ai.get_completion")
+def test_question_provider_failure_returns_502(mock_gc, client, auth_headers, caplog):
+    raw_key = _fake_api_key()
+    payload = {
+        **VALID_PAYLOAD,
+        "api_key": raw_key,
+        "question": "Which findings should I fix first?",
+    }
+    mock_gc.side_effect = ["summary", "plan", RuntimeError(f"auth failed: {raw_key}")]
+    with caplog.at_level("WARNING", logger="api.routes.ai"):
+        resp = _post(client, payload, auth_headers)
+    assert resp.status_code == 502
+    body_str = json.dumps(resp.get_json())
+    assert "answer" not in resp.get_json()
+    assert raw_key not in body_str
+    assert raw_key not in caplog.text
+
+
+@patch("api.routes.ai.get_completion")
+def test_api_key_not_in_response_with_question(mock_gc, client, auth_headers):
+    raw_key = _fake_api_key()
+    mock_gc.side_effect = ["summary", "plan", "answer"]
+    payload = {
+        **VALID_PAYLOAD,
+        "api_key": raw_key,
+        "question": "Which findings should I fix first?",
+    }
+    resp = _post(client, payload, auth_headers)
+    assert resp.status_code == 200
+    assert raw_key not in json.dumps(resp.get_json())
+
+
+@patch("api.routes.ai.get_completion")
 def test_provider_failure_returns_502(mock_gc, client, auth_headers, caplog):
     raw_key = _fake_api_key()
     payload = {**VALID_PAYLOAD, "api_key": raw_key}


### PR DESCRIPTION
## Summary
Closes #82. Extends `POST /api/ai/insights` so users can ask plain-English questions about scan findings and receive an AI-generated answer, without breaking existing endpoint behaviour.

- Adds an optional `question` request field. When provided, a focused Q&A prompt is built from the (severity-sorted) findings and sent through the existing `get_completion` provider abstraction, and an `answer` field is added to the response.
- When `question` is absent or blank/whitespace-only, the response is unchanged — no `answer` key (not `null`, not `""`). Fully backwards compatible.
- Works for Anthropic, Groq, and Gemini with no duplicated provider logic (no provider-layer changes needed).
- Preserves existing security guarantees: API keys are never stored, logged, or returned; raw provider errors are not surfaced (safe 502 with fixed message + provider name); JWT auth unchanged; no new endpoint.

## Prompt design
The Q&A prompt instructs the model to answer using only the supplied findings, not invent facts, prioritise high-severity/exploitable/compliance-impacting findings and remediation urgency, stay concise, and state when evidence is insufficient.

## Files changed
- `api/routes/ai.py` — `_build_question_prompt()`, optional `question` parsing, conditional `answer` in response.
- `tests/test_ai_insights.py` — 9 new tests.

## Test plan
- [x] No `question` → response omits `answer`, 2 provider calls
- [x] Blank/whitespace `question` treated as absent
- [x] `question` → `answer` returned, 3 provider calls
- [x] Q&A answer path works for Anthropic, Groq, Gemini
- [x] Provider failure still returns safe 502, no key/answer leak
- [x] API key not present in response
- [x] `python -m pytest tests/ -v` → 24 passed
- [x] `python -m py_compile api/services/ai_provider.py api/routes/ai.py` → OK