### PR TITLE
fix(compliance): align rule reference and framework mappings

### DIFF
--- a/compliance/frameworks/cis_azure_benchmark.json
+++ b/compliance/frameworks/cis_azure_benchmark.json
@@ -158,10 +158,20 @@
       "control_name": "Ensure that public network access to Key Vault is disabled",
       "description": "Azure Key Vault should not allow public network access unless absolutely necessary. Enabling public access increases the attack surface and exposes sensitive secrets, keys, and certificates to potential unauthorized access. Private endpoints should be used to restrict access to trusted networks."
     },
+    "AZ-KV-003": {
+      "control_id": "8.4",
+      "control_name": "Ensure that logging is enabled for Azure Key Vault",
+      "description": "Azure Key Vault diagnostic logging should be enabled so access to secrets, keys, and certificates is recorded. Without diagnostic logs, unauthorized access attempts and destructive operations cannot be investigated effectively."
+    },
     "AZ-NET-011": {
       "control_id": "6.5",
       "control_name": "Ensure that Network Watcher is enabled in all regions",
       "description": "Network Watcher should be enabled in all regions where Azure resources are deployed. Network Watcher provides network monitoring, diagnostics, and logging capabilities essential for investigating network-level incidents."
+    },
+    "AZ-NET-012": {
+      "control_id": "6.5",
+      "control_name": "Ensure that Network Watcher flow logs are enabled for Network Security Groups",
+      "description": "Network Security Group flow logs should be enabled through Network Watcher so network traffic can be audited and investigated. Without flow logs, lateral movement and suspicious network activity cannot be reconstructed."
     },
     "AZ-DB-003": {
       "control_id": "4.3.6",

--- a/compliance/frameworks/iso27001.json
+++ b/compliance/frameworks/iso27001.json
@@ -158,10 +158,20 @@
       "control_name": "Network controls",
       "description": "Networks should be managed and controlled to protect information systems and applications. Allowing public network access to Azure Key Vault increases exposure of sensitive cryptographic material."
     },
+    "AZ-KV-003": {
+      "control_id": "A.12.4.1",
+      "control_name": "Event logging",
+      "description": "Azure Key Vault diagnostic logging records access to secrets, keys, and certificates. Event logs recording security-relevant activities should be produced, kept, and reviewed to support monitoring and investigation."
+    },
     "AZ-NET-011": {
       "control_id": "A.12.4.1",
       "control_name": "Event logging",
       "description": "Network Watcher must be enabled in all regions where resources are deployed to ensure network events are logged and available for investigation. Event logs recording network activities should be produced and kept available."
+    },
+    "AZ-NET-012": {
+      "control_id": "A.12.4.1",
+      "control_name": "Event logging",
+      "description": "Network Security Group flow logs record network traffic activity for investigation and monitoring. Without flow logs, event records needed to reconstruct suspicious network activity are not produced."
     },
     "AZ-DB-003": {
       "control_id": "A.10.1.1",

--- a/compliance/frameworks/nist_csf.json
+++ b/compliance/frameworks/nist_csf.json
@@ -143,6 +143,11 @@
       "control_name": "Remote access",
       "description": "Key Vaults that allow public network access expose sensitive secrets, keys, and certificates to remote access attempts from outside trusted networks. Restricting access through private endpoints or trusted networks helps manage remote access paths."
     },
+    "AZ-KV-003": {
+      "control_id": "DE.CM-7",
+      "control_name": "Monitoring for unauthorized personnel, connections, devices, and software is performed",
+      "description": "Key Vault diagnostic logs provide the audit trail needed to monitor access to secrets, keys, and certificates. Without logging, unauthorized access and destructive changes cannot be detected or investigated."
+    },
     "AZ-STOR-003": {
       "control_id": "PR.DS-3",
       "control_name": "Assets are formally managed throughout removal, transfers, and disposition",
@@ -162,6 +167,11 @@
       "control_id": "DE.CM-7",
       "control_name": "Monitoring for unauthorized personnel, connections, devices, and software is performed",
       "description": "Network Watcher must be enabled in all active regions to support continuous monitoring of network activity. Without it, unauthorized connections and anomalous network behaviour cannot be detected or investigated."
+    },
+    "AZ-NET-012": {
+      "control_id": "DE.CM-1",
+      "control_name": "The network is monitored to detect potential cybersecurity events",
+      "description": "Network Security Group flow logs provide visibility into network traffic patterns and blocked or allowed flows. Without flow logs, potential cybersecurity events in network traffic cannot be detected or reconstructed."
     },
     "AZ-DB-003": {
       "control_id": "PR.DS-2",

--- a/compliance/frameworks/soc2.json
+++ b/compliance/frameworks/soc2.json
@@ -138,6 +138,11 @@
       "control_name": "Protects Data in Transit and At Rest",
       "description": "Virtual machine OS and data disks are using platform-managed encryption only (EncryptionAtRestWithPlatformKey). CC6.7 requires that data is protected using encryption. Platform-managed keys lack customer control and audit capabilities needed for compliance."
     },
+    "AZ-CMP-003": {
+      "control_id": "CC6.8",
+      "control_name": "Prevents or Detects Unauthorized Software",
+      "description": "Virtual machines without recognized endpoint protection lack controls to prevent, detect, and act upon malicious software. CC6.8 requires controls that address the introduction of unauthorized or malicious software on systems."
+    },
     "AZ-CMP-004": {
       "control_id": "CC7.1",
       "control_name": "System Vulnerabilities are Identified and Managed",
@@ -153,10 +158,20 @@
       "control_name": "Restricts Access from Outside the Network Boundary",
       "description": "A Key Vault accessible from the public internet allows any external party to attempt access to secrets, keys and certificates. CC6.6 requires that access from outside the network boundary is restricted. Network rules should deny public access."
     },
+    "AZ-KV-003": {
+      "control_id": "CC7.2",
+      "control_name": "System monitoring",
+      "description": "Key Vault diagnostic logging supports monitoring of access to secrets, keys, and certificates. Without diagnostic logs, unauthorized activity cannot be detected, investigated, or escalated through monitoring procedures."
+    },
     "AZ-NET-011": {
       "control_id": "CC7.2",
       "control_name": "System monitoring",
       "description": "Network Watcher must be enabled in all regions where resources are deployed to support continuous system monitoring. Without it, network-level events cannot be detected or investigated, preventing incident response."
+    },
+    "AZ-NET-012": {
+      "control_id": "CC7.2",
+      "control_name": "System monitoring",
+      "description": "Network Security Group flow logs support continuous monitoring of network traffic and investigation of anomalous connections. Without flow logs, network-level security events may not be detected or reconstructed."
     },
     "AZ-DB-003": {
       "control_id": "CC6.1",

--- a/docs/rules-reference.md
+++ b/docs/rules-reference.md
@@ -1,26 +1,31 @@
 # Rules Reference
 
-OpenShield currently ships 39 Azure scan rules. This table is generated from the module-level constants in `scanner/rules/`.
+OpenShield currently ships 44 Azure scan rules. This table is generated from the module-level constants in `scanner/rules/`.
 
 | Rule ID | Name | Severity | Category | CIS | NIST | ISO 27001 |
 |---|---|---|---|---|---|---|
 | AZ-CMP-001 | VM with Public IP and No Associated NSG on Network Interface | HIGH | Compute | 7.2 | PR.AC-3 | A.13.1.1 |
 | AZ-CMP-002 | Virtual machine disk not protected by customer-managed key or ADE | HIGH | Compute | 7.2 | PR.DS-1 | A.10.1.1 |
-| AZ-CMP-003 | VM Without Endpoint Protection Installed | HIGH | Compute | 8.2 | DE.CM-1 | A.12.2.1 |
-| AZ-CMP-004 | VM Without Automatic OS Patching Enabled | HIGH | Compute | 7.3 | SI-2 | A.12.6.1 |
+| AZ-CMP-003 | VM Without Endpoint Protection Installed | HIGH | Compute | 8.2 | DE.CM-4 | A.12.2.1 |
+| AZ-CMP-004 | VM Without Automatic OS Patching Enabled | HIGH | Compute | 8.3 | PR.IP-12 | A.12.6.1 |
 | AZ-DB-001 | PostgreSQL Server Allows Public Network Access | HIGH | Database | 4.3.1 | PR.AC-3 | A.13.1.1 |
 | AZ-DB-002 | Azure SQL Server Has No Auditing Configured | MEDIUM | Database | 4.1.3 | DE.CM-7 | A.12.4.1 |
-| AZ-DB-003 | PostgreSQL Flexible Server SSL Enforcement Disabled | HIGH | Database | 4.3.4 | SC-8 | A.10.1.1 |
-| AZ-DB-004 | SQL Server Firewall Allows All Azure Services | HIGH | Database | 4.1.2 | SC-7 | A.13.1.1 |
+| AZ-DB-003 | PostgreSQL Flexible Server SSL Enforcement Disabled | HIGH | Database | 4.3.6 | PR.DS-2 | A.10.1.1 |
+| AZ-DB-004 | SQL Server Firewall Allows All Azure Services | HIGH | Database | 4.1.2 | PR.AC-3 | A.13.1.1 |
 | AZ-IDN-001 | Service Principal Assigned Owner Role at Subscription Scope | HIGH | Identity | 1.23 | PR.AC-4 | A.9.2.3 |
 | AZ-IDN-002 | No MFA Enforced on Admin Accounts via Conditional Access | HIGH | Identity | 1.2.4 | PR.AC-1 | A.9.4.2 |
-| AZ-IDN-003 | Guest user invitations not restricted to admins in Entra ID | MEDIUM | Identity | 1.15 | PR.AC-6 | A.9.2.6 |
-| AZ-IDN-004 | No Privileged Identity Management for Admin Roles | HIGH | Identity | 1.1.1 | PR.AC-4 | A.9.2.3 |
-| AZ-KV-001 | Key Vault with Soft Delete Disabled | MEDIUM | Key Vault | 8.5 | PR.IP-4 | A.17.2.1 |
+| AZ-IDN-003 | Guest user invitations not restricted to admins in Entra ID | MEDIUM | Identity | 1.15 | PR.AC-1 | A.9.2.1 |
+| AZ-IDN-004 | No Privileged Identity Management for Admin Roles | HIGH | Identity | 1.14 | PR.AC-4 | A.9.2.3 |
+| AZ-IDN-005 | Guest User with High Privilege Role in Entra ID | HIGH | Identity | 1.3 | PR.AC-4 | A.9.2.3 |
+| AZ-IDN-006 | Service Principal Client Secret Older Than 90 Days | HIGH | Identity | 1.14 | PR.AC-1 | A.9.4.3 |
+| AZ-IDN-007 | Active User with No MFA Registered in Entra ID | HIGH | Identity | 1.1 | PR.AC-7 | A.9.4.2 |
+| AZ-IDN-008 | Custom RBAC Role with Wildcard Permissions at Subscription Scope | HIGH | Identity | 1.23 | PR.AC-4 | A.9.2.3 |
+| AZ-IDN-009 | No Activity Log Alert for Role Assignment Changes | MEDIUM | Identity | 5.2.1 | DE.CM-3 | A.12.4.1 |
+| AZ-KV-001 | Key Vault with Soft Delete Disabled | MEDIUM | KeyVault | 8.5 | PR.IP-4 | A.17.2.1 |
 | AZ-KV-002 | Key Vault Allows Public Network Access Without Private Endpoint | HIGH | Key Vault | 8.3 | AC-17 | A.13.1.1 |
 | AZ-KV-003 | Key Vault Without Diagnostic Logging Enabled | MEDIUM | Key Vault | 8.4 | DE.CM-7 | A.12.4.1 |
-| AZ-KV-004 | Key Vault Purge Protection Disabled | MEDIUM | Key Vault | 8.5 | PR.IP-4 | A.17.2.1 |
-| AZ-KV-005 | Key Vault Certificate Expiring Within 30 Days | MEDIUM | Key Vault | 8.1 | PR.IP-3 | A.10.1.2 |
+| AZ-KV-004 | Key Vault Purge Protection Disabled | MEDIUM | Key Vault | 8.6 | PR.IP-4 | A.17.2.1 |
+| AZ-KV-005 | Key Vault Certificate Expiring Within 30 Days | MEDIUM | Key Vault | 8.5 | PR.MA-1 | A.10.1.2 |
 | AZ-NET-001 | NSG Allows Unrestricted Inbound SSH from Any Source | HIGH | Network | 6.2 | PR.AC-3 | A.13.1.1 |
 | AZ-NET-002 | NSG Allows Unrestricted Inbound RDP from Any Source | HIGH | Network | 6.3 | PR.AC-3 | A.13.1.1 |
 | AZ-NET-003 | NSG allows unrestricted inbound on port 443 | HIGH | Network | 9.3 | SC-7 | A.13.1.1 |
@@ -31,15 +36,18 @@ OpenShield currently ships 39 Azure scan rules. This table is generated from the
 | AZ-NET-008 | Load balancer with no backend pool configured | LOW | Network | 9.1 | CM-7 | A.13.1.1 |
 | AZ-NET-009 | VPN gateway using outdated IKE version | HIGH | Network | 9.5 | SC-8 | A.13.2.1 |
 | AZ-NET-010 | Subnet with no network security group attached | HIGH | Network | 9.2 | SC-7 | A.13.1.1 |
-| AZ-NET-011 | Network Watcher Not Enabled in All Regions | LOW | Network | 9.7 | DE.CM-1 | A.12.4.1 |
-| AZ-NET-012 | NSG Flow Logs Not Enabled | MEDIUM | Network | 9.7 | DE.CM-1 | A.12.4.1 |
-| AZ-NET-013 | Azure Firewall Not Enabled on Virtual Network | HIGH | Network | 9.6 | SC-7 | A.13.1.1 |
-| AZ-NET-014 | VNet Peering Configured Without Gateway Transit Restrictions | MEDIUM | Network | 9.2 | SC-7 | A.13.1.3 |
+| AZ-NET-011 | Network Watcher Not Enabled in All Regions | LOW | Network | 6.5 | DE.CM-7 | A.12.4.1 |
+| AZ-NET-012 | NSG Flow Logs Not Enabled | MEDIUM | Network | 6.5 | DE.CM-1 | A.12.4.1 |
+| AZ-NET-013 | Azure Firewall Not Enabled on Virtual Network | HIGH | Network | 6.4 | PR.AC-5 | A.13.1.1 |
+| AZ-NET-014 | VNet Peering Configured Without Gateway Transit Restrictions | MEDIUM | Network | 6.4 | PR.AC-5 | A.13.1.1 |
+| AZ-PQC-001 | TLS Using Classical Key Exchange Algorithm | HIGH | PostQuantum | 9.1 | PR.DS-2 | A.10.1.1 |
+| AZ-PQC-002 | Key Vault Key Using Non-Quantum-Safe Algorithm | HIGH | PostQuantum | 8.1 | PR.DS-2 | A.10.1.1 |
+| AZ-PQC-003 | Key Vault Certificate Using Non-Quantum-Safe Signature Algorithm | MEDIUM | PostQuantum | 8.5 | PR.DS-2 | A.10.1.1 |
 | AZ-STOR-001 | Public Blob Access Enabled on Storage Account | HIGH | Storage | 3.5 | PR.AC-3 | A.9.4.1 |
 | AZ-STOR-002 | Storage Account Allows HTTP Traffic (Not HTTPS-Only) | HIGH | Storage | 3.1 | PR.DS-2 | A.10.1.1 |
 | AZ-STOR-003 | Storage Account Has No Lifecycle Management Policy | MEDIUM | Storage | 3.7 | PR.DS-3 | A.8.3.1 |
-| AZ-STOR-004 | Storage Account Diagnostic Logging Disabled | MEDIUM | Storage | 3.11 | DE.CM-7 | A.12.4.1 |
-| AZ-STOR-005 | Storage Account Not Using Geo-Redundant Replication | MEDIUM | Storage | 3.12 | PR.IP-4 | A.17.2.1 |
+| AZ-STOR-004 | Storage Account Diagnostic Logging Disabled | MEDIUM | Storage | 3.3 | DE.CM-7 | A.12.4.1 |
+| AZ-STOR-005 | Storage Account Not Using Geo-Redundant Replication | MEDIUM | Storage | 3.1 | PR.IP-4 | A.17.2.1 |
 
 SOC 2 mappings are maintained in `compliance/frameworks/soc2.json`.
 


### PR DESCRIPTION
## Summary

- Update the rules reference from 39 to 44 scanner rules.
- Add the newer AZ-IDN-005 to AZ-IDN-009 and AZ-PQC-001 to AZ-PQC-003 rules to the reference table.
- Align stale rule-reference framework IDs with the scanner rule constants.
- Add missing framework mappings for AZ-KV-003, AZ-NET-012, and AZ-CMP-003 so every scanner rule is represented across CIS, NIST CSF, ISO 27001, and SOC 2.

## Why

The scanner now contains 44 rules, but the rule reference and compliance framework JSON files had drifted. This could undercount compliance coverage and make the documentation disagree with the rule metadata shipped by the scanner.

## Validation

- `python3 -m json.tool` on all compliance framework JSON files
- Audit script confirmed all 44 scanner rules are documented and represented in every framework JSON
- `python3 -m pytest tests/test_rules_storage.py tests/test_rules_network.py tests/test_rules_identity.py tests/test_rules_database.py tests/test_rules_keyvault.py tests/test_pqc_rules.py -q` passed with `22 passed`
- GitHub Actions passed: OpenShield CI, CodeQL Python, and CodeQL JavaScript/TypeScript

Note: after installing the missing local Python packages, full `python3 -m pytest -q` is still blocked locally because `api.app` initializes the Flask app and database migrations at import time, and this shell does not have `DATABASE_URL` configured.
