### PR TITLE
fix(security): drop credential key_id from AZ-IDN-006 debug logging (#178)

### DIFF
--- a/scanner/rules/az_idn_006.py
+++ b/scanner/rules/az_idn_006.py
@@ -87,9 +87,8 @@ def scan(azure_client: Any, subscription_id: str) -> List[Dict[str, Any]]:
                     already_expired = end_dt < now
                 except ValueError:
                     logger.debug(
-                        "AZ-IDN-006: Invalid endDateTime for app_id=%s key_id=%s: %r",
+                        "AZ-IDN-006: Invalid endDateTime for app_id=%s: %r",
                         app_id,
-                        key_id,
                         end_dt_str,
                     )
 

--- a/tests/test_rules_identity.py
+++ b/tests/test_rules_identity.py
@@ -288,6 +288,38 @@ def test_idn_006_noncompliant_secret_no_expiry_returns_finding(mock_azure, subsc
     assert findings[0]["metadata"]["no_expiry"] is True
 
 
+def test_idn_006_malformed_end_date_time_does_not_log_key_id(mock_azure, subscription_id, monkeypatch, caplog):
+    """CodeQL: clear-text logging of sensitive information. keyId is a Graph
+    API credential-slot identifier (not the secret itself), but the debug log
+    for a malformed endDateTime must not include it regardless — the value
+    isn't needed to diagnose a date-parsing failure."""
+    sentinel_key_id = "sentinel-key-id-should-not-appear-in-logs"
+    apps = {
+        "value": [
+            {
+                "id": "app1",
+                "displayName": "App One",
+                "appId": "client-1",
+                "passwordCredentials": [
+                    {
+                        "keyId": sentinel_key_id,
+                        "hint": "ab",
+                        "startDateTime": "2020-01-01T00:00:00Z",
+                        "endDateTime": "not-a-valid-date",
+                    }
+                ],
+            }
+        ]
+    }
+    _install_router(monkeypatch, [("/applications", _Resp(apps))])
+    with caplog.at_level("DEBUG", logger="scanner.rules.az_idn_006"):
+        findings = az_idn_006.scan(mock_azure, subscription_id)
+
+    # Malformed endDateTime alone doesn't matter here: the secret is already stale by age.
+    assert len(findings) == 1
+    assert sentinel_key_id not in caplog.text
+
+
 # ── AZ-IDN-007: active user with no MFA registered ──────────────────────────
 
 


### PR DESCRIPTION
## Summary

Fixes #178 — the medium-priority CodeQL batch (2 findings, both the same log statement in `scanner/rules/az_idn_006.py`).

`app_id`/`key_id` are Azure AD identifiers — Microsoft Graph never returns the actual password-credential secret text after creation, so these are GUIDs referencing a credential, not the credential itself. This is very likely CodeQL's naming-heuristic flagging variables near a "credential"/`cred` context rather than a genuine secret leak.

Regardless of true/false-positive status, `key_id` isn't needed to diagnose a malformed `endDateTime` value, so the fix removes it from the log line entirely rather than arguing the classification. `key_id` itself is untouched everywhere else in the file (it's still used correctly in the finding's `resource_id` and `metadata`).

## Test plan

- [x] Added `test_idn_006_malformed_end_date_time_does_not_log_key_id`, which feeds a malformed `endDateTime` and asserts a sentinel `keyId` value never appears in the captured log output
- [x] Verified this test actually catches the bug: temporarily reverted the fix and confirmed the new test fails against the old code, then confirmed it passes against the fix
- [x] `ruff check` / `ruff format --check` — clean
- [x] Full pytest suite: 332 passed, same 2 pre-existing unrelated local failures, no regressions
- [x] No merge conflicts against `dev`