### PR TITLE
Fix: Make Flask app test-safe and run full pytest suite in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -337,6 +337,15 @@ jobs:
           echo "=== Running rule regression tests ==="
           pytest tests/test_rules_*.py -v --tb=short
 
+      # ── CHECK 8: Full Python test suite ──────────────────────────────
+      - name: Run Python test suite
+        id: pytest_check
+        run: |
+          echo "=== Running full Python test suite ==="
+          python -m pytest tests/             --ignore=tests/smoke_test.py             -v --tb=short -q
+        env:
+          OPENSHIELD_ENV: "development"
+
       # ── Final summary — always runs, shows per-check pass/fail ────────
       - name: CI Summary
         if: always()
@@ -361,6 +370,7 @@ jobs:
               ("Compliance JSON validation",           os.environ["JSON"]),
               ("API syntax check",                     os.environ["API"]),
               ("Compliance vs rule cross-reference",   os.environ["XREF"]),
+              ("Python test suite",                      os.environ["PYTEST"]),
               ("Rule regression tests",                os.environ["RULE_TESTS"]),
           ]
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -357,6 +357,7 @@ jobs:
           JSON:       ${{ steps.json_check.outcome }}
           API:        ${{ steps.api_check.outcome }}
           XREF:       ${{ steps.xref_check.outcome }}
+          PYTEST:     ${{ steps.pytest_check.outcome }}
           RULE_TESTS: ${{ steps.rule_tests.outcome }}
         run: |
           python - <<'PYEOF'

--- a/api/app.py
+++ b/api/app.py
@@ -117,9 +117,20 @@ def create_app() -> Flask:
     # ------------------------------------------------------------------ #
     # Database Management                                                   #
     # ------------------------------------------------------------------ #
-    with app.app_context():
-        db = DatabaseManager()
-        db.run_migrations()
+    # Skip migrations when DATABASE_URL is not set (e.g. during unit tests).
+    # Deployment startup always sets DATABASE_URL so migrations still run in
+    # production and staging. Tests that need a real database should set
+    # DATABASE_URL explicitly in their environment.
+    if os.environ.get("DATABASE_URL"):
+        with app.app_context():
+            db = DatabaseManager()
+            db.run_migrations()
+    else:
+        logger.info(
+            "DATABASE_URL not set — skipping migrations. "
+            "This is expected during unit tests and local development "
+            "without a database."
+        )
 
     @app.teardown_appcontext
     def close_db(error=None):


### PR DESCRIPTION
## What does this PR do?
Makes the Flask app safe to import without a live DATABASE_URL, then adds the full Python test suite to CI.

## Type of change
- [ ] New scan rule
- [ ] Remediation playbook
- [x] Bug fix
- [ ] Dashboard/front-end work
- [ ] API endpoint
- [ ] Documentation
- [ ] Compliance mapping

## Problem
Importing api.app triggered create_app() which immediately called DatabaseManager() and db.run_migrations(). DatabaseManager.__init__ reads os.environ["DATABASE_URL"] and raises KeyError when it is not set. This caused the full test suite to fail at collection time with no DATABASE_URL available in CI.

## Fix

### api/app.py
Wrapped the migration block in a DATABASE_URL check:
- If DATABASE_URL is set → run migrations as before (production and staging unchanged)
- If DATABASE_URL is not set → log a clear info message and skip migrations (unit tests and local dev without a database)

### .github/workflows/ci.yml
Added CHECK 8 — runs the full pytest suite excluding smoke_test.py with OPENSHIELD_ENV=development so JWT secret validation stays permissive during tests.

## Acceptance criteria
- [x] python3 -m pytest -q runs locally without requiring a production database
- [x] Importing api.app does not trigger migrations when DATABASE_URL is unset
- [x] CI runs all test files under tests/ excluding smoke tests
- [x] Deployment startup still runs migrations when DATABASE_URL is set
- [x] All existing CI checks still pass

## Testing
- [x] Verified locally — app creates successfully without DATABASE_URL
- [x] No hardcoded credentials or secrets
- [x] All CI checks passing locally

## Related issue
Closes #[ISSUE NUMBER]