### PR TITLE
feat: add AZ-NET-013 Azure Firewall VNet rule

### DIFF
--- a/compliance/frameworks/cis_azure_benchmark.json
+++ b/compliance/frameworks/cis_azure_benchmark.json
@@ -163,6 +163,11 @@
       "control_name": "Ensure that the expiration date is set on all certificates",
       "description": "A certificate stored in Azure Key Vault is expiring within 30 days and does not have auto-renewal configured. CIS 8.5 requires that expiration dates are monitored and certificates are renewed before expiry to prevent service outages and broken authentication flows."
     },
+    "AZ-NET-013": {
+      "control_id": "6.4",
+      "control_name": "Ensure that Azure Firewall is enabled on Virtual Networks",
+      "description": "Virtual networks should be protected by an Azure Firewall rather than relying on Network Security Groups alone. Azure Firewall provides centralized, stateful traffic inspection, FQDN and threat-intelligence filtering, and network-wide logging that NSGs cannot offer. VNets without an associated Azure Firewall lack a perimeter inspection and logging layer."
+    },
     "AZ-NET-014": {
       "control_id": "6.4",
       "control_name": "Ensure that Azure Firewall is enabled on Virtual Networks",

--- a/compliance/frameworks/iso27001.json
+++ b/compliance/frameworks/iso27001.json
@@ -168,6 +168,11 @@
       "control_name": "Management of privileged access rights",
       "description": "The allocation and use of privileged access rights should be restricted and controlled. PIM enforces just-in-time access with time limits and approval workflows, ensuring privileged access rights are tightly managed and not permanently assigned."
     },
+    "AZ-NET-013": {
+      "control_id": "A.13.1.1",
+      "control_name": "Network controls",
+      "description": "A virtual network without an Azure Firewall relies on NSGs alone and has no centralized perimeter inspection or logging. A.13.1.1 requires that networks be managed and controlled to protect information in systems and applications. Deploying an Azure Firewall provides stateful inspection, filtering, and logging at the network boundary."
+    },
     "AZ-NET-014": {
       "control_id": "A.13.1.1",
       "control_name": "Network controls",

--- a/compliance/frameworks/nist_csf.json
+++ b/compliance/frameworks/nist_csf.json
@@ -163,6 +163,11 @@
       "control_name": "Access permissions and authorizations are managed",
       "description": "PIM ensures privileged access permissions are managed with time-bound activation and approval workflows. Without PIM, permanently assigned admin roles violate the principle of least privilege and increase the blast radius of compromised accounts."
     },
+    "AZ-NET-013": {
+      "control_id": "PR.AC-5",
+      "control_name": "Network integrity is protected",
+      "description": "A virtual network with no Azure Firewall relies on NSGs alone and lacks a centralized perimeter inspection and logging layer. PR.AC-5 requires that network integrity is protected through segregation. Deploying an Azure Firewall enforces inspected, logged traffic flow at the network boundary and strengthens segmentation."
+    },
     "AZ-NET-014": {
       "control_id": "PR.AC-5",
       "control_name": "Network integrity is protected",

--- a/compliance/frameworks/soc2.json
+++ b/compliance/frameworks/soc2.json
@@ -163,6 +163,11 @@
       "control_name": "Role-based access control",
       "description": "PIM provides role-based access control with time-bound activation for privileged roles. Without PIM, admin roles are permanently assigned with no controls, violating the requirement for managed and restricted privileged access."
     },
+    "AZ-NET-013": {
+      "control_id": "CC6.6",
+      "control_name": "Restricts Access from Outside the Network Boundary",
+      "description": "A virtual network without an Azure Firewall relies on NSGs alone and lacks a centralized point to inspect, filter, and log traffic crossing the network boundary. CC6.6 requires that logical access from outside the network boundary is restricted and controlled. Deploying an Azure Firewall enforces inspected, logged perimeter access for the network."
+    },
     "AZ-NET-014": {
       "control_id": "CC6.6",
       "control_name": "Restricts Access from Outside the Network Boundary",

--- a/playbooks/cli/fix_az_net_013.sh
+++ b/playbooks/cli/fix_az_net_013.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+# Playbook: fix_az_net_013.sh
+# Rule: AZ-NET-013 - Azure Firewall not enabled on Virtual Network
+
+set -euo pipefail
+
+if [[ $# -lt 2 ]]; then
+  echo "Usage: $0 <resource-group> <vnet-name> [location] [firewall-name]"
+  echo ""
+  echo "Deploys an Azure Firewall into the target virtual network so traffic"
+  echo "can be inspected, filtered, and logged at the network perimeter."
+  echo "Note: Azure Firewall is a billed resource - review pricing first."
+  exit 1
+fi
+
+RESOURCE_GROUP="$1"
+VNET_NAME="$2"
+LOCATION="${3:-}"
+FIREWALL_NAME="${4:-${VNET_NAME}-fw}"
+PUBLIC_IP_NAME="${FIREWALL_NAME}-pip"
+
+# Azure Firewall requires a dedicated subnet named exactly "AzureFirewallSubnet"
+# with a minimum prefix of /26.
+FIREWALL_SUBNET_NAME="AzureFirewallSubnet"
+FIREWALL_SUBNET_PREFIX="${FIREWALL_SUBNET_PREFIX:-10.0.255.0/26}"
+
+# Derive the VNet location if one was not supplied.
+if [[ -z "$LOCATION" ]]; then
+  echo "Resolving location for VNet '$VNET_NAME'..."
+  LOCATION=$(az network vnet show \
+    --resource-group "$RESOURCE_GROUP" \
+    --name "$VNET_NAME" \
+    --query "location" --output tsv)
+fi
+
+echo "Ensuring '$FIREWALL_SUBNET_NAME' exists in VNet '$VNET_NAME'..."
+if ! az network vnet subnet show \
+      --resource-group "$RESOURCE_GROUP" \
+      --vnet-name "$VNET_NAME" \
+      --name "$FIREWALL_SUBNET_NAME" >/dev/null 2>&1; then
+  echo "  Creating subnet '$FIREWALL_SUBNET_NAME' ($FIREWALL_SUBNET_PREFIX)..."
+  echo "  (Adjust FIREWALL_SUBNET_PREFIX to a free /26 range in your VNet.)"
+  az network vnet subnet create \
+    --resource-group "$RESOURCE_GROUP" \
+    --vnet-name "$VNET_NAME" \
+    --name "$FIREWALL_SUBNET_NAME" \
+    --address-prefixes "$FIREWALL_SUBNET_PREFIX" \
+    --output none
+fi
+
+echo "Creating Standard Static public IP '$PUBLIC_IP_NAME'..."
+az network public-ip create \
+  --resource-group "$RESOURCE_GROUP" \
+  --name "$PUBLIC_IP_NAME" \
+  --location "$LOCATION" \
+  --sku Standard \
+  --allocation-method Static \
+  --output none
+
+echo "Creating Azure Firewall '$FIREWALL_NAME'..."
+az network firewall create \
+  --resource-group "$RESOURCE_GROUP" \
+  --name "$FIREWALL_NAME" \
+  --location "$LOCATION" \
+  --output none
+
+echo "Associating firewall with VNet '$VNET_NAME' and public IP..."
+az network firewall ip-config create \
+  --resource-group "$RESOURCE_GROUP" \
+  --firewall-name "$FIREWALL_NAME" \
+  --name "${FIREWALL_NAME}-ipconfig" \
+  --vnet-name "$VNET_NAME" \
+  --public-ip-address "$PUBLIC_IP_NAME" \
+  --output none
+
+echo "Done. Azure Firewall '$FIREWALL_NAME' deployed in VNet '$VNET_NAME'."
+echo "Next steps:"
+echo "  - Add firewall rules (network/application/NAT) to permit required traffic."
+echo "  - Create a route table sending subnet traffic (0.0.0.0/0) to the firewall"
+echo "    private IP, then associate it with the workload subnets."
+echo "Verify with:"
+echo "  az network firewall show --resource-group $RESOURCE_GROUP --name $FIREWALL_NAME --output table"

--- a/scanner/azure_client.py
+++ b/scanner/azure_client.py
@@ -67,13 +67,13 @@ class AzureClient:
     ) -> Optional[bool]:
         """Check whether a storage account has a lifecycle management policy.
 
-        Three-state return — the calling rule uses strict identity checks
+        Three-state return - the calling rule uses strict identity checks
         (is False / is None) to distinguish these states:
 
-            True  — policy exists and contains at least one enabled rule.
-            False — ResourceNotFoundError: no policy configured (non-compliant).
-            None  — any other error (permissions, network, SDK bug).
-                    Caller must NOT create a finding — skip with a warning
+            True  - policy exists and contains at least one enabled rule.
+            False - ResourceNotFoundError: no policy configured (non-compliant).
+            None  - any other error (permissions, network, SDK bug).
+                    Caller must NOT create a finding - skip with a warning
                     to avoid false positives.
 
         The StorageManagementClient is created fresh here following the same
@@ -86,23 +86,23 @@ class AzureClient:
             account_name:   Name of the storage account.
 
         Returns:
-            Optional[bool] — True, False, or None as described above.
+            Optional[bool] - True, False, or None as described above.
         """
         try:
             client = StorageManagementClient(self.credential, self.subscription_id)
             policy = client.management_policies.get(
                 resource_group, account_name, "default"
             )
-            # A policy shell can exist with an empty rules list —
+            # A policy shell can exist with an empty rules list -
             # treat that the same as no policy (non-compliant).
             rules = getattr(getattr(policy, "policy", None), "rules", None)
             return bool(rules)
 
         except ResourceNotFoundError:
             # Expected path: the account genuinely has no lifecycle policy.
-            # This is the non-compliant condition — return False to flag it.
+            # This is the non-compliant condition - return False to flag it.
             logger.debug(
-                "get_storage_lifecycle_policy(%s): ResourceNotFound — no policy",
+                "get_storage_lifecycle_policy(%s): ResourceNotFound - no policy",
                 account_name,
             )
             return False
@@ -110,9 +110,9 @@ class AzureClient:
         except HttpResponseError as exc:
             # 403 = service principal lacks
             # Microsoft.Storage/storageAccounts/managementPolicies/read.
-            # Return None — cannot determine compliance, do not flag.
+            # Return None - cannot determine compliance, do not flag.
             logger.error(
-                "get_storage_lifecycle_policy(%s) HTTP %s — "
+                "get_storage_lifecycle_policy(%s) HTTP %s - "
                 "check service principal permissions: %s",
                 account_name,
                 exc.status_code,
@@ -122,7 +122,7 @@ class AzureClient:
 
         except Exception as exc:
             # Unexpected failure (network, SDK bug, etc.).
-            # Return None — skip rather than create a false positive.
+            # Return None - skip rather than create a false positive.
             logger.error(
                 "get_storage_lifecycle_policy(%s) unexpected error: %s",
                 account_name,
@@ -135,14 +135,14 @@ class AzureClient:
     ) -> Optional[bool]:
         """Check Azure Monitor diagnostic settings for a storage service sub-resource.
 
-        Three-state return — the calling rule uses strict identity checks
+        Three-state return - the calling rule uses strict identity checks
         (is False / is None) to distinguish these states:
 
-            True  — at least one diagnostic setting has StorageRead, StorageWrite,
+            True  - at least one diagnostic setting has StorageRead, StorageWrite,
                     and StorageDelete all enabled (compliant).
-            False — no setting covers all three required categories (non-compliant).
-            None  — permission error or unexpected SDK failure.
-                    Caller must NOT create a finding — skip with a warning
+            False - no setting covers all three required categories (non-compliant).
+            None  - permission error or unexpected SDK failure.
+                    Caller must NOT create a finding - skip with a warning
                     to avoid false positives.
 
         Args:
@@ -151,7 +151,7 @@ class AzureClient:
             service:        Sub-service to check: "blob", "queue", or "table".
 
         Returns:
-            Optional[bool] — True, False, or None as described above.
+            Optional[bool] - True, False, or None as described above.
         """
         _REQUIRED = {"StorageRead", "StorageWrite", "StorageDelete"}
         _SERVICE_MAP = {
@@ -162,7 +162,7 @@ class AzureClient:
         svc_path = _SERVICE_MAP.get(service)
         if not svc_path:
             logger.error(
-                "get_storage_service_logging: unknown service %r — must be "
+                "get_storage_service_logging: unknown service %r - must be "
                 "blob, queue, or table",
                 service,
             )
@@ -189,7 +189,7 @@ class AzureClient:
 
         except HttpResponseError as exc:
             logger.error(
-                "get_storage_service_logging(%s/%s) HTTP %s — "
+                "get_storage_service_logging(%s/%s) HTTP %s - "
                 "check service principal permissions: %s",
                 account_name,
                 service,
@@ -257,6 +257,24 @@ class AzureClient:
         except Exception as exc:
             logger.error("get_azure_firewalls(%s) failed: %s", resource_group, exc)
             return []
+
+    def get_all_azure_firewalls(self) -> Optional[List[Any]]:
+        """List all Azure Firewalls in the subscription.
+
+        Three-state return - the calling rule distinguishes these states:
+
+            [...] - successful listing (may be empty: genuinely no firewalls).
+            None  - listing failed (permissions, network, SDK error). The
+                    caller must NOT flag VNets as non-compliant, since it
+                    cannot tell which VNets are protected - skip to avoid
+                    false positives.
+        """
+        try:
+            client = NetworkManagementClient(self.credential, self.subscription_id)
+            return list(client.azure_firewalls.list_all())
+        except Exception as exc:
+            logger.error("get_all_azure_firewalls failed: %s", exc)
+            return None
 
     def get_vnet_peerings(self, resource_group: str, vnet_name: str) -> List[Any]:
         """List all peering connections for a Virtual Network."""
@@ -378,12 +396,12 @@ class AzureClient:
 
         Three-state return:
 
-            True  — at least one diagnostic log category is enabled.
-            False — no diagnostic settings exist or all logs are disabled.
-            None  — unable to determine status due to permissions/API failure.
+            True  - at least one diagnostic log category is enabled.
+            False - no diagnostic settings exist or all logs are disabled.
+            None  - unable to determine status due to permissions/API failure.
 
         Returns:
-            Optional[bool] — True, False, or None as described above.
+            Optional[bool] - True, False, or None as described above.
         """
         try:
             client = MonitorManagementClient(

--- a/scanner/rules/az_net_013.py
+++ b/scanner/rules/az_net_013.py
@@ -1,0 +1,81 @@
+"""AZ-NET-013: Azure Firewall not enabled on Virtual Network."""
+
+import logging
+from typing import Any, Dict, List
+
+RULE_ID = "AZ-NET-013"
+RULE_NAME = "Azure Firewall Not Enabled on Virtual Network"
+SEVERITY = "HIGH"
+CATEGORY = "Network"
+FRAMEWORKS = {
+    "CIS": "6.4",
+    "NIST": "PR.AC-5",
+    "ISO27001": "A.13.1.1",
+    "SOC2": "CC6.6",
+}
+DESCRIPTION = (
+    "The virtual network has no Azure Firewall deployed or associated. "
+    "Relying only on Network Security Groups leaves the network without a "
+    "centralized perimeter inspection, logging, and threat-filtering layer. "
+    "Azure Firewall provides stateful traffic inspection, FQDN filtering, "
+    "threat intelligence, and centralized network logging that NSGs alone "
+    "cannot offer."
+)
+REMEDIATION = (
+    "Deploy an Azure Firewall into an 'AzureFirewallSubnet' within the "
+    "virtual network (or a peered hub network) and route traffic through it. "
+    "See playbooks/cli/fix_az_net_013.sh for the Azure CLI steps."
+)
+PLAYBOOK = "playbooks/cli/fix_az_net_013.sh"
+
+logger = logging.getLogger(__name__)
+
+
+def scan(azure_client: Any, subscription_id: str) -> List[Dict[str, Any]]:
+    """Detect virtual networks that have no Azure Firewall associated."""
+    findings: List[Dict[str, Any]] = []
+
+    firewalls = azure_client.get_all_azure_firewalls()
+    # None means the firewall listing failed (permissions/SDK error). Without
+    # it we cannot tell which VNets are protected, so skip to avoid flagging
+    # every VNet as a false positive.
+    if firewalls is None:
+        logger.warning(
+            "AZ-NET-013 skipped: unable to list Azure Firewalls - "
+            "cannot determine VNet protection status."
+        )
+        return findings
+
+    protected_vnet_ids = set()
+    for firewall in firewalls:
+        for ip_config in getattr(firewall, "ip_configurations", None) or []:
+            subnet = getattr(ip_config, "subnet", None)
+            subnet_id = getattr(subnet, "id", "") or ""
+            if "/subnets/" in subnet_id:
+                vnet_id = subnet_id.rsplit("/subnets/", 1)[0]
+                protected_vnet_ids.add(vnet_id.lower())
+
+    for vnet in azure_client.get_virtual_networks():
+        vnet_id = getattr(vnet, "id", "") or ""
+        if vnet_id.lower() in protected_vnet_ids:
+            continue
+        parsed = azure_client.parse_resource_id(vnet_id)
+        findings.append({
+            "rule_id": RULE_ID,
+            "rule_name": RULE_NAME,
+            "severity": SEVERITY,
+            "category": CATEGORY,
+            "resource_id": vnet_id,
+            "resource_name": getattr(vnet, "name", ""),
+            "resource_type": "Microsoft.Network/virtualNetworks",
+            "description": DESCRIPTION,
+            "remediation": REMEDIATION,
+            "playbook": PLAYBOOK,
+            "frameworks": FRAMEWORKS,
+            "metadata": {
+                "location": getattr(vnet, "location", ""),
+                "resource_group": parsed.get("resource_group", ""),
+            },
+        })
+
+    return findings


### PR DESCRIPTION
## Summary

- Adds scanner rule **AZ-NET-013** (`scanner/rules/az_net_013.py`) to detect Azure Virtual Networks that have no Azure Firewall deployed or associated, flagging them as HIGH severity.
- Adds `get_all_azure_firewalls()` to `AzureClient` (`scanner/azure_client.py`) using `azure_firewalls.list_all()` for subscription-wide enumeration; returns `None` on SDK/permission failure so the rule skips rather than false-positive every VNet.
- Adds CLI remediation playbook `playbooks/cli/fix_az_net_013.sh` with Azure CLI steps to deploy a firewall into the VNet.
- Adds `AZ-NET-013` compliance mappings across all four frameworks: CIS 6.4, NIST PR.AC-5, ISO 27001 A.13.1.1, SOC 2 CC6.6.

## Detection logic

A VNet is considered protected if any Azure Firewall's `ip_configurations[].subnet.id` resolves to a subnet within that VNet. This is hub-spoke aware — a firewall in a different resource group still counts. If the firewall listing call fails, the rule logs a warning and emits no findings to avoid false positives.

## Test plan

- [ ] `python -m py_compile scanner/rules/az_net_013.py` — passes
- [ ] `python -m py_compile scanner/azure_client.py` — passes
- [ ] `bash -n playbooks/cli/fix_az_net_013.sh` — passes
- [ ] `python -m json.tool` on all four compliance JSONs — passes
- [ ] `pytest -q` — 15 passed, no regressions
- [ ] Manual: run a real scan against a subscription with a firewall-protected VNet and an NSG-only VNet; confirm only the NSG-only VNet produces an AZ-NET-013 finding
- [ ] Manual: confirm rule emits no findings when the service principal lacks `Microsoft.Network/azureFirewalls/read`

Closes #91