### PR TITLE
  fix(scanner): improve AZ-NET-008 with SOC2 mapping and azure_client abstraction

### DIFF
--- a/scanner/azure_client.py
+++ b/scanner/azure_client.py
@@ -270,6 +270,14 @@ class AzureClient:
         except Exception as exc:
             logger.error("get_vnet_peerings(%s) failed: %s", vnet_name, exc)
             return []
+    def get_load_balancers(self) -> List[Any]:
+        """List all load balancers in the subscription."""
+        try:
+            client = NetworkManagementClient(self.credential, self.subscription_id)
+            return list(client.load_balancers.list_all())
+        except Exception as exc:
+            logger.error("get_load_balancers failed: %s", exc)
+            return []
 
     def get_dns_zones(self) -> List[Any]:
         """List all DNS zones in the subscription."""

--- a/scanner/rules/az_net_008.py
+++ b/scanner/rules/az_net_008.py
@@ -7,7 +7,7 @@ RULE_ID = "AZ-NET-008"
 RULE_NAME = "Load balancer with no backend pool configured"
 SEVERITY = "LOW"
 CATEGORY = "Network"
-FRAMEWORKS = {"CIS": "9.1", "NIST": "CM-7", "ISO27001": "A.13.1.1"}
+FRAMEWORKS = {"CIS": "9.1", "NIST": "CM-7", "ISO27001": "A.13.1.1", "SOC2": "CC8.1"}
 DESCRIPTION = (
     "A load balancer exists in the subscription but has no backend pool "
     "configured. A load balancer with no backend pool is either misconfigured "
@@ -28,19 +28,11 @@ def scan(azure_client: Any, subscription_id: str) -> List[Dict[str, Any]]:
     """Detect load balancers with no backend pool configured."""
     findings: List[Dict[str, Any]] = []
 
-    try:
-        from azure.mgmt.network import NetworkManagementClient
-        client = NetworkManagementClient(
-            azure_client.credential, azure_client.subscription_id
-        )
-        load_balancers = list(client.load_balancers.list_all())
-    except Exception as exc:
-        logger.error("Failed to list load balancers: %s", exc)
-        return findings
-
-    for lb in load_balancers:
+    for lb in azure_client.get_load_balancers():
         backend_pools = getattr(lb, "backend_address_pools", []) or []
         if len(backend_pools) == 0:
+            parsed = azure_client.parse_resource_id(getattr(lb, "id", ""))
+            resource_group = parsed.get("resource_group", "")
             findings.append({
                 "rule_id": RULE_ID,
                 "rule_name": RULE_NAME,
@@ -56,6 +48,7 @@ def scan(azure_client: Any, subscription_id: str) -> List[Dict[str, Any]]:
                 "metadata": {
                     "location": getattr(lb, "location", ""),
                     "backend_pool_count": len(backend_pools),
+                    "resource_group": resource_group,
                 },
             })
 


### PR DESCRIPTION
What does this PR do?
Improves the existing AZ-NET-008 rule rather than adding a duplicate AZ-NET-016 rule, as identified in review.
Changes

Adds missing SOC2: CC8.1 to the FRAMEWORKS dict in az_net_008.py (the entry already existed in soc2.json but was absent from the Python rule)
Refactors the scan function to use azure_client.get_load_balancers() for consistency with the project's abstraction pattern
Adds resource_group to the metadata output
Removes the duplicate az_net_016.py rule and its playbook

Type of change

 Bug fix / improvement to existing rule

Testing

 Returns correct JSON output
 All seven CI checks pass
 No hardcoded credentials or secrets