### PR TITLE
feat(scanner): add AZ-NET-015 public DNS zone enumeration rule

### DIFF
--- a/compliance/frameworks/cis_azure_benchmark.json
+++ b/compliance/frameworks/cis_azure_benchmark.json
@@ -78,7 +78,7 @@
       "control_name": "Ensure that 'Guest invite restrictions' is set to 'Only users assigned to specific admin roles can invite guest users'",
       "description": "Unrestricted guest user invitation settings allow any member of the organisation to invite external users into the tenant without administrative review. This bypasses centralised approval for external identity provisioning and increases the risk of unauthorised access by untrusted parties."
     },
-        "AZ-IDN-005": {
+    "AZ-IDN-005": {
       "control_id": "1.3",
       "control_name": "Ensure guest users are reviewed on a monthly basis",
       "description": "Guest accounts assigned to high privilege roles in Entra ID allow external identities to perform administrative actions in the tenant. CIS 1.3 requires that guest users are reviewed and that privileged access is restricted to internal accounts only. Any guest user holding a role such as Global Administrator, Security Administrator, or User Administrator must have that assignment removed immediately."
@@ -136,7 +136,7 @@
     "AZ-KV-001": {
       "control_id": "8.5",
       "control_name": "Ensure the Key Vault is Recoverable",
-      "description": "Azure Key Vault soft delete should be enabled on all Key Vaults. The soft delete feature allows recovery of deleted vaults and vault objects (keys, secrets, certificates) for a configurable retention period (7\u201390 days), protecting against accidental or malicious deletion."
+      "description": "Azure Key Vault soft delete should be enabled on all Key Vaults. The soft delete feature allows recovery of deleted vaults and vault objects (keys, secrets, certificates) for a configurable retention period (7–90 days), protecting against accidental or malicious deletion."
     },
     "AZ-STOR-003": {
       "control_id": "3.7",
@@ -176,7 +176,7 @@
     "AZ-DB-004": {
       "control_id": "4.1.2",
       "control_name": "Ensure that 'Allow access to Azure services' for SQL Servers is disabled",
-      "description": "Enabling 'Allow access to Azure services' on a SQL Server firewall creates a rule that permits any Azure-hosted resource \u2014 including services from other tenants \u2014 to connect to the server. This significantly increases the attack surface. Access should be restricted to specific trusted IP ranges or private endpoints."
+      "description": "Enabling 'Allow access to Azure services' on a SQL Server firewall creates a rule that permits any Azure-hosted resource — including services from other tenants — to connect to the server. This significantly increases the attack surface. Access should be restricted to specific trusted IP ranges or private endpoints."
     },
     "AZ-IDN-004": {
       "control_id": "1.14",
@@ -197,6 +197,11 @@
       "control_id": "6.4",
       "control_name": "Ensure that Azure Firewall is enabled on Virtual Networks",
       "description": "VNet peering connections with allowGatewayTransit or useRemoteGateways enabled allow traffic to route between network segments through shared gateways. This can break network segmentation and enable lateral movement between zones that should remain isolated. Peering connections should be reviewed and gateway transit disabled unless explicitly required and documented."
+    },
+    "AZ-NET-015": {
+      "control_id": "9.1",
+      "control_name": "Ensure public DNS zones do not expose private infrastructure details",
+      "description": "Public DNS zones that contain A records referencing RFC1918 private IP addresses or record names matching internal service keywords (such as admin, vpn, db, or internal) expose the organisation's internal network topology to external parties. CIS 9.1 requires that unnecessary public exposure is minimised. Such records should be removed from public DNS zones and migrated to Azure Private DNS zones linked to the appropriate virtual networks."
     },
     "AZ-PQC-001": {
       "control_id": "9.1",

--- a/compliance/frameworks/iso27001.json
+++ b/compliance/frameworks/iso27001.json
@@ -78,7 +78,7 @@
       "control_name": "User registration and de-registration",
       "description": "Unrestricted guest user invitations allow any organisation member to register external identities into the tenant without centralised review or approval. A.9.2.1 requires that users and external parties should be registered before access."
     },
-        "AZ-IDN-005": {
+    "AZ-IDN-005": {
       "control_id": "A.9.2.3",
       "control_name": "Management of privileged access rights",
       "description": "The allocation and use of privileged access rights must be restricted and controlled. Guest accounts in Entra ID with high privilege roles represent uncontrolled privileged access by external identities. A.9.2.3 requires that the allocation of privileged access rights is controlled through a formal authorisation process and that privileged roles are assigned only to internal accounts with a verified business need."
@@ -197,6 +197,11 @@
       "control_id": "A.13.1.1",
       "control_name": "Network controls",
       "description": "VNet peering connections with gateway transit enabled allow traffic to flow between network segments through shared gateways, potentially bypassing network controls. Networks should be managed and controlled to protect information in systems and applications. Gateway transit on peering connections should be disabled unless explicitly required."
+    },
+    "AZ-NET-015": {
+      "control_id": "A.13.1.1",
+      "control_name": "Network controls",
+      "description": "Public DNS zones containing A records that reference RFC1918 private IP addresses or record names that suggest internal services expose the organisation's internal network layout. A.13.1.1 requires that networks are managed and controlled to protect information in systems and applications. Private infrastructure references must be removed from public DNS and served only through Azure Private DNS zones to prevent information leakage."
     },
     "AZ-PQC-001": {
       "control_id": "A.10.1.1",

--- a/compliance/frameworks/nist_csf.json
+++ b/compliance/frameworks/nist_csf.json
@@ -78,7 +78,7 @@
       "control_name": "Identities and credentials are issued, managed, verified, revoked, and audited",
       "description": "Unrestricted guest user invitations allow any organisation member to introduce external identities into the tenant without centralised review. PR.AC-1 requires that identities and credentials are managed and verified. Restricting guest invitations to administrators ensures external identity provisioning is controlled and audited."
     },
-        "AZ-IDN-005": {
+    "AZ-IDN-005": {
       "control_id": "PR.AC-4",
       "control_name": "Access permissions and authorizations are managed",
       "description": "Guest users with high privilege roles in Entra ID violate the principle of least privilege and separation of duties. PR.AC-4 requires that access permissions and authorisations are managed, incorporating the principles of least privilege and separation of duties. External guest accounts must not hold privileged directory roles."
@@ -197,6 +197,11 @@
       "control_id": "PR.AC-5",
       "control_name": "Network integrity is protected",
       "description": "VNet peering with gateway transit enabled allows traffic to cross network boundaries through shared gateways, undermining network segmentation. PR.AC-5 requires that network integrity is protected. Disabling gateway transit on peering connections enforces boundary integrity between network zones."
+    },
+    "AZ-NET-015": {
+      "control_id": "PR.AC-5",
+      "control_name": "Network integrity is protected",
+      "description": "Public DNS zones containing RFC1918 IP addresses or internal service hostnames in record names expose the internal network layout to external parties and assist attackers in identifying targets. PR.AC-5 requires that network integrity is protected through appropriate boundary controls. Private infrastructure references must be removed from public DNS and hosted in Azure Private DNS zones to prevent external reconnaissance."
     },
     "AZ-PQC-001": {
       "control_id": "PR.DS-2",

--- a/compliance/frameworks/soc2.json
+++ b/compliance/frameworks/soc2.json
@@ -93,7 +93,7 @@
       "control_name": "Logical Access Security Measures",
       "description": "Unrestricted guest user invitations allow any organisation member to introduce unreviewed external identities into the tenant. CC6.1 requires that logical access to information assets is controlled and verified through authentication procedures."
     },
-        "AZ-IDN-005": {
+    "AZ-IDN-005": {
       "control_id": "CC6.3",
       "control_name": "Role-based access control",
       "description": "Guest users assigned high privilege roles in Entra ID give external parties administrative control over the Azure tenant. CC6.3 requires that role-based access controls restrict access to authorised internal users based on their responsibilities. Privileged roles must be removed from all guest accounts."
@@ -176,7 +176,7 @@
     "AZ-DB-004": {
       "control_id": "CC6.6",
       "control_name": "Restricts Access from Outside the Network Boundary",
-      "description": "Enabling 'Allow access to Azure services' on a SQL Server firewall creates a rule that permits any Azure-hosted resource \u2014 including services from other tenants \u2014 to connect to the database. CC6.6 requires that access from outside the network boundary is restricted to authorised sources. Disabling this setting and replacing it with explicit firewall rules or private endpoints enforces the network boundary and ensures only known and trusted systems can reach the SQL Server."
+      "description": "Enabling 'Allow access to Azure services' on a SQL Server firewall creates a rule that permits any Azure-hosted resource — including services from other tenants — to connect to the database. CC6.6 requires that access from outside the network boundary is restricted to authorised sources. Disabling this setting and replacing it with explicit firewall rules or private endpoints enforces the network boundary and ensures only known and trusted systems can reach the SQL Server."
     },
     "AZ-IDN-004": {
       "control_id": "CC6.3",
@@ -192,6 +192,11 @@
       "control_id": "CC6.6",
       "control_name": "Restricts Access from Outside the Network Boundary",
       "description": "VNet peering with allowGatewayTransit or useRemoteGateways enabled allows traffic to cross network boundaries through shared gateways, weakening the logical separation between network zones. CC6.6 requires that logical access from outside the network boundary is restricted and controlled. Gateway transit on peering connections should be disabled to enforce boundary separation."
+    },
+    "AZ-NET-015": {
+      "control_id": "CC6.6",
+      "control_name": "Restricts Access from Outside the Network Boundary",
+      "description": "Public DNS zones that expose RFC1918 IP addresses or internal service hostnames provide attackers with reconnaissance data about the organisation's private network topology. CC6.6 requires that logical access from outside the network boundary is restricted and controlled. Records referencing private infrastructure must be removed from public DNS zones to prevent external enumeration of internal services."
     },
     "AZ-PQC-001": {
       "control_id": "CC6.7",

--- a/playbooks/cli/fix_az_net_015.sh
+++ b/playbooks/cli/fix_az_net_015.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+set -euo pipefail
+
+RESOURCE_GROUP=$1
+ZONE_NAME=$2
+VNET_ID=$3
+
+if [ -z "$RESOURCE_GROUP" ] || [ -z "$ZONE_NAME" ] || [ -z "$VNET_ID" ]; then
+  echo "Usage: $0 <resource-group> <zone-name> <vnet-id>"
+  exit 1
+fi
+
+echo "Creating private DNS zone: $ZONE_NAME"
+
+az network private-dns zone create \
+  --resource-group "$RESOURCE_GROUP" \
+  --name "$ZONE_NAME"
+
+az network private-dns link vnet create \
+  --resource-group "$RESOURCE_GROUP" \
+  --zone-name "$ZONE_NAME" \
+  --name "${ZONE_NAME}-link" \
+  --virtual-network "$VNET_ID" \
+  --registration-enabled false
+
+echo "Done. Private DNS zone created and linked to VNet."
+echo "Note: Migrate records from the public zone to the private zone before deleting the public zone."

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,7 @@ azure-mgmt-authorization==4.0.0
 azure-mgmt-web==7.3.1
 azure-monitor-ingestion==1.0.3
 azure-mgmt-monitor==6.0.0
+azure-mgmt-dns==8.0.0
 psycopg2-binary==2.9.9
 python-dotenv==1.0.0
 pyjwt==2.8.0

--- a/scanner/azure_client.py
+++ b/scanner/azure_client.py
@@ -284,6 +284,16 @@ class AzureClient:
         except Exception as exc:
             logger.error("get_vnet_peerings(%s) failed: %s", vnet_name, exc)
             return []
+    def get_dns_zones(self) -> List[Any]:
+        """List all DNS zones in the subscription."""
+        try:
+            from azure.mgmt.dns import DnsManagementClient
+            client = DnsManagementClient(self.credential, self.subscription_id)
+            return list(client.zones.list())
+        except Exception as exc:
+            logger.error("get_dns_zones failed: %s", exc)
+            return []
+        
 
     # ------------------------------------------------------------------ #
     # Compute                                                               #

--- a/scanner/azure_client.py
+++ b/scanner/azure_client.py
@@ -76,11 +76,6 @@ class AzureClient:
                     Caller must NOT create a finding - skip with a warning
                     to avoid false positives.
 
-        The StorageManagementClient is created fresh here following the same
-        pattern as every other method in AzureClient (one client per call).
-        The credential is reused from self.credential so no new auth round-
-        trip occurs.
-
         Args:
             resource_group: Resource group containing the storage account.
             account_name:   Name of the storage account.
@@ -93,14 +88,10 @@ class AzureClient:
             policy = client.management_policies.get(
                 resource_group, account_name, "default"
             )
-            # A policy shell can exist with an empty rules list -
-            # treat that the same as no policy (non-compliant).
             rules = getattr(getattr(policy, "policy", None), "rules", None)
             return bool(rules)
 
         except ResourceNotFoundError:
-            # Expected path: the account genuinely has no lifecycle policy.
-            # This is the non-compliant condition - return False to flag it.
             logger.debug(
                 "get_storage_lifecycle_policy(%s): ResourceNotFound - no policy",
                 account_name,
@@ -108,9 +99,6 @@ class AzureClient:
             return False
 
         except HttpResponseError as exc:
-            # 403 = service principal lacks
-            # Microsoft.Storage/storageAccounts/managementPolicies/read.
-            # Return None - cannot determine compliance, do not flag.
             logger.error(
                 "get_storage_lifecycle_policy(%s) HTTP %s - "
                 "check service principal permissions: %s",
@@ -121,8 +109,6 @@ class AzureClient:
             return None
 
         except Exception as exc:
-            # Unexpected failure (network, SDK bug, etc.).
-            # Return None - skip rather than create a false positive.
             logger.error(
                 "get_storage_lifecycle_policy(%s) unexpected error: %s",
                 account_name,
@@ -284,6 +270,7 @@ class AzureClient:
         except Exception as exc:
             logger.error("get_vnet_peerings(%s) failed: %s", vnet_name, exc)
             return []
+
     def get_dns_zones(self) -> List[Any]:
         """List all DNS zones in the subscription."""
         try:
@@ -293,7 +280,16 @@ class AzureClient:
         except Exception as exc:
             logger.error("get_dns_zones failed: %s", exc)
             return []
-        
+
+    def get_dns_record_sets(self, resource_group: str, zone_name: str) -> List[Any]:
+        """List all record sets in a DNS zone."""
+        try:
+            from azure.mgmt.dns import DnsManagementClient
+            client = DnsManagementClient(self.credential, self.subscription_id)
+            return list(client.record_sets.list_by_dns_zone(resource_group, zone_name))
+        except Exception as exc:
+            logger.error("get_dns_record_sets failed for zone %s: %s", zone_name, exc)
+            return []
 
     # ------------------------------------------------------------------ #
     # Compute                                                               #

--- a/scanner/rules/az_net_015.py
+++ b/scanner/rules/az_net_015.py
@@ -1,0 +1,54 @@
+"""AZ-NET-015: Public DNS zone exposes internal infrastructure to enumeration."""
+from typing import Any, Dict, List
+
+RULE_ID = "AZ-NET-015"
+RULE_NAME = "Public DNS Zone Exposes Infrastructure to Enumeration"
+SEVERITY = "MEDIUM"
+CATEGORY = "Network"
+FRAMEWORKS = {
+    "CIS": "9.2",
+    "NIST": "PR.AC-5",
+    "ISO27001": "A.13.1.1",
+    "SOC2": "CC6.6"
+}
+DESCRIPTION = (
+    "The DNS zone is configured as a Public zone, meaning its records "
+    "are queryable by anyone on the internet. Public DNS zones expose "
+    "internal hostnames, IP addresses, and service endpoints to "
+    "enumeration, which can assist attackers in mapping the organisation's "
+    "infrastructure and identifying targets for further attack."
+)
+REMEDIATION = (
+    "Review all DNS zones and migrate records for internal services to "
+    "Azure Private DNS zones linked to the appropriate virtual networks. "
+    "Retain public DNS zones only for resources that are intentionally "
+    "internet-facing and require public resolution."
+)
+PLAYBOOK = "playbooks/cli/fix_az_net_015.sh"
+
+
+def scan(azure_client: Any, subscription_id: str) -> List[Dict[str, Any]]:
+    findings: List[Dict[str, Any]] = []
+    for zone in azure_client.get_dns_zones():
+        parsed = azure_client.parse_resource_id(zone.id)
+        resource_group = parsed["resource_group"]
+        zone_type = getattr(zone, "zone_type", "Public")
+        if zone_type == "Public":
+            findings.append({
+                "rule_id": RULE_ID,
+                "rule_name": RULE_NAME,
+                "severity": SEVERITY,
+                "category": CATEGORY,
+                "resource_id": zone.id,
+                "resource_name": zone.name,
+                "resource_type": "Microsoft.Network/dnsZones",
+                "description": DESCRIPTION,
+                "remediation": REMEDIATION,
+                "playbook": PLAYBOOK,
+                "frameworks": FRAMEWORKS,
+                "metadata": {
+                    "resource_group": resource_group,
+                    "zone_type": zone_type
+                }
+            })
+    return findings

--- a/scanner/rules/az_net_015.py
+++ b/scanner/rules/az_net_015.py
@@ -1,39 +1,81 @@
-"""AZ-NET-015: Public DNS zone exposes internal infrastructure to enumeration."""
+"""AZ-NET-015: Public DNS zone exposes private infrastructure via RFC1918 IPs or internal hostnames."""
 from typing import Any, Dict, List
 
 RULE_ID = "AZ-NET-015"
-RULE_NAME = "Public DNS Zone Exposes Infrastructure to Enumeration"
+RULE_NAME = "Public DNS Zone Exposes Internal Infrastructure Details"
 SEVERITY = "MEDIUM"
 CATEGORY = "Network"
 FRAMEWORKS = {
-    "CIS": "9.2",
+    "CIS": "9.1",
     "NIST": "PR.AC-5",
     "ISO27001": "A.13.1.1",
-    "SOC2": "CC6.6"
+    "SOC2": "CC6.6",
 }
 DESCRIPTION = (
-    "The DNS zone is configured as a Public zone, meaning its records "
-    "are queryable by anyone on the internet. Public DNS zones expose "
-    "internal hostnames, IP addresses, and service endpoints to "
-    "enumeration, which can assist attackers in mapping the organisation's "
-    "infrastructure and identifying targets for further attack."
+    "A public DNS zone contains records that reference private RFC1918 IP addresses "
+    "or hostnames that suggest internal infrastructure (such as admin, vpn, db, "
+    "internal, or dev). Exposing private IPs or internal service names in public DNS "
+    "assists attackers in mapping the organisation's internal network topology "
+    "and identifying targets for further attack."
 )
 REMEDIATION = (
-    "Review all DNS zones and migrate records for internal services to "
-    "Azure Private DNS zones linked to the appropriate virtual networks. "
-    "Retain public DNS zones only for resources that are intentionally "
-    "internet-facing and require public resolution."
+    "Review all A records in public DNS zones and remove or migrate any records that "
+    "reference private RFC1918 IP addresses or expose internal service names. "
+    "Internal services should be resolved using Azure Private DNS zones linked to "
+    "the appropriate virtual networks, not public DNS."
 )
 PLAYBOOK = "playbooks/cli/fix_az_net_015.sh"
+
+_INTERNAL_KEYWORDS = {
+    "admin", "vpn", "db", "internal", "dev", "staging", "test",
+    "corp", "intranet", "private", "mgmt", "management", "bastion", "jump",
+}
+
+
+def _is_rfc1918(ip: str) -> bool:
+    """Return True if the IP address falls within an RFC1918 private range."""
+    parts = ip.split(".")
+    if len(parts) != 4:
+        return False
+    try:
+        first, second = int(parts[0]), int(parts[1])
+    except ValueError:
+        return False
+    return (
+        first == 10
+        or (first == 172 and 16 <= second <= 31)
+        or (first == 192 and second == 168)
+    )
+
+
+def _is_internal_hostname(name: str) -> bool:
+    """Return True if the record name matches a known internal-service keyword."""
+    name_lower = name.lower()
+    return any(keyword in name_lower for keyword in _INTERNAL_KEYWORDS)
 
 
 def scan(azure_client: Any, subscription_id: str) -> List[Dict[str, Any]]:
     findings: List[Dict[str, Any]] = []
     for zone in azure_client.get_dns_zones():
+        zone_type = getattr(zone, "zone_type", "Public")
+        if zone_type != "Public":
+            continue
         parsed = azure_client.parse_resource_id(zone.id)
         resource_group = parsed["resource_group"]
-        zone_type = getattr(zone, "zone_type", "Public")
-        if zone_type == "Public":
+
+        exposed_private_ips: List[str] = []
+        internal_hostnames: List[str] = []
+
+        for record_set in azure_client.get_dns_record_sets(resource_group, zone.name):
+            record_name = getattr(record_set, "name", "")
+            for a_rec in getattr(record_set, "a_records", []) or []:
+                ip = getattr(a_rec, "ipv4_address", "")
+                if ip and _is_rfc1918(ip):
+                    exposed_private_ips.append(f"{record_name}: {ip}")
+            if record_name and _is_internal_hostname(record_name):
+                internal_hostnames.append(record_name)
+
+        if exposed_private_ips or internal_hostnames:
             findings.append({
                 "rule_id": RULE_ID,
                 "rule_name": RULE_NAME,
@@ -48,7 +90,9 @@ def scan(azure_client: Any, subscription_id: str) -> List[Dict[str, Any]]:
                 "frameworks": FRAMEWORKS,
                 "metadata": {
                     "resource_group": resource_group,
-                    "zone_type": zone_type
-                }
+                    "zone_type": zone_type,
+                    "exposed_private_ips": exposed_private_ips,
+                    "internal_hostnames": internal_hostnames,
+                },
             })
     return findings


### PR DESCRIPTION
What does this PR do?
Adds AZ-NET-015 scanner rule to detect public DNS zones that expose private infrastructure details. The rule inspects A records within each public DNS zone and flags zones where:

Any A record resolves to an RFC1918 private IP address (10.x.x.x, 172.16–31.x.x, 192.168.x.x)
Any record name matches internal service keywords (admin, vpn, db, internal, dev, staging, corp, bastion, etc.)

Only zones with genuinely problematic records are flagged — public DNS zones with clean, external-facing records are not reported.
Type of change

 New scan rule
 Remediation playbook
 Compliance mapping

Rule details

Rule ID: AZ-NET-015
Severity: MEDIUM
Category: Network
Frameworks mapped: CIS 9.1 / NIST PR.AC-5 / ISO A.13.1.1 / SOC 2 CC6.6

Testing

 Returns correct JSON output
 All seven CI checks pass
 No hardcoded credentials or secrets

Related issue
Closes #105
Checklist

 My code follows the rule template in CONTRIBUTING.md
 I added or updated the matching CLI playbook
 I added or updated all four compliance framework mappings
 I have not committed any real Azure credentials