### PR TITLE
fix(security): complete #183 — XSS output encoding + legacy AI key purge

### DIFF
--- a/frontend/src/utils/aiApi.js
+++ b/frontend/src/utils/aiApi.js
@@ -24,6 +24,13 @@ const TIMEOUT = 30000;
 // persist in localStorage as before.
 let apiKeyInMemory = '';
 
+// One-time migration: builds before the in-memory switch (issue #180) stored
+// the key at localStorage['ai_api_key']. Purge it on load so existing users
+// don't keep a plaintext key sitting in storage indefinitely. Deliberately not
+// read into apiKeyInMemory — the whole point is that the secret no longer lives
+// in a persistent, XSS-readable store.
+localStorage.removeItem('ai_api_key');
+
 export const aiSettings = {
   getProvider: () => localStorage.getItem('ai_provider') || 'anthropic',
   getApiKey:   () => apiKeyInMemory,
@@ -36,6 +43,7 @@ export const aiSettings = {
   isConfigured: () => !!apiKeyInMemory,
   clear: () => {
     apiKeyInMemory = '';
+    localStorage.removeItem('ai_api_key'); // defence in depth: also drop any legacy stored key
     localStorage.removeItem('ai_provider');
     localStorage.removeItem('ai_model');
   },

--- a/frontend/src/utils/aiApi.test.mjs
+++ b/frontend/src/utils/aiApi.test.mjs
@@ -15,7 +15,7 @@ import path from 'node:path';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
-function loadAiApiModule() {
+function loadAiApiModule(seed = {}) {
   let source = readFileSync(path.join(__dirname, 'aiApi.js'), 'utf8');
 
   // Neutralize the one Vite-only construct so this can run under plain Node.
@@ -30,7 +30,10 @@ function loadAiApiModule() {
   source = source.replace(/^export const /gm, 'const ');
   source += '\nreturn { aiSettings, aiApi };';
 
-  const backingStore = new Map();
+  // `seed` pre-populates localStorage before the module body runs, so tests can
+  // simulate a browser that already has values from a previous app version
+  // (e.g. a legacy plaintext ai_api_key that predates the in-memory switch).
+  const backingStore = new Map(Object.entries(seed));
   const localStorageStub = {
     getItem: (k) => (backingStore.has(k) ? backingStore.get(k) : null),
     setItem: (k, v) => backingStore.set(k, String(v)),
@@ -105,6 +108,32 @@ check('a fresh module load never sees a key from a previous instance (no shared 
   const second = loadAiApiModule();
   assert.equal(second.aiSettings.isConfigured(), false);
   assert.equal(second.aiSettings.getApiKey(), '');
+});
+
+check('loading the module purges a legacy plaintext ai_api_key left by an older version', () => {
+  // Users who ran a build before the in-memory switch (issue #180) still have
+  // their key sitting in localStorage. The module must delete it on load, or
+  // the very leak the fix was meant to close persists indefinitely for them.
+  const { backingStore } = loadAiApiModule({ ai_api_key: 'legacy-plaintext-key' });
+  assert.equal(backingStore.has('ai_api_key'), false);
+  assert.ok(
+    ![...backingStore.values()].some((v) => String(v).includes('legacy-plaintext-key')),
+    'legacy key still present in localStorage after module load',
+  );
+});
+
+check('the migration does not resurrect the legacy key into the in-memory field', () => {
+  // Purging the stored key must not silently load it into memory either — a
+  // fresh load with a legacy key present should still start unconfigured.
+  const { aiSettings } = loadAiApiModule({ ai_api_key: 'legacy-plaintext-key' });
+  assert.equal(aiSettings.isConfigured(), false);
+  assert.equal(aiSettings.getApiKey(), '');
+});
+
+check('clear() also removes any legacy ai_api_key still in storage', () => {
+  const { aiSettings, backingStore } = loadAiApiModule({ ai_api_key: 'legacy-plaintext-key' });
+  aiSettings.clear();
+  assert.equal(backingStore.has('ai_api_key'), false);
 });
 
 if (failures > 0) {

--- a/website/script.js
+++ b/website/script.js
@@ -245,7 +245,12 @@ function toEmbedUrl(raw) {
     try {
         const parsed = new URL(raw);
         if (parsed.protocol === 'https:' && EMBED_ALLOWED_HOSTS.has(parsed.hostname)) {
-            return raw;
+            // Return the canonicalised href, not the raw input: a valid host
+            // still lets an attribute-injection payload (e.g. a literal
+            // double-quote) through on an allowed origin. parsed.href
+            // percent-encodes quotes/spaces/brackets so the value is safe to
+            // interpolate into the iframe src="..." attribute.
+            return parsed.href;
         }
     } catch {
         // Not a valid absolute URL — fall through to reject below.

--- a/website/test_toEmbedUrl.mjs
+++ b/website/test_toEmbedUrl.mjs
@@ -80,7 +80,33 @@ const rejected = [
   'not a url at all but contains youtube.com/embed',
 ];
 
+// Inputs on an ALLOWED host that still carry an attribute-injection payload.
+// The host passes the allowlist, so the earlier "rejected" cases don't cover
+// this — the returned value is interpolated into an iframe src="..." attribute,
+// so it must never contain a raw double-quote that could break out of it.
+// The fix returns the canonicalised URL.href (which percent-encodes quotes and
+// spaces) instead of the raw input.
+const sanitizedPassthrough = [
+  [
+    'https://www.youtube.com/embed/abc" onload="alert(1)',
+    'https://www.youtube.com/embed/abc%22%20onload=%22alert(1)',
+    'attribute-injection payload on allowed host is percent-encoded',
+  ],
+  [
+    'https://player.vimeo.com/video/1"><script>alert(1)</script>',
+    'https://player.vimeo.com/video/1%22%3E%3Cscript%3Ealert(1)%3C/script%3E',
+    'script-injection payload on allowed vimeo host is percent-encoded',
+  ],
+];
+
 let failures = 0;
+
+function assertNoDoubleQuote(value, description) {
+  assert.ok(
+    !String(value).includes('"'),
+    `${description}: return value must not contain a raw double-quote (iframe src breakout): ${JSON.stringify(value)}`,
+  );
+}
 
 for (const [input, expected, description] of cases) {
   const actual = toEmbedUrl(input);
@@ -101,6 +127,18 @@ for (const input of rejected) {
   } catch {
     failures++;
     console.error(`FAIL: bypass NOT rejected — input=${JSON.stringify(input)} got=${JSON.stringify(actual)}`);
+  }
+}
+
+for (const [input, expected, description] of sanitizedPassthrough) {
+  const actual = toEmbedUrl(input);
+  try {
+    assert.equal(actual, expected);
+    assertNoDoubleQuote(actual, description);
+    console.log(`PASS: ${description}`);
+  } catch (err) {
+    failures++;
+    console.error(`FAIL: ${description} — input=${JSON.stringify(input)} got=${JSON.stringify(actual)}\n  ${err.message}`);
   }
 }
 


### PR DESCRIPTION
Follow-up to #183, addressing two residual issues @ritiksah141 flagged in review after it merged. Both are real; neither warranted reverting #183, so this patches forward.

## 1. XSS — `toEmbedUrl()` returned the raw input, not the validated URL
`website/script.js`'s embed fallback correctly validated the **host** via `new URL(raw)` against an allowlist, but then returned `raw` — the unmodified input. On an **allowed** host, an attribute-injection payload still passes:

```
https://www.youtube.com/embed/abc" onload="alert(1)
```

`hostname` is `www.youtube.com` (passes the allowlist), but the literal `"` survives and breaks out of the iframe `src="..."` attribute when interpolated. The earlier "rejected" tests only covered *disallowed hosts*, so this class was never exercised.

**Fix:** return `parsed.href` instead of `raw`. The WHATWG URL serializer percent-encodes quotes, spaces, and angle brackets, so the returned value is safe to interpolate. Legitimate embed URLs are unaffected (they contain no characters that get encoded).

## 2. Legacy plaintext key never purged (#180 regression)
The in-memory-key switch removed the `localStorage.setItem('ai_api_key', ...)` write but never removed keys **older builds had already persisted**. Any user who configured a key before that build keeps a plaintext `ai_api_key` in localStorage indefinitely — the exact leak #180 set out to close.

**Fix:** `localStorage.removeItem('ai_api_key')` once on module load (deliberately *not* read into memory) and again in `clear()` as defence-in-depth.

## Verification
- Both regression tests were confirmed to **fail against the current `dev` code** before the fix and **pass after** (not just added green).
- `node website/test_toEmbedUrl.mjs` — passes (2 new attribute-injection-on-allowed-host cases)
- `node frontend/src/utils/aiApi.test.mjs` — passes (3 new legacy-key migration cases)
- `npm run lint` — 0 errors (4 pre-existing warnings in untouched files)

## Note
This is the miss I flagged in the #183 post-merge review: my approval checked the host-validation gate but not the value flowing out of it. These tests close that specific gap. cc @ritiksah141 @Vishnu2707
