### PR TITLE
feat(scanner): add enterprise AKS security rule pack

### DIFF
--- a/.github/ISSUE_TEMPLATE/new_rule.md
+++ b/.github/ISSUE_TEMPLATE/new_rule.md
@@ -9,7 +9,7 @@ assignees: ''
 ## Rule Details
 - Rule ID: AZ-XXX-000
 - Severity: HIGH / MEDIUM / LOW
-- Category: Storage / Network / Identity / Database / Compute / Key Vault / PostQuantum
+- Category: Storage / Network / Identity / Database / Compute / Key Vault / Kubernetes / PostQuantum
 - Frameworks: CIS / NIST / ISO 27001 / SOC 2
 
 ## What does it detect?

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -13,7 +13,7 @@
 ## Rule details (if applicable)
 - Rule ID: AZ-XXX-000
 - Severity: HIGH / MEDIUM / LOW
-- Category: Storage / Network / Identity / Database / Compute / Key Vault
+- Category: Storage / Network / Identity / Database / Compute / Key Vault / Kubernetes
 - Frameworks mapped: CIS / NIST / ISO 27001 / SOC 2
 
 ## Testing

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -16,4 +16,8 @@ jobs:
       - uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4
         with:
           fail-on-severity: high
+          # The wheel omits license metadata, but Microsoft's upstream Azure
+          # SDK repository licenses this package under MIT:
+          # https://github.com/Azure/azure-sdk-for-python/blob/main/LICENSE
+          allow-dependencies-licenses: pkg:pypi/azure-mgmt-containerservice@41.3.0
           comment-summary-in-pr: always

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,7 +51,7 @@ from typing import Any, Dict, List
 RULE_ID = "AZ-STOR-001"
 RULE_NAME = "Public Blob Access Enabled on Storage Account"
 SEVERITY = "HIGH"           # HIGH / MEDIUM / LOW / INFO
-CATEGORY = "Storage"        # Storage / Network / Identity / Database / Compute / Key Vault
+CATEGORY = "Storage"        # Storage / Network / Identity / Database / Compute / Key Vault / Kubernetes
 FRAMEWORKS = {
     "CIS": "3.5",
     "NIST": "PR.AC-3",
@@ -178,6 +178,7 @@ Use the format: `AZ-[CATEGORY]-[NUMBER]`
 | Database | DB | AZ-DB-001 |
 | Compute | CMP | AZ-CMP-001 |
 | Key Vault | KV | AZ-KV-001 |
+| Kubernetes (AKS) | AKS | AZ-AKS-001 |
 
 Check existing rules before picking a number to avoid clashes.
 
@@ -201,6 +202,7 @@ Use the existing wrapper methods in `scanner/azure_client.py` rather than constr
 | `azure_client.get_sql_servers()` | List of Azure SQL Server objects |
 | `azure_client.get_sql_server_auditing_policy(resource_group, server_name)` | ServerBlobAuditingPolicy or None |
 | `azure_client.get_key_vaults()` | List of Key Vault objects |
+| `azure_client.get_managed_clusters()` | List of AKS ManagedCluster objects, or `None` on API failure |
 | `azure_client.get_service_principals()` | List of role assignments for service principals |
 | `azure_client.get_conditional_access_policies()` | List of Conditional Access policy dicts from Microsoft Graph |
 

--- a/compliance/frameworks/cis_azure_benchmark.json
+++ b/compliance/frameworks/cis_azure_benchmark.json
@@ -227,6 +227,36 @@
       "control_id": "8.9",
       "control_name": "Ensure certificates use quantum-safe signature algorithms",
       "description": "Key Vault certificates signed with RSA or ECDSA are vulnerable to quantum attacks. CIS 8.9 requires that certificate management includes monitoring of algorithm strength. Certificates should be migrated to post-quantum safe signature algorithms such as ML-DSA when CA support is available."
+    },
+    "AZ-AKS-001": {
+      "control_id": "N/A-AKS-001",
+      "control_name": "AKS private cluster baseline (not mapped in CIS Azure Foundations 2.0.0)",
+      "description": "Microsoft recommends private AKS clusters to keep control-plane traffic on private networks. This OpenShield check is intentionally marked not applicable to the repository's CIS Azure Foundations 2.0.0 benchmark rather than claiming an unsupported CIS mapping."
+    },
+    "AZ-AKS-002": {
+      "control_id": "N/A-AKS-002",
+      "control_name": "AKS local account baseline (not mapped in CIS Azure Foundations 2.0.0)",
+      "description": "Microsoft recommends disabling AKS local accounts so authentication is governed through Microsoft Entra ID. This check has no direct control in the repository's CIS Azure Foundations 2.0.0 benchmark."
+    },
+    "AZ-AKS-003": {
+      "control_id": "N/A-AKS-003",
+      "control_name": "AKS managed identity baseline (not mapped in CIS Azure Foundations 2.0.0)",
+      "description": "Microsoft recommends managed identities instead of AKS service-principal credentials. This check has no direct control in the repository's CIS Azure Foundations 2.0.0 benchmark."
+    },
+    "AZ-AKS-004": {
+      "control_id": "N/A-AKS-004",
+      "control_name": "AKS Workload Identity baseline (not mapped in CIS Azure Foundations 2.0.0)",
+      "description": "Microsoft recommends Workload Identity for scoped, secretless access from pods to Azure resources. This check has no direct control in the repository's CIS Azure Foundations 2.0.0 benchmark."
+    },
+    "AZ-AKS-005": {
+      "control_id": "N/A-AKS-005",
+      "control_name": "AKS Azure Policy baseline (not mapped in CIS Azure Foundations 2.0.0)",
+      "description": "Microsoft recommends the Azure Policy add-on for centralized Kubernetes governance. This check has no direct control in the repository's CIS Azure Foundations 2.0.0 benchmark."
+    },
+    "AZ-AKS-006": {
+      "control_id": "N/A-AKS-006",
+      "control_name": "AKS node OS upgrade baseline (not mapped in CIS Azure Foundations 2.0.0)",
+      "description": "Microsoft recommends a managed node OS upgrade channel for timely security patches. This check has no direct control in the repository's CIS Azure Foundations 2.0.0 benchmark."
     }
   }
 }

--- a/compliance/frameworks/iso27001.json
+++ b/compliance/frameworks/iso27001.json
@@ -227,6 +227,36 @@
       "control_id": "A.10.1.1",
       "control_name": "Policy on the use of cryptographic controls",
       "description": "Certificates using classical signature algorithms expose the organisation to quantum-enabled signature forgery. A.10.1.1 requires that the cryptographic controls policy covers all cryptographic assets including certificates. Migration planning to post-quantum safe signature algorithms is required."
+    },
+    "AZ-AKS-001": {
+      "control_id": "A.13.1.1",
+      "control_name": "Network controls",
+      "description": "Private AKS API access restricts the control plane to approved network paths and reduces exposure to internet-originated attacks."
+    },
+    "AZ-AKS-002": {
+      "control_id": "A.9.2.1",
+      "control_name": "User registration and de-registration",
+      "description": "Disabling local accounts ensures AKS administrator access follows the centralized Microsoft Entra identity lifecycle."
+    },
+    "AZ-AKS-003": {
+      "control_id": "A.9.2.1",
+      "control_name": "User registration and de-registration",
+      "description": "Managed identity removes separately managed service-principal credentials from the AKS control plane."
+    },
+    "AZ-AKS-004": {
+      "control_id": "A.9.2.3",
+      "control_name": "Management of privileged access rights",
+      "description": "Workload Identity allows Azure permissions to be scoped and lifecycle-managed for individual Kubernetes workloads."
+    },
+    "AZ-AKS-005": {
+      "control_id": "A.12.1.2",
+      "control_name": "Change management",
+      "description": "Azure Policy provides controlled and repeatable governance for Kubernetes resource admission and configuration changes."
+    },
+    "AZ-AKS-006": {
+      "control_id": "A.12.6.1",
+      "control_name": "Management of technical vulnerabilities",
+      "description": "Automatic AKS node OS upgrades help deploy tested security patches within a managed maintenance process."
     }
   }
 }

--- a/compliance/frameworks/nist_csf.json
+++ b/compliance/frameworks/nist_csf.json
@@ -227,6 +227,36 @@
       "control_id": "PR.DS-2",
       "control_name": "Data in transit is protected",
       "description": "Certificates using classical signature algorithms are vulnerable to quantum attacks, undermining authentication and integrity guarantees. PR.DS-2 requires that data protection includes integrity mechanisms. Migration to ML-DSA or SLH-DSA signature algorithms should be planned."
+    },
+    "AZ-AKS-001": {
+      "control_id": "PR.AC-3",
+      "control_name": "Remote access is managed",
+      "description": "A private AKS API endpoint reduces public control-plane exposure and ensures administrative access is mediated through approved private network paths."
+    },
+    "AZ-AKS-002": {
+      "control_id": "PR.AC-1",
+      "control_name": "Identities and credentials are issued, managed, verified, revoked, and audited",
+      "description": "Disabling local AKS accounts ensures cluster access uses centrally governed Microsoft Entra identities instead of unmanaged static credentials."
+    },
+    "AZ-AKS-003": {
+      "control_id": "PR.AC-1",
+      "control_name": "Identities and credentials are issued, managed, verified, revoked, and audited",
+      "description": "Managed identities remove manually rotated service-principal credentials from AKS control-plane access to Azure resources."
+    },
+    "AZ-AKS-004": {
+      "control_id": "PR.AC-4",
+      "control_name": "Access permissions and authorizations are managed",
+      "description": "Workload Identity supports workload-specific, least-privilege authorization to Azure resources without shared application secrets."
+    },
+    "AZ-AKS-005": {
+      "control_id": "PR.IP-1",
+      "control_name": "A baseline configuration is created and maintained",
+      "description": "The Azure Policy add-on enables centrally defined Kubernetes security baselines to be audited and enforced consistently."
+    },
+    "AZ-AKS-006": {
+      "control_id": "PR.IP-12",
+      "control_name": "A vulnerability management plan is developed and implemented",
+      "description": "Managed node OS upgrade channels apply tested security updates to reduce exposure to known operating-system vulnerabilities."
     }
   }
 }

--- a/compliance/frameworks/soc2.json
+++ b/compliance/frameworks/soc2.json
@@ -227,6 +227,36 @@
       "control_id": "CC6.7",
       "control_name": "Protects Data in Transit",
       "description": "Certificates using classical signature algorithms will be vulnerable to quantum-enabled forgery, undermining authentication and data integrity. CC6.7 requires that data integrity is maintained through encryption and signing. Migration to post-quantum safe certificate algorithms should be planned."
+    },
+    "AZ-AKS-001": {
+      "control_id": "CC6.6",
+      "control_name": "Restricts Access to Information Assets",
+      "description": "A private AKS API endpoint restricts control-plane access to approved private network paths."
+    },
+    "AZ-AKS-002": {
+      "control_id": "CC6.1",
+      "control_name": "Logical and Physical Access Controls",
+      "description": "Disabling AKS local accounts makes centrally governed Microsoft Entra identities the required authentication path."
+    },
+    "AZ-AKS-003": {
+      "control_id": "CC6.1",
+      "control_name": "Logical and Physical Access Controls",
+      "description": "Managed identities reduce reliance on long-lived service-principal credentials for AKS control-plane operations."
+    },
+    "AZ-AKS-004": {
+      "control_id": "CC6.3",
+      "control_name": "Role-Based Access",
+      "description": "Workload Identity enables permissions to be assigned to specific Kubernetes workloads according to least privilege."
+    },
+    "AZ-AKS-005": {
+      "control_id": "CC8.1",
+      "control_name": "Change Management",
+      "description": "The Azure Policy add-on supports consistent audit and enforcement of approved Kubernetes configurations."
+    },
+    "AZ-AKS-006": {
+      "control_id": "CC7.1",
+      "control_name": "Detects and Monitors Configuration Changes",
+      "description": "Managed node OS upgrade channels maintain worker-node security patches through an observable Azure-controlled process."
     }
   }
 }

--- a/docs/adding-a-rule.md
+++ b/docs/adding-a-rule.md
@@ -27,7 +27,7 @@ logger = logging.getLogger(__name__)
 RULE_ID = "AZ-XXXX-000"          # Unique ID. Check existing rules to avoid clashes.
 RULE_NAME = "Human-readable name" # Shown in the dashboard and reports.
 SEVERITY = "HIGH"                 # HIGH | MEDIUM | LOW | INFO
-CATEGORY = "Storage"              # Storage | Network | Identity | Database | Compute | Key Vault
+CATEGORY = "Storage"              # Storage | Network | Identity | Database | Compute | Key Vault | Kubernetes
 FRAMEWORKS = {
     "CIS":      "3.5",            # CIS Azure Benchmark control ID
     "NIST":     "PR.AC-3",        # NIST CSF subcategory
@@ -124,6 +124,7 @@ def scan(azure_client: Any, subscription_id: str) -> List[Dict[str, Any]]:
 | `azure_client.get_sql_servers()` | List of Server objects (Azure SQL) |
 | `azure_client.get_sql_server_auditing_policy(rg, name)` | ServerBlobAuditingPolicy or None |
 | `azure_client.get_key_vaults()` | List of Vault objects (with full properties) |
+| `azure_client.get_managed_clusters()` | List of AKS ManagedCluster objects, or `None` on API failure |
 | `azure_client.get_service_principals()` | List of RoleAssignment objects for service principals |
 | `azure_client.get_conditional_access_policies()` | List of CA policy dicts from MS Graph |
 | `azure_client.parse_resource_id(id)` | Dict with `resource_group` and `name` |

--- a/docs/aks-security-rules.md
+++ b/docs/aks-security-rules.md
@@ -1,0 +1,54 @@
+# AKS Security Rules
+
+OpenShield evaluates Azure Kubernetes Service control-plane configuration through
+the Azure Resource Manager API. The scanner does not download kubeconfig files,
+request Kubernetes administrator credentials, or inspect in-cluster workloads.
+
+## Coverage
+
+| Rule | Control |
+|---|---|
+| `AZ-AKS-001` | Private API server endpoint |
+| `AZ-AKS-002` | Local account disablement |
+| `AZ-AKS-003` | Control-plane managed identity |
+| `AZ-AKS-004` | OIDC issuer and Workload Identity |
+| `AZ-AKS-005` | Azure Policy add-on |
+| `AZ-AKS-006` | Managed node OS security upgrades |
+
+## Required permissions
+
+The scanning identity needs the following Azure Resource Manager action at the
+subscription or relevant resource-group scope:
+
+```text
+Microsoft.ContainerService/managedClusters/read
+```
+
+Azure's built-in **Reader** role includes this action. No Kubernetes RBAC role,
+cluster credential, Microsoft Graph permission, or data-plane access is needed.
+
+If Azure denies or fails the inventory request, the AKS accessor returns an
+indeterminate state. Rules skip evaluation and log the failure instead of
+reporting the subscription as compliant.
+
+## Remediation safety
+
+The matching CLI playbooks validate the selected Azure account and cluster,
+describe operational impact, and require the operator to type `APPLY`. Enabling
+a private endpoint, disabling local credentials, migrating identity, or changing
+node patch behavior should first be tested in a non-production cluster.
+
+## Compliance note
+
+This repository currently models CIS Microsoft Azure Foundations Benchmark
+2.0.0. That benchmark does not directly identify these six AKS configuration
+checks, so their CIS values are explicitly recorded as `N/A-AKS-*`. The rules
+do not claim CIS Kubernetes Benchmark coverage. NIST CSF 1.1, ISO/IEC 27001:2013,
+and SOC 2 mappings follow the framework versions already used by OpenShield.
+
+## Authoritative references
+
+- [Azure Policy built-ins for AKS](https://learn.microsoft.com/azure/aks/policy-reference)
+- [AKS baseline architecture](https://learn.microsoft.com/azure/architecture/reference-architectures/containers/aks/baseline-aks)
+- [AKS managed-cluster API](https://learn.microsoft.com/rest/api/aks/managed-clusters/get)
+- [AKS node OS automatic upgrades](https://learn.microsoft.com/azure/aks/auto-upgrade-node-os-image)

--- a/docs/rules-reference.md
+++ b/docs/rules-reference.md
@@ -48,6 +48,12 @@ OpenShield currently ships 44 Azure scan rules. This table is generated from the
 | AZ-STOR-003 | Storage Account Has No Lifecycle Management Policy | MEDIUM | Storage | 3.7 | PR.DS-3 | A.8.3.1 |
 | AZ-STOR-004 | Storage Account Diagnostic Logging Disabled | MEDIUM | Storage | 3.3 | DE.CM-7 | A.12.4.1 |
 | AZ-STOR-005 | Storage Account Not Using Geo-Redundant Replication | MEDIUM | Storage | 3.8 | PR.IP-4 | A.17.2.1 |
+| AZ-AKS-001 | AKS Private Cluster Not Enabled | HIGH | Kubernetes | N/A-AKS-001 | PR.AC-3 | A.13.1.1 |
+| AZ-AKS-002 | AKS Local Accounts Enabled | HIGH | Kubernetes | N/A-AKS-002 | PR.AC-1 | A.9.2.1 |
+| AZ-AKS-003 | AKS Cluster Not Using Managed Identity | HIGH | Kubernetes | N/A-AKS-003 | PR.AC-1 | A.9.2.1 |
+| AZ-AKS-004 | AKS Workload Identity Not Fully Enabled | MEDIUM | Kubernetes | N/A-AKS-004 | PR.AC-4 | A.9.2.3 |
+| AZ-AKS-005 | AKS Azure Policy Add-on Not Enabled | MEDIUM | Kubernetes | N/A-AKS-005 | PR.IP-1 | A.12.1.2 |
+| AZ-AKS-006 | AKS Node OS Automatic Upgrades Disabled | HIGH | Kubernetes | N/A-AKS-006 | PR.IP-12 | A.12.6.1 |
 
 SOC 2 mappings are maintained in `compliance/frameworks/soc2.json`.
 

--- a/playbooks/cli/fix_az_aks_001.sh
+++ b/playbooks/cli/fix_az_aks_001.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# OpenShield Remediation Playbook
+# Rule: AZ-AKS-001 - AKS private cluster not enabled
+# Usage: ./fix_az_aks_001.sh <resource-group> <cluster-name>
+# Severity: HIGH
+
+set -euo pipefail
+
+RESOURCE_GROUP=${1:-}
+CLUSTER_NAME=${2:-}
+if [ -z "$RESOURCE_GROUP" ] || [ -z "$CLUSTER_NAME" ]; then
+  echo "Usage: $0 <resource-group> <cluster-name>"
+  exit 1
+fi
+
+az account show --output none
+az aks show --resource-group "$RESOURCE_GROUP" --name "$CLUSTER_NAME" --output none
+echo "WARNING: Enabling a private API endpoint changes cluster connectivity and DNS requirements."
+echo "Confirm that administrators and automation have private network access before continuing."
+read -r -p "Type APPLY to enable private-cluster mode on '$CLUSTER_NAME': " CONFIRM
+[ "$CONFIRM" = "APPLY" ] || { echo "Cancelled."; exit 1; }
+
+az aks update --resource-group "$RESOURCE_GROUP" --name "$CLUSTER_NAME" --enable-private-cluster
+az aks show --resource-group "$RESOURCE_GROUP" --name "$CLUSTER_NAME" \
+  --query "apiServerAccessProfile.enablePrivateCluster" --output tsv

--- a/playbooks/cli/fix_az_aks_002.sh
+++ b/playbooks/cli/fix_az_aks_002.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# OpenShield Remediation Playbook
+# Rule: AZ-AKS-002 - AKS local accounts enabled
+# Usage: ./fix_az_aks_002.sh <resource-group> <cluster-name>
+# Severity: HIGH
+
+set -euo pipefail
+
+RESOURCE_GROUP=${1:-}
+CLUSTER_NAME=${2:-}
+if [ -z "$RESOURCE_GROUP" ] || [ -z "$CLUSTER_NAME" ]; then
+  echo "Usage: $0 <resource-group> <cluster-name>"
+  exit 1
+fi
+
+az account show --output none
+az aks show --resource-group "$RESOURCE_GROUP" --name "$CLUSTER_NAME" --output none
+echo "WARNING: Existing local kubeconfig credentials will stop working."
+echo "Verify Microsoft Entra administrator access before continuing."
+read -r -p "Type APPLY to disable local accounts on '$CLUSTER_NAME': " CONFIRM
+[ "$CONFIRM" = "APPLY" ] || { echo "Cancelled."; exit 1; }
+
+az aks update --resource-group "$RESOURCE_GROUP" --name "$CLUSTER_NAME" --disable-local-accounts
+az aks show --resource-group "$RESOURCE_GROUP" --name "$CLUSTER_NAME" \
+  --query "disableLocalAccounts" --output tsv

--- a/playbooks/cli/fix_az_aks_003.sh
+++ b/playbooks/cli/fix_az_aks_003.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# OpenShield Remediation Playbook
+# Rule: AZ-AKS-003 - AKS cluster not using managed identity
+# Usage: ./fix_az_aks_003.sh <resource-group> <cluster-name>
+# Severity: HIGH
+
+set -euo pipefail
+
+RESOURCE_GROUP=${1:-}
+CLUSTER_NAME=${2:-}
+if [ -z "$RESOURCE_GROUP" ] || [ -z "$CLUSTER_NAME" ]; then
+  echo "Usage: $0 <resource-group> <cluster-name>"
+  exit 1
+fi
+
+az account show --output none
+az aks show --resource-group "$RESOURCE_GROUP" --name "$CLUSTER_NAME" --output none
+echo "WARNING: Migration changes the cluster control-plane identity."
+echo "Review dependent role assignments and allow time for permission propagation."
+read -r -p "Type APPLY to enable managed identity on '$CLUSTER_NAME': " CONFIRM
+[ "$CONFIRM" = "APPLY" ] || { echo "Cancelled."; exit 1; }
+
+az aks update --resource-group "$RESOURCE_GROUP" --name "$CLUSTER_NAME" --enable-managed-identity
+az aks show --resource-group "$RESOURCE_GROUP" --name "$CLUSTER_NAME" \
+  --query "identity.type" --output tsv

--- a/playbooks/cli/fix_az_aks_004.sh
+++ b/playbooks/cli/fix_az_aks_004.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# OpenShield Remediation Playbook
+# Rule: AZ-AKS-004 - AKS Workload Identity not fully enabled
+# Usage: ./fix_az_aks_004.sh <resource-group> <cluster-name>
+# Severity: MEDIUM
+
+set -euo pipefail
+
+RESOURCE_GROUP=${1:-}
+CLUSTER_NAME=${2:-}
+if [ -z "$RESOURCE_GROUP" ] || [ -z "$CLUSTER_NAME" ]; then
+  echo "Usage: $0 <resource-group> <cluster-name>"
+  exit 1
+fi
+
+az account show --output none
+az aks show --resource-group "$RESOURCE_GROUP" --name "$CLUSTER_NAME" --output none
+echo "This enables the OIDC issuer and Workload Identity platform features."
+echo "Each workload still requires a federated identity credential and service-account annotation."
+read -r -p "Type APPLY to continue for '$CLUSTER_NAME': " CONFIRM
+[ "$CONFIRM" = "APPLY" ] || { echo "Cancelled."; exit 1; }
+
+az aks update --resource-group "$RESOURCE_GROUP" --name "$CLUSTER_NAME" \
+  --enable-oidc-issuer --enable-workload-identity
+az aks show --resource-group "$RESOURCE_GROUP" --name "$CLUSTER_NAME" \
+  --query "{oidc:oidcIssuerProfile.enabled,workloadIdentity:securityProfile.workloadIdentity.enabled}"

--- a/playbooks/cli/fix_az_aks_005.sh
+++ b/playbooks/cli/fix_az_aks_005.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+# OpenShield Remediation Playbook
+# Rule: AZ-AKS-005 - AKS Azure Policy add-on not enabled
+# Usage: ./fix_az_aks_005.sh <resource-group> <cluster-name>
+# Severity: MEDIUM
+
+set -euo pipefail
+
+RESOURCE_GROUP=${1:-}
+CLUSTER_NAME=${2:-}
+if [ -z "$RESOURCE_GROUP" ] || [ -z "$CLUSTER_NAME" ]; then
+  echo "Usage: $0 <resource-group> <cluster-name>"
+  exit 1
+fi
+
+az account show --output none
+az aks show --resource-group "$RESOURCE_GROUP" --name "$CLUSTER_NAME" --output none
+echo "Enable the add-on first, then roll out policy initiatives in audit mode before deny mode."
+read -r -p "Type APPLY to enable Azure Policy on '$CLUSTER_NAME': " CONFIRM
+[ "$CONFIRM" = "APPLY" ] || { echo "Cancelled."; exit 1; }
+
+az aks enable-addons --resource-group "$RESOURCE_GROUP" --name "$CLUSTER_NAME" --addons azure-policy
+az aks show --resource-group "$RESOURCE_GROUP" --name "$CLUSTER_NAME" \
+  --query "addonProfiles.azurepolicy.enabled" --output tsv

--- a/playbooks/cli/fix_az_aks_006.sh
+++ b/playbooks/cli/fix_az_aks_006.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# OpenShield Remediation Playbook
+# Rule: AZ-AKS-006 - AKS node OS automatic upgrades disabled
+# Usage: ./fix_az_aks_006.sh <resource-group> <cluster-name>
+# Severity: HIGH
+
+set -euo pipefail
+
+RESOURCE_GROUP=${1:-}
+CLUSTER_NAME=${2:-}
+if [ -z "$RESOURCE_GROUP" ] || [ -z "$CLUSTER_NAME" ]; then
+  echo "Usage: $0 <resource-group> <cluster-name>"
+  exit 1
+fi
+
+az account show --output none
+az aks show --resource-group "$RESOURCE_GROUP" --name "$CLUSTER_NAME" --output none
+echo "WARNING: SecurityPatch updates can reimage nodes when required."
+echo "Configure and validate an AKS planned-maintenance window for production clusters."
+read -r -p "Type APPLY to enable SecurityPatch on '$CLUSTER_NAME': " CONFIRM
+[ "$CONFIRM" = "APPLY" ] || { echo "Cancelled."; exit 1; }
+
+az aks update --resource-group "$RESOURCE_GROUP" --name "$CLUSTER_NAME" \
+  --node-os-upgrade-channel SecurityPatch
+az aks show --resource-group "$RESOURCE_GROUP" --name "$CLUSTER_NAME" \
+  --query "autoUpgradeProfile.nodeOsUpgradeChannel" --output tsv

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,6 +14,7 @@ azure-mgmt-web==7.3.1
 azure-monitor-ingestion==1.0.3
 azure-mgmt-monitor==6.0.0
 azure-mgmt-dns==8.0.0
+azure-mgmt-containerservice==41.3.0
 psycopg2-binary==2.9.9
 python-dotenv==1.2.2
 pyjwt==2.13.0

--- a/scanner/azure_client.py
+++ b/scanner/azure_client.py
@@ -7,6 +7,7 @@ from azure.core.exceptions import HttpResponseError, ResourceNotFoundError
 from azure.identity import DefaultAzureCredential
 from azure.mgmt.authorization import AuthorizationManagementClient
 from azure.mgmt.compute import ComputeManagementClient
+from azure.mgmt.containerservice import ContainerServiceClient
 from azure.mgmt.keyvault import KeyVaultManagementClient
 from azure.mgmt.network import NetworkManagementClient
 from azure.mgmt.rdbms.postgresql import PostgreSQLManagementClient
@@ -19,6 +20,7 @@ logger = logging.getLogger(__name__)
 
 # Azure built-in role definition GUIDs (subscription-scoped)
 OWNER_ROLE_ID = "8e3af657-a8ff-443c-a75c-2fe8c4bcb635"
+_UNSET = object()
 
 
 class AzureClient:
@@ -32,6 +34,7 @@ class AzureClient:
     def __init__(self, subscription_id: str, credential: Optional[Any] = None) -> None:
         self.subscription_id = subscription_id
         self.credential = credential or DefaultAzureCredential()
+        self._managed_clusters_cache: Any = _UNSET
 
     # ------------------------------------------------------------------ #
     # Static helpers                                                        #
@@ -286,6 +289,41 @@ class AzureClient:
         except Exception as exc:
             logger.error("get_dns_record_sets failed for zone %s: %s", zone_name, exc)
             return []
+
+    # ------------------------------------------------------------------ #
+    # Kubernetes / AKS                                                     #
+    # ------------------------------------------------------------------ #
+
+    def get_managed_clusters(self) -> Optional[List[Any]]:
+        """List AKS managed clusters, preserving an indeterminate failure state.
+
+        The result is cached for the lifetime of this client because every AKS
+        rule evaluates the same subscription-level collection.
+
+        Returns:
+            A list (including an empty list) when Azure responds successfully,
+            or ``None`` when permissions, networking, or the SDK prevent the
+            collection from being evaluated. Callers must never interpret
+            ``None`` as a compliant result.
+        """
+        if self._managed_clusters_cache is not _UNSET:
+            return self._managed_clusters_cache
+
+        try:
+            client = ContainerServiceClient(self.credential, self.subscription_id)
+            self._managed_clusters_cache = list(client.managed_clusters.list())
+        except HttpResponseError as exc:
+            logger.error(
+                "get_managed_clusters HTTP %s - check Microsoft.ContainerService/managedClusters/read: %s",
+                exc.status_code,
+                exc,
+            )
+            self._managed_clusters_cache = None
+        except Exception as exc:
+            logger.error("get_managed_clusters failed: %s", exc)
+            self._managed_clusters_cache = None
+
+        return self._managed_clusters_cache
 
     # ------------------------------------------------------------------ #
     # Compute                                                               #

--- a/scanner/cve_correlator.py
+++ b/scanner/cve_correlator.py
@@ -42,6 +42,8 @@ _RULE_CVE_KEYWORD_MAP: dict[str, str] = {
     # Identity
     "AZ-IDN": "Azure Active Directory",
     "AZ-IDN-001": "Azure RBAC privilege escalation",
+    # Azure Kubernetes Service
+    "AZ-AKS": "Azure Kubernetes Service",
     # App Service
     "AZ-APP": "Azure App Service",
 }

--- a/scanner/rules/_aks_common.py
+++ b/scanner/rules/_aks_common.py
@@ -1,0 +1,55 @@
+"""Shared helpers for Azure Kubernetes Service rule modules."""
+
+from typing import Any, Dict, Mapping
+
+_MISSING = object()
+
+
+def cluster_property(cluster: Any, name: str, default: Any = None) -> Any:
+    """Read an AKS property across both flattened and nested SDK models."""
+    value = getattr(cluster, name, _MISSING)
+    if value is not _MISSING:
+        return value
+
+    properties = getattr(cluster, "properties", None)
+    if properties is None:
+        return default
+    return getattr(properties, name, default)
+
+
+def resource_identity(cluster: Any) -> tuple[str, str]:
+    """Return a validated AKS resource ID and display name."""
+    resource_id = getattr(cluster, "id", "") or ""
+    resource_name = getattr(cluster, "name", "") or ""
+    return resource_id, resource_name
+
+
+def finding(
+    cluster: Any,
+    *,
+    rule_id: str,
+    rule_name: str,
+    severity: str,
+    category: str,
+    description: str,
+    remediation: str,
+    playbook: str,
+    frameworks: Mapping[str, str],
+    metadata: Mapping[str, Any],
+) -> Dict[str, Any]:
+    """Build the repository-standard finding payload for an AKS cluster."""
+    resource_id, resource_name = resource_identity(cluster)
+    return {
+        "rule_id": rule_id,
+        "rule_name": rule_name,
+        "severity": severity,
+        "category": category,
+        "resource_id": resource_id,
+        "resource_name": resource_name,
+        "resource_type": "Microsoft.ContainerService/managedClusters",
+        "description": description,
+        "remediation": remediation,
+        "playbook": playbook,
+        "frameworks": dict(frameworks),
+        "metadata": dict(metadata),
+    }

--- a/scanner/rules/az_aks_001.py
+++ b/scanner/rules/az_aks_001.py
@@ -1,0 +1,44 @@
+"""AZ-AKS-001: AKS cluster does not use a private API server endpoint."""
+
+import logging
+from typing import Any, Dict, List
+
+from scanner.rules._aks_common import cluster_property, finding, resource_identity
+
+RULE_ID = "AZ-AKS-001"
+RULE_NAME = "AKS Private Cluster Not Enabled"
+SEVERITY = "HIGH"
+CATEGORY = "Kubernetes"
+FRAMEWORKS = {"CIS": "N/A-AKS-001", "NIST": "PR.AC-3", "ISO27001": "A.13.1.1", "SOC2": "CC6.6"}
+DESCRIPTION = (
+    "The AKS API server is reachable through a public endpoint. Public control-plane exposure "
+    "increases the opportunity for credential attacks and unauthorized cluster access."
+)
+REMEDIATION = "Enable the AKS private cluster feature after validating private DNS and administrator connectivity."
+PLAYBOOK = "playbooks/cli/fix_az_aks_001.sh"
+
+logger = logging.getLogger(__name__)
+
+
+def scan(azure_client: Any, subscription_id: str) -> List[Dict[str, Any]]:
+    findings: List[Dict[str, Any]] = []
+    clusters = azure_client.get_managed_clusters()
+    if clusters is None:
+        logger.warning("%s: AKS clusters could not be enumerated", RULE_ID)
+        return findings
+
+    for cluster in clusters:
+        resource_id, resource_name = resource_identity(cluster)
+        if not resource_id or not resource_name:
+            continue
+        profile = cluster_property(cluster, "api_server_access_profile")
+        enabled = getattr(profile, "enable_private_cluster", None) if profile is not None else None
+        if enabled is None:
+            logger.warning("%s: private-cluster status unknown for %s", RULE_ID, resource_name)
+            continue
+        if enabled is False:
+            findings.append(finding(cluster, rule_id=RULE_ID, rule_name=RULE_NAME, severity=SEVERITY,
+                                    category=CATEGORY, description=DESCRIPTION, remediation=REMEDIATION,
+                                    playbook=PLAYBOOK, frameworks=FRAMEWORKS,
+                                    metadata={"private_cluster_enabled": False}))
+    return findings

--- a/scanner/rules/az_aks_001.py
+++ b/scanner/rules/az_aks_001.py
@@ -37,8 +37,18 @@ def scan(azure_client: Any, subscription_id: str) -> List[Dict[str, Any]]:
             logger.warning("%s: private-cluster status unknown for %s", RULE_ID, resource_name)
             continue
         if enabled is False:
-            findings.append(finding(cluster, rule_id=RULE_ID, rule_name=RULE_NAME, severity=SEVERITY,
-                                    category=CATEGORY, description=DESCRIPTION, remediation=REMEDIATION,
-                                    playbook=PLAYBOOK, frameworks=FRAMEWORKS,
-                                    metadata={"private_cluster_enabled": False}))
+            findings.append(
+                finding(
+                    cluster,
+                    rule_id=RULE_ID,
+                    rule_name=RULE_NAME,
+                    severity=SEVERITY,
+                    category=CATEGORY,
+                    description=DESCRIPTION,
+                    remediation=REMEDIATION,
+                    playbook=PLAYBOOK,
+                    frameworks=FRAMEWORKS,
+                    metadata={"private_cluster_enabled": False},
+                )
+            )
     return findings

--- a/scanner/rules/az_aks_002.py
+++ b/scanner/rules/az_aks_002.py
@@ -35,8 +35,18 @@ def scan(azure_client: Any, subscription_id: str) -> List[Dict[str, Any]]:
             logger.warning("%s: local-account status unknown for %s", RULE_ID, resource_name)
             continue
         if disabled is False:
-            findings.append(finding(cluster, rule_id=RULE_ID, rule_name=RULE_NAME, severity=SEVERITY,
-                                    category=CATEGORY, description=DESCRIPTION, remediation=REMEDIATION,
-                                    playbook=PLAYBOOK, frameworks=FRAMEWORKS,
-                                    metadata={"local_accounts_disabled": False}))
+            findings.append(
+                finding(
+                    cluster,
+                    rule_id=RULE_ID,
+                    rule_name=RULE_NAME,
+                    severity=SEVERITY,
+                    category=CATEGORY,
+                    description=DESCRIPTION,
+                    remediation=REMEDIATION,
+                    playbook=PLAYBOOK,
+                    frameworks=FRAMEWORKS,
+                    metadata={"local_accounts_disabled": False},
+                )
+            )
     return findings

--- a/scanner/rules/az_aks_002.py
+++ b/scanner/rules/az_aks_002.py
@@ -1,0 +1,42 @@
+"""AZ-AKS-002: AKS local administrator accounts are enabled."""
+
+import logging
+from typing import Any, Dict, List
+
+from scanner.rules._aks_common import cluster_property, finding, resource_identity
+
+RULE_ID = "AZ-AKS-002"
+RULE_NAME = "AKS Local Accounts Enabled"
+SEVERITY = "HIGH"
+CATEGORY = "Kubernetes"
+FRAMEWORKS = {"CIS": "N/A-AKS-002", "NIST": "PR.AC-1", "ISO27001": "A.9.2.1", "SOC2": "CC6.1"}
+DESCRIPTION = (
+    "Local AKS accounts bypass centralized Microsoft Entra identity controls and can provide "
+    "long-lived cluster access outside normal conditional-access and lifecycle processes."
+)
+REMEDIATION = "Disable AKS local accounts after confirming Microsoft Entra administrators can access the cluster."
+PLAYBOOK = "playbooks/cli/fix_az_aks_002.sh"
+
+logger = logging.getLogger(__name__)
+
+
+def scan(azure_client: Any, subscription_id: str) -> List[Dict[str, Any]]:
+    findings: List[Dict[str, Any]] = []
+    clusters = azure_client.get_managed_clusters()
+    if clusters is None:
+        logger.warning("%s: AKS clusters could not be enumerated", RULE_ID)
+        return findings
+    for cluster in clusters:
+        resource_id, resource_name = resource_identity(cluster)
+        if not resource_id or not resource_name:
+            continue
+        disabled = cluster_property(cluster, "disable_local_accounts")
+        if disabled is None:
+            logger.warning("%s: local-account status unknown for %s", RULE_ID, resource_name)
+            continue
+        if disabled is False:
+            findings.append(finding(cluster, rule_id=RULE_ID, rule_name=RULE_NAME, severity=SEVERITY,
+                                    category=CATEGORY, description=DESCRIPTION, remediation=REMEDIATION,
+                                    playbook=PLAYBOOK, frameworks=FRAMEWORKS,
+                                    metadata={"local_accounts_disabled": False}))
+    return findings

--- a/scanner/rules/az_aks_003.py
+++ b/scanner/rules/az_aks_003.py
@@ -1,0 +1,41 @@
+"""AZ-AKS-003: AKS cluster uses a legacy service principal."""
+
+import logging
+from typing import Any, Dict, List
+
+from scanner.rules._aks_common import finding, resource_identity
+
+RULE_ID = "AZ-AKS-003"
+RULE_NAME = "AKS Cluster Not Using Managed Identity"
+SEVERITY = "HIGH"
+CATEGORY = "Kubernetes"
+FRAMEWORKS = {"CIS": "N/A-AKS-003", "NIST": "PR.AC-1", "ISO27001": "A.9.2.1", "SOC2": "CC6.1"}
+DESCRIPTION = (
+    "The AKS control plane is not configured with a managed identity. Legacy service principals "
+    "depend on credentials that require rotation and can be exposed or expire unexpectedly."
+)
+REMEDIATION = "Migrate the AKS cluster from its service principal to a system- or user-assigned managed identity."
+PLAYBOOK = "playbooks/cli/fix_az_aks_003.sh"
+
+logger = logging.getLogger(__name__)
+_MANAGED_TYPES = {"systemassigned", "userassigned", "systemassigned,userassigned"}
+
+
+def scan(azure_client: Any, subscription_id: str) -> List[Dict[str, Any]]:
+    findings: List[Dict[str, Any]] = []
+    clusters = azure_client.get_managed_clusters()
+    if clusters is None:
+        logger.warning("%s: AKS clusters could not be enumerated", RULE_ID)
+        return findings
+    for cluster in clusters:
+        resource_id, resource_name = resource_identity(cluster)
+        if not resource_id or not resource_name:
+            continue
+        identity = getattr(cluster, "identity", None)
+        identity_type = str(getattr(identity, "type", "") or "").replace(" ", "").lower()
+        if identity_type not in _MANAGED_TYPES:
+            findings.append(finding(cluster, rule_id=RULE_ID, rule_name=RULE_NAME, severity=SEVERITY,
+                                    category=CATEGORY, description=DESCRIPTION, remediation=REMEDIATION,
+                                    playbook=PLAYBOOK, frameworks=FRAMEWORKS,
+                                    metadata={"identity_type": identity_type or "service-principal"}))
+    return findings

--- a/scanner/rules/az_aks_003.py
+++ b/scanner/rules/az_aks_003.py
@@ -34,8 +34,18 @@ def scan(azure_client: Any, subscription_id: str) -> List[Dict[str, Any]]:
         identity = getattr(cluster, "identity", None)
         identity_type = str(getattr(identity, "type", "") or "").replace(" ", "").lower()
         if identity_type not in _MANAGED_TYPES:
-            findings.append(finding(cluster, rule_id=RULE_ID, rule_name=RULE_NAME, severity=SEVERITY,
-                                    category=CATEGORY, description=DESCRIPTION, remediation=REMEDIATION,
-                                    playbook=PLAYBOOK, frameworks=FRAMEWORKS,
-                                    metadata={"identity_type": identity_type or "service-principal"}))
+            findings.append(
+                finding(
+                    cluster,
+                    rule_id=RULE_ID,
+                    rule_name=RULE_NAME,
+                    severity=SEVERITY,
+                    category=CATEGORY,
+                    description=DESCRIPTION,
+                    remediation=REMEDIATION,
+                    playbook=PLAYBOOK,
+                    frameworks=FRAMEWORKS,
+                    metadata={"identity_type": identity_type or "service-principal"},
+                )
+            )
     return findings

--- a/scanner/rules/az_aks_004.py
+++ b/scanner/rules/az_aks_004.py
@@ -1,0 +1,44 @@
+"""AZ-AKS-004: AKS Workload Identity or OIDC issuer is disabled."""
+
+import logging
+from typing import Any, Dict, List
+
+from scanner.rules._aks_common import cluster_property, finding, resource_identity
+
+RULE_ID = "AZ-AKS-004"
+RULE_NAME = "AKS Workload Identity Not Fully Enabled"
+SEVERITY = "MEDIUM"
+CATEGORY = "Kubernetes"
+FRAMEWORKS = {"CIS": "N/A-AKS-004", "NIST": "PR.AC-4", "ISO27001": "A.9.2.3", "SOC2": "CC6.3"}
+DESCRIPTION = (
+    "AKS Workload Identity and its OIDC issuer are not both enabled. Applications may consequently "
+    "depend on shared credentials or broader node identities when accessing Azure resources."
+)
+REMEDIATION = "Enable both the AKS OIDC issuer and Microsoft Entra Workload Identity, then federate each workload."
+PLAYBOOK = "playbooks/cli/fix_az_aks_004.sh"
+
+logger = logging.getLogger(__name__)
+
+
+def scan(azure_client: Any, subscription_id: str) -> List[Dict[str, Any]]:
+    findings: List[Dict[str, Any]] = []
+    clusters = azure_client.get_managed_clusters()
+    if clusters is None:
+        logger.warning("%s: AKS clusters could not be enumerated", RULE_ID)
+        return findings
+    for cluster in clusters:
+        resource_id, resource_name = resource_identity(cluster)
+        if not resource_id or not resource_name:
+            continue
+        oidc_profile = cluster_property(cluster, "oidc_issuer_profile")
+        security_profile = cluster_property(cluster, "security_profile")
+        workload_profile = getattr(security_profile, "workload_identity", None) if security_profile else None
+        oidc_enabled = bool(getattr(oidc_profile, "enabled", False))
+        workload_enabled = bool(getattr(workload_profile, "enabled", False))
+        if not (oidc_enabled and workload_enabled):
+            findings.append(finding(cluster, rule_id=RULE_ID, rule_name=RULE_NAME, severity=SEVERITY,
+                                    category=CATEGORY, description=DESCRIPTION, remediation=REMEDIATION,
+                                    playbook=PLAYBOOK, frameworks=FRAMEWORKS,
+                                    metadata={"oidc_issuer_enabled": oidc_enabled,
+                                              "workload_identity_enabled": workload_enabled}))
+    return findings

--- a/scanner/rules/az_aks_004.py
+++ b/scanner/rules/az_aks_004.py
@@ -36,9 +36,18 @@ def scan(azure_client: Any, subscription_id: str) -> List[Dict[str, Any]]:
         oidc_enabled = bool(getattr(oidc_profile, "enabled", False))
         workload_enabled = bool(getattr(workload_profile, "enabled", False))
         if not (oidc_enabled and workload_enabled):
-            findings.append(finding(cluster, rule_id=RULE_ID, rule_name=RULE_NAME, severity=SEVERITY,
-                                    category=CATEGORY, description=DESCRIPTION, remediation=REMEDIATION,
-                                    playbook=PLAYBOOK, frameworks=FRAMEWORKS,
-                                    metadata={"oidc_issuer_enabled": oidc_enabled,
-                                              "workload_identity_enabled": workload_enabled}))
+            findings.append(
+                finding(
+                    cluster,
+                    rule_id=RULE_ID,
+                    rule_name=RULE_NAME,
+                    severity=SEVERITY,
+                    category=CATEGORY,
+                    description=DESCRIPTION,
+                    remediation=REMEDIATION,
+                    playbook=PLAYBOOK,
+                    frameworks=FRAMEWORKS,
+                    metadata={"oidc_issuer_enabled": oidc_enabled, "workload_identity_enabled": workload_enabled},
+                )
+            )
     return findings

--- a/scanner/rules/az_aks_005.py
+++ b/scanner/rules/az_aks_005.py
@@ -34,8 +34,18 @@ def scan(azure_client: Any, subscription_id: str) -> List[Dict[str, Any]]:
         azure_policy = profiles.get("azurepolicy") if isinstance(profiles, Mapping) else None
         enabled = bool(getattr(azure_policy, "enabled", False))
         if not enabled:
-            findings.append(finding(cluster, rule_id=RULE_ID, rule_name=RULE_NAME, severity=SEVERITY,
-                                    category=CATEGORY, description=DESCRIPTION, remediation=REMEDIATION,
-                                    playbook=PLAYBOOK, frameworks=FRAMEWORKS,
-                                    metadata={"azure_policy_enabled": False}))
+            findings.append(
+                finding(
+                    cluster,
+                    rule_id=RULE_ID,
+                    rule_name=RULE_NAME,
+                    severity=SEVERITY,
+                    category=CATEGORY,
+                    description=DESCRIPTION,
+                    remediation=REMEDIATION,
+                    playbook=PLAYBOOK,
+                    frameworks=FRAMEWORKS,
+                    metadata={"azure_policy_enabled": False},
+                )
+            )
     return findings

--- a/scanner/rules/az_aks_005.py
+++ b/scanner/rules/az_aks_005.py
@@ -1,0 +1,41 @@
+"""AZ-AKS-005: Azure Policy add-on is disabled for AKS."""
+
+import logging
+from typing import Any, Dict, List, Mapping
+
+from scanner.rules._aks_common import cluster_property, finding, resource_identity
+
+RULE_ID = "AZ-AKS-005"
+RULE_NAME = "AKS Azure Policy Add-on Not Enabled"
+SEVERITY = "MEDIUM"
+CATEGORY = "Kubernetes"
+FRAMEWORKS = {"CIS": "N/A-AKS-005", "NIST": "PR.IP-1", "ISO27001": "A.12.1.2", "SOC2": "CC8.1"}
+DESCRIPTION = (
+    "The Azure Policy add-on is not enabled for the AKS cluster. The organization cannot centrally "
+    "audit or enforce Kubernetes admission controls through Azure Policy."
+)
+REMEDIATION = "Enable the Azure Policy add-on and assign an appropriate AKS security initiative in audit mode first."
+PLAYBOOK = "playbooks/cli/fix_az_aks_005.sh"
+
+logger = logging.getLogger(__name__)
+
+
+def scan(azure_client: Any, subscription_id: str) -> List[Dict[str, Any]]:
+    findings: List[Dict[str, Any]] = []
+    clusters = azure_client.get_managed_clusters()
+    if clusters is None:
+        logger.warning("%s: AKS clusters could not be enumerated", RULE_ID)
+        return findings
+    for cluster in clusters:
+        resource_id, resource_name = resource_identity(cluster)
+        if not resource_id or not resource_name:
+            continue
+        profiles = cluster_property(cluster, "addon_profiles", {}) or {}
+        azure_policy = profiles.get("azurepolicy") if isinstance(profiles, Mapping) else None
+        enabled = bool(getattr(azure_policy, "enabled", False))
+        if not enabled:
+            findings.append(finding(cluster, rule_id=RULE_ID, rule_name=RULE_NAME, severity=SEVERITY,
+                                    category=CATEGORY, description=DESCRIPTION, remediation=REMEDIATION,
+                                    playbook=PLAYBOOK, frameworks=FRAMEWORKS,
+                                    metadata={"azure_policy_enabled": False}))
+    return findings

--- a/scanner/rules/az_aks_006.py
+++ b/scanner/rules/az_aks_006.py
@@ -34,8 +34,18 @@ def scan(azure_client: Any, subscription_id: str) -> List[Dict[str, Any]]:
         profile = cluster_property(cluster, "auto_upgrade_profile")
         channel = str(getattr(profile, "node_os_upgrade_channel", "") or "")
         if channel.lower() not in _COMPLIANT_CHANNELS:
-            findings.append(finding(cluster, rule_id=RULE_ID, rule_name=RULE_NAME, severity=SEVERITY,
-                                    category=CATEGORY, description=DESCRIPTION, remediation=REMEDIATION,
-                                    playbook=PLAYBOOK, frameworks=FRAMEWORKS,
-                                    metadata={"node_os_upgrade_channel": channel or "None"}))
+            findings.append(
+                finding(
+                    cluster,
+                    rule_id=RULE_ID,
+                    rule_name=RULE_NAME,
+                    severity=SEVERITY,
+                    category=CATEGORY,
+                    description=DESCRIPTION,
+                    remediation=REMEDIATION,
+                    playbook=PLAYBOOK,
+                    frameworks=FRAMEWORKS,
+                    metadata={"node_os_upgrade_channel": channel or "None"},
+                )
+            )
     return findings

--- a/scanner/rules/az_aks_006.py
+++ b/scanner/rules/az_aks_006.py
@@ -1,0 +1,41 @@
+"""AZ-AKS-006: AKS node OS automatic security upgrades are disabled."""
+
+import logging
+from typing import Any, Dict, List
+
+from scanner.rules._aks_common import cluster_property, finding, resource_identity
+
+RULE_ID = "AZ-AKS-006"
+RULE_NAME = "AKS Node OS Automatic Upgrades Disabled"
+SEVERITY = "HIGH"
+CATEGORY = "Kubernetes"
+FRAMEWORKS = {"CIS": "N/A-AKS-006", "NIST": "PR.IP-12", "ISO27001": "A.12.6.1", "SOC2": "CC7.1"}
+DESCRIPTION = (
+    "The AKS node OS upgrade channel does not automatically apply managed security updates. "
+    "Worker nodes can remain exposed to operating-system vulnerabilities without a separate patch process."
+)
+REMEDIATION = "Set the AKS node OS upgrade channel to SecurityPatch or NodeImage and configure a maintenance window."
+PLAYBOOK = "playbooks/cli/fix_az_aks_006.sh"
+
+logger = logging.getLogger(__name__)
+_COMPLIANT_CHANNELS = {"securitypatch", "nodeimage"}
+
+
+def scan(azure_client: Any, subscription_id: str) -> List[Dict[str, Any]]:
+    findings: List[Dict[str, Any]] = []
+    clusters = azure_client.get_managed_clusters()
+    if clusters is None:
+        logger.warning("%s: AKS clusters could not be enumerated", RULE_ID)
+        return findings
+    for cluster in clusters:
+        resource_id, resource_name = resource_identity(cluster)
+        if not resource_id or not resource_name:
+            continue
+        profile = cluster_property(cluster, "auto_upgrade_profile")
+        channel = str(getattr(profile, "node_os_upgrade_channel", "") or "")
+        if channel.lower() not in _COMPLIANT_CHANNELS:
+            findings.append(finding(cluster, rule_id=RULE_ID, rule_name=RULE_NAME, severity=SEVERITY,
+                                    category=CATEGORY, description=DESCRIPTION, remediation=REMEDIATION,
+                                    playbook=PLAYBOOK, frameworks=FRAMEWORKS,
+                                    metadata={"node_os_upgrade_channel": channel or "None"}))
+    return findings

--- a/tests/helpers/mock_azure.py
+++ b/tests/helpers/mock_azure.py
@@ -81,6 +81,7 @@ class MockAzureClient:
         self._dns_zones: List[Any] = []
         self._dns_record_sets: Dict[Tuple[str, str], List[Any]] = {}
         self._web_apps: List[Any] = []
+        self._managed_clusters: Optional[List[Any]] = []
         # Some rules read azure_client.subscription_id when constructing an
         # SDK management client inside scan() (e.g. AZ-NET-007..010).
         self.subscription_id = "00000000-0000-0000-0000-000000000001"
@@ -88,6 +89,14 @@ class MockAzureClient:
     def set_storage_accounts(self, accounts: List[Any]) -> "MockAzureClient":
         self._storage_accounts = accounts
         return self
+
+    def set_managed_clusters(self, clusters: Optional[List[Any]]) -> "MockAzureClient":
+        """Configure AKS inventory; ``None`` represents an API failure."""
+        self._managed_clusters = clusters
+        return self
+
+    def get_managed_clusters(self) -> Optional[List[Any]]:
+        return self._managed_clusters
 
     def set_network_security_groups(self, nsgs: List[Any]) -> "MockAzureClient":
         self._network_security_groups = nsgs

--- a/tests/test_azure_client_aks.py
+++ b/tests/test_azure_client_aks.py
@@ -1,0 +1,44 @@
+"""Tests for the AzureClient AKS inventory accessor."""
+
+from unittest.mock import MagicMock, patch
+
+from azure.core.exceptions import HttpResponseError
+
+from scanner.azure_client import AzureClient
+
+
+@patch("scanner.azure_client.ContainerServiceClient")
+def test_get_managed_clusters_returns_and_caches_successful_inventory(client_type):
+    sdk_client = client_type.return_value
+    sdk_client.managed_clusters.list.return_value = ["cluster-a", "cluster-b"]
+    client = AzureClient("sub-1", credential=MagicMock())
+
+    assert client.get_managed_clusters() == ["cluster-a", "cluster-b"]
+    assert client.get_managed_clusters() == ["cluster-a", "cluster-b"]
+    sdk_client.managed_clusters.list.assert_called_once_with()
+
+
+@patch("scanner.azure_client.ContainerServiceClient")
+def test_get_managed_clusters_preserves_empty_successful_inventory(client_type):
+    client_type.return_value.managed_clusters.list.return_value = []
+    client = AzureClient("sub-1", credential=MagicMock())
+
+    assert client.get_managed_clusters() == []
+
+
+@patch("scanner.azure_client.ContainerServiceClient")
+def test_get_managed_clusters_returns_and_caches_none_on_http_failure(client_type):
+    client_type.return_value.managed_clusters.list.side_effect = HttpResponseError(message="forbidden")
+    client = AzureClient("sub-1", credential=MagicMock())
+
+    assert client.get_managed_clusters() is None
+    assert client.get_managed_clusters() is None
+    client_type.return_value.managed_clusters.list.assert_called_once_with()
+
+
+@patch("scanner.azure_client.ContainerServiceClient")
+def test_get_managed_clusters_returns_none_on_unexpected_failure(client_type):
+    client_type.return_value.managed_clusters.list.side_effect = RuntimeError("network unavailable")
+    client = AzureClient("sub-1", credential=MagicMock())
+
+    assert client.get_managed_clusters() is None

--- a/tests/test_engine_integration.py
+++ b/tests/test_engine_integration.py
@@ -43,11 +43,11 @@ def _nsg_id(name):
     return f"/subscriptions/{_SUB}/resourceGroups/{_RG}/providers/Microsoft.Network/networkSecurityGroups/{name}"
 
 
-def test_engine_loads_all_45_rules(monkeypatch):
-    """The engine must dynamically load all 45 rule modules."""
+def test_engine_loads_all_51_rules(monkeypatch):
+    """The engine must dynamically load the complete rule set."""
     _patch_engine_client(monkeypatch, _offline_mock())
     eng = ScanEngine(_SUB)
-    assert len(eng.rules) >= 45
+    assert len(eng.rules) >= 51
     # Every loaded rule must expose a callable scan() and a RULE_ID.
     for rule in eng.rules:
         assert callable(getattr(rule, "scan", None))
@@ -129,7 +129,7 @@ def test_engine_isolates_a_failing_rule(monkeypatch):
 
     result = eng.run_scan()  # must not raise
     assert result["status"] == "completed"
-    # The other 44 rules still ran (empty mock -> no findings) and the scan
+    # The other rules still ran (empty mock -> no findings) and the scan
     # completed. Crucially, there is NO field in the result naming the failed
     # rule -- this is the observability gap flagged in the validation report.
     assert "errored_rules" not in result

--- a/tests/test_rules_aks.py
+++ b/tests/test_rules_aks.py
@@ -1,0 +1,151 @@
+"""Unit tests for the AZ-AKS-001 through AZ-AKS-006 rule pack."""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from scanner.rules import az_aks_001, az_aks_002, az_aks_003, az_aks_004, az_aks_005, az_aks_006
+
+
+def ns(**kwargs):
+    return SimpleNamespace(**kwargs)
+
+
+def cluster(**overrides):
+    values = {
+        "id": "/subscriptions/sub-1/resourceGroups/rg-1/providers/Microsoft.ContainerService/managedClusters/aks-1",
+        "name": "aks-1",
+        "api_server_access_profile": ns(enable_private_cluster=True),
+        "disable_local_accounts": True,
+        "identity": ns(type="SystemAssigned"),
+        "oidc_issuer_profile": ns(enabled=True),
+        "security_profile": ns(workload_identity=ns(enabled=True)),
+        "addon_profiles": {"azurepolicy": ns(enabled=True)},
+        "auto_upgrade_profile": ns(node_os_upgrade_channel="SecurityPatch"),
+    }
+    values.update(overrides)
+    return ns(**values)
+
+
+RULES = [az_aks_001, az_aks_002, az_aks_003, az_aks_004, az_aks_005, az_aks_006]
+
+
+@pytest.mark.parametrize("rule", RULES)
+def test_compliant_cluster_returns_no_findings(rule):
+    client = MagicMock()
+    client.get_managed_clusters.return_value = [cluster()]
+
+    assert rule.scan(client, "sub-1") == []
+
+
+@pytest.mark.parametrize(
+    ("rule", "override", "metadata_key"),
+    [
+        (az_aks_001, {"api_server_access_profile": ns(enable_private_cluster=False)}, "private_cluster_enabled"),
+        (az_aks_002, {"disable_local_accounts": False}, "local_accounts_disabled"),
+        (az_aks_003, {"identity": None}, "identity_type"),
+        (
+            az_aks_004,
+            {"oidc_issuer_profile": ns(enabled=False)},
+            "oidc_issuer_enabled",
+        ),
+        (az_aks_005, {"addon_profiles": {}}, "azure_policy_enabled"),
+        (az_aks_006, {"auto_upgrade_profile": ns(node_os_upgrade_channel="None")}, "node_os_upgrade_channel"),
+    ],
+)
+def test_non_compliant_cluster_returns_standard_finding(rule, override, metadata_key):
+    client = MagicMock()
+    client.get_managed_clusters.return_value = [cluster(**override)]
+
+    findings = rule.scan(client, "sub-1")
+
+    assert len(findings) == 1
+    result = findings[0]
+    assert result["rule_id"] == rule.RULE_ID
+    assert result["resource_name"] == "aks-1"
+    assert result["resource_type"] == "Microsoft.ContainerService/managedClusters"
+    assert result["playbook"] == rule.PLAYBOOK
+    assert metadata_key in result["metadata"]
+
+
+@pytest.mark.parametrize("rule", RULES)
+def test_inventory_failure_never_creates_false_finding(rule):
+    client = MagicMock()
+    client.get_managed_clusters.return_value = None
+
+    assert rule.scan(client, "sub-1") == []
+
+
+@pytest.mark.parametrize("rule", RULES)
+def test_invalid_resource_identity_is_skipped(rule):
+    client = MagicMock()
+    client.get_managed_clusters.return_value = [cluster(id="")]
+
+    assert rule.scan(client, "sub-1") == []
+
+
+def test_unknown_private_cluster_state_is_skipped():
+    client = MagicMock()
+    client.get_managed_clusters.return_value = [cluster(api_server_access_profile=None)]
+
+    assert az_aks_001.scan(client, "sub-1") == []
+
+
+def test_unknown_local_account_state_is_skipped():
+    client = MagicMock()
+    client.get_managed_clusters.return_value = [cluster(disable_local_accounts=None)]
+
+    assert az_aks_002.scan(client, "sub-1") == []
+
+
+def test_current_sdk_nested_properties_are_supported():
+    current_model_cluster = ns(
+        id="/subscriptions/sub-1/resourceGroups/rg-1/providers/Microsoft.ContainerService/managedClusters/aks-2",
+        name="aks-2",
+        identity=ns(type="SystemAssigned"),
+        properties=ns(
+            api_server_access_profile=ns(enable_private_cluster=False),
+            disable_local_accounts=False,
+            oidc_issuer_profile=ns(enabled=False),
+            security_profile=ns(workload_identity=ns(enabled=False)),
+            addon_profiles={},
+            auto_upgrade_profile=ns(node_os_upgrade_channel="None"),
+        ),
+    )
+    client = MagicMock()
+    client.get_managed_clusters.return_value = [current_model_cluster]
+
+    assert [len(rule.scan(client, "sub-1")) for rule in RULES] == [1, 1, 0, 1, 1, 1]
+
+
+def test_multiple_clusters_are_evaluated_independently():
+    client = MagicMock()
+    client.get_managed_clusters.return_value = [
+        cluster(),
+        cluster(
+            id="/subscriptions/sub-1/resourceGroups/rg-1/providers/Microsoft.ContainerService/managedClusters/aks-2",
+            name="aks-2",
+            disable_local_accounts=False,
+        ),
+    ]
+
+    findings = az_aks_002.scan(client, "sub-1")
+
+    assert [item["resource_name"] for item in findings] == ["aks-2"]
+
+
+@pytest.mark.parametrize("identity_type", ["SystemAssigned", "UserAssigned", "SystemAssigned, UserAssigned"])
+def test_supported_managed_identity_types_are_compliant(identity_type):
+    client = MagicMock()
+    client.get_managed_clusters.return_value = [cluster(identity=ns(type=identity_type))]
+
+    assert az_aks_003.scan(client, "sub-1") == []
+
+
+@pytest.mark.parametrize("channel", ["SecurityPatch", "NodeImage", "securitypatch", "nodeimage"])
+def test_managed_node_os_channels_are_compliant(channel):
+    client = MagicMock()
+    client.get_managed_clusters.return_value = [cluster(auto_upgrade_profile=ns(node_os_upgrade_channel=channel))]
+
+    assert az_aks_006.scan(client, "sub-1") == []


### PR DESCRIPTION
## What does this PR do?

Adds enterprise-focused Azure Kubernetes Service control-plane coverage with a cached, failure-aware AKS inventory accessor and six independently testable security rules.

## Type of change

- [x] New scan rules
- [x] Remediation playbooks
- [x] Documentation
- [x] Compliance mapping

## Rule details

| Rule | Severity | Detection |
|---|---|---|
| `AZ-AKS-001` | HIGH | Private cluster not enabled |
| `AZ-AKS-002` | HIGH | Local Kubernetes accounts enabled |
| `AZ-AKS-003` | HIGH | Managed identity not used |
| `AZ-AKS-004` | MEDIUM | OIDC issuer or Workload Identity disabled |
| `AZ-AKS-005` | MEDIUM | Azure Policy add-on disabled |
| `AZ-AKS-006` | HIGH | Managed node OS security upgrades disabled |

Category: `Kubernetes`

## Design and safety

- Uses ARM management-plane inspection only; it never requests kubeconfig or Kubernetes administrator credentials.
- Pins `azure-mgmt-containerservice==41.3.0`.
- Supports both flattened legacy SDK objects and the current nested `properties` model.
- Caches AKS inventory so six rules perform one subscription-level API call per scan.
- Preserves `None` as an indeterminate API/permission failure so an incomplete scan cannot be reported as compliant.
- Validates resource identity and excludes credentials, tokens, kubeconfig, and secrets from finding metadata.
- Remediation playbooks validate the Azure account and target, warn about operational impact, require an explicit `APPLY`, and verify the resulting state.

## Compliance

Mappings were added for the repository's existing NIST CSF 1.1, ISO/IEC 27001:2013, and SOC 2 schemas. The repository currently models CIS Microsoft Azure Foundations 2.0.0, which does not directly contain these AKS checks. CIS values are therefore explicitly marked `N/A-AKS-*`; this PR does not claim CIS Kubernetes Benchmark coverage.

## Testing

- [x] 370 tests passed from a clean checkout
- [x] 3 existing environment-dependent tests skipped
- [x] 39 AKS-specific tests passed
- [x] Compliant, non-compliant, unknown, multiple-cluster, nested-SDK, caching, HTTP-failure, and unexpected-failure paths covered
- [x] Ruff passed
- [x] Rule structure, uniqueness, playbook, JSON, and compliance cross-reference validation passed
- [x] All Bash playbooks passed syntax validation
- [x] Bandit passed at CI severity threshold
- [x] `pip-audit` found no known vulnerabilities using the CI exclusions
- [x] `pip check` found no broken requirements
- [x] No hardcoded credentials or secrets
- [ ] Live Azure subscription validation (requires an approved non-production AKS environment)

## Required permission

The scanner only requires:

```text
Microsoft.ContainerService/managedClusters/read
```

This is included in Azure's built-in Reader role.

## Related issue

Closes #186