### PR TITLE
feat(scanner): add Supply Chain security pack (AZ-SC-001..008)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,3 +12,7 @@ GEMINI_API_KEY=
 # Optional
 NVD_API_KEY=
 SENTRY_DSN=
+
+# Optional - enables AZ-SC-007/008 (Azure DevOps pipeline scanning)
+AZURE_DEVOPS_ORG_URL=
+AZURE_DEVOPS_PROJECT=

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,13 +50,9 @@ from typing import Any, Dict, List
 
 RULE_ID = "AZ-STOR-001"
 RULE_NAME = "Public Blob Access Enabled on Storage Account"
-SEVERITY = "HIGH"           # HIGH / MEDIUM / LOW / INFO
-CATEGORY = "Storage"        # Storage / Network / Identity / Database / Compute / Key Vault / Kubernetes
-FRAMEWORKS = {
-    "CIS": "3.5",
-    "NIST": "PR.AC-3",
-    "ISO27001": "A.9.4.1"
-}
+SEVERITY = "HIGH"  # HIGH / MEDIUM / LOW / INFO
+CATEGORY = "Storage"  # Storage / Network / Identity / Database / Compute / Key Vault / Kubernetes
+FRAMEWORKS = {"CIS": "3.5", "NIST": "PR.AC-3", "ISO27001": "A.9.4.1"}
 DESCRIPTION = (
     "Storage accounts with public blob access enabled allow anyone on the "
     "internet to read data without authentication. This can lead to data "
@@ -72,20 +68,22 @@ def scan(azure_client: Any, subscription_id: str) -> List[Dict[str, Any]]:
 
     for account in azure_client.get_storage_accounts():
         if getattr(account, "allow_blob_public_access", False):
-            findings.append({
-                "rule_id": RULE_ID,
-                "rule_name": RULE_NAME,
-                "severity": SEVERITY,
-                "category": CATEGORY,
-                "resource_id": account.id,
-                "resource_name": account.name,
-                "resource_type": "Microsoft.Storage/storageAccounts",
-                "description": DESCRIPTION,
-                "remediation": REMEDIATION,
-                "playbook": PLAYBOOK,
-                "frameworks": FRAMEWORKS,
-                "metadata": {}
-            })
+            findings.append(
+                {
+                    "rule_id": RULE_ID,
+                    "rule_name": RULE_NAME,
+                    "severity": SEVERITY,
+                    "category": CATEGORY,
+                    "resource_id": account.id,
+                    "resource_name": account.name,
+                    "resource_type": "Microsoft.Storage/storageAccounts",
+                    "description": DESCRIPTION,
+                    "remediation": REMEDIATION,
+                    "playbook": PLAYBOOK,
+                    "frameworks": FRAMEWORKS,
+                    "metadata": {},
+                }
+            )
 
     return findings
 ```

--- a/compliance/frameworks/cis_azure_benchmark.json
+++ b/compliance/frameworks/cis_azure_benchmark.json
@@ -287,6 +287,14 @@
       "control_id": "TBD-IDN-015",
       "control_name": "Managed Identity least privilege (not mapped in CIS Azure Foundations 2.0.0)",
       "description": "Microsoft recommends least-privilege roles and scopes for managed identities. This check has no direct control in the repository's CIS Azure Foundations 2.0.0 benchmark."
-    }
+    },
+    "AZ-SC-001": {"control_id":"TBD-SC-001","control_name":"Container Registry Admin User Enabled placeholder","description":"Numbered placeholder pending maintainer approval of a direct CIS mapping."},
+    "AZ-SC-002": {"control_id":"TBD-SC-002","control_name":"Container Registry Public Network Access Enabled placeholder","description":"Numbered placeholder pending maintainer approval of a direct CIS mapping."},
+    "AZ-SC-003": {"control_id":"TBD-SC-003","control_name":"Container Registry Allows Anonymous Pull placeholder","description":"Numbered placeholder pending maintainer approval of a direct CIS mapping."},
+    "AZ-SC-004": {"control_id":"TBD-SC-004","control_name":"Container Registry Missing Retention or Quarantine Policy placeholder","description":"Numbered placeholder pending maintainer approval of a direct CIS mapping."},
+    "AZ-SC-005": {"control_id":"TBD-SC-005","control_name":"Terraform State Storage Container Publicly Readable placeholder","description":"Numbered placeholder pending maintainer approval of a direct CIS mapping."},
+    "AZ-SC-006": {"control_id":"TBD-SC-006","control_name":"Terraform State Storage Account Missing Versioning or Soft Delete placeholder","description":"Numbered placeholder pending maintainer approval of a direct CIS mapping."},
+    "AZ-SC-007": {"control_id":"TBD-SC-007","control_name":"Pipeline Service Connection Scoped to Subscription and Shared placeholder","description":"Numbered placeholder pending maintainer approval of a direct CIS mapping."},
+    "AZ-SC-008": {"control_id":"TBD-SC-008","control_name":"Pipeline Service Connection Uses Password Instead of Federated Credential placeholder","description":"Numbered placeholder pending maintainer approval of a direct CIS mapping."}
   }
 }

--- a/compliance/frameworks/cis_azure_benchmark.json
+++ b/compliance/frameworks/cis_azure_benchmark.json
@@ -288,13 +288,45 @@
       "control_name": "Managed Identity least privilege (not mapped in CIS Azure Foundations 2.0.0)",
       "description": "Microsoft recommends least-privilege roles and scopes for managed identities. This check has no direct control in the repository's CIS Azure Foundations 2.0.0 benchmark."
     },
-    "AZ-SC-001": {"control_id":"TBD-SC-001","control_name":"Container Registry Admin User Enabled placeholder","description":"Numbered placeholder pending maintainer approval of a direct CIS mapping."},
-    "AZ-SC-002": {"control_id":"TBD-SC-002","control_name":"Container Registry Public Network Access Enabled placeholder","description":"Numbered placeholder pending maintainer approval of a direct CIS mapping."},
-    "AZ-SC-003": {"control_id":"TBD-SC-003","control_name":"Container Registry Allows Anonymous Pull placeholder","description":"Numbered placeholder pending maintainer approval of a direct CIS mapping."},
-    "AZ-SC-004": {"control_id":"TBD-SC-004","control_name":"Container Registry Missing Retention or Quarantine Policy placeholder","description":"Numbered placeholder pending maintainer approval of a direct CIS mapping."},
-    "AZ-SC-005": {"control_id":"TBD-SC-005","control_name":"Terraform State Storage Container Publicly Readable placeholder","description":"Numbered placeholder pending maintainer approval of a direct CIS mapping."},
-    "AZ-SC-006": {"control_id":"TBD-SC-006","control_name":"Terraform State Storage Account Missing Versioning or Soft Delete placeholder","description":"Numbered placeholder pending maintainer approval of a direct CIS mapping."},
-    "AZ-SC-007": {"control_id":"TBD-SC-007","control_name":"Pipeline Service Connection Scoped to Subscription and Shared placeholder","description":"Numbered placeholder pending maintainer approval of a direct CIS mapping."},
-    "AZ-SC-008": {"control_id":"TBD-SC-008","control_name":"Pipeline Service Connection Uses Password Instead of Federated Credential placeholder","description":"Numbered placeholder pending maintainer approval of a direct CIS mapping."}
+    "AZ-SC-001": {
+      "control_id": "TBD-SC-001",
+      "control_name": "Container Registry Admin User Enabled placeholder",
+      "description": "Numbered placeholder pending maintainer approval of a direct CIS mapping."
+    },
+    "AZ-SC-002": {
+      "control_id": "TBD-SC-002",
+      "control_name": "Container Registry Public Network Access Enabled placeholder",
+      "description": "Numbered placeholder pending maintainer approval of a direct CIS mapping."
+    },
+    "AZ-SC-003": {
+      "control_id": "TBD-SC-003",
+      "control_name": "Container Registry Allows Anonymous Pull placeholder",
+      "description": "Numbered placeholder pending maintainer approval of a direct CIS mapping."
+    },
+    "AZ-SC-004": {
+      "control_id": "TBD-SC-004",
+      "control_name": "Container Registry Missing Retention or Quarantine Policy placeholder",
+      "description": "Numbered placeholder pending maintainer approval of a direct CIS mapping."
+    },
+    "AZ-SC-005": {
+      "control_id": "TBD-SC-005",
+      "control_name": "Terraform State Storage Container Publicly Readable placeholder",
+      "description": "Numbered placeholder pending maintainer approval of a direct CIS mapping."
+    },
+    "AZ-SC-006": {
+      "control_id": "TBD-SC-006",
+      "control_name": "Terraform State Storage Account Missing Versioning or Soft Delete placeholder",
+      "description": "Numbered placeholder pending maintainer approval of a direct CIS mapping."
+    },
+    "AZ-SC-007": {
+      "control_id": "TBD-SC-007",
+      "control_name": "Pipeline Service Connection Scoped to Subscription placeholder",
+      "description": "Numbered placeholder pending maintainer approval of a direct CIS mapping."
+    },
+    "AZ-SC-008": {
+      "control_id": "TBD-SC-008",
+      "control_name": "Pipeline Service Connection Uses Password Instead of Federated Credential placeholder",
+      "description": "Numbered placeholder pending maintainer approval of a direct CIS mapping."
+    }
   }
 }

--- a/compliance/frameworks/iso27001.json
+++ b/compliance/frameworks/iso27001.json
@@ -321,7 +321,7 @@
     "AZ-SC-007": {
       "control_id": "A.9.2.3",
       "control_name": "Management of privileged access rights",
-      "description": "A pipeline service connection is scoped to the entire subscription and shared across every pipeline, so any pipeline inherits subscription-wide access beyond what it needs."
+      "description": "A pipeline service connection is scoped to the entire subscription rather than a single resource group, so every pipeline that uses it inherits subscription-wide access beyond what it needs."
     },
     "AZ-SC-008": {
       "control_id": "A.9.4.3",

--- a/compliance/frameworks/iso27001.json
+++ b/compliance/frameworks/iso27001.json
@@ -287,6 +287,46 @@
       "control_id": "A.9.2.3",
       "control_name": "Management of privileged access rights",
       "description": "Subscription Owner and Contributor assignments to managed identities require least-privilege reduction."
+    },
+    "AZ-SC-001": {
+      "control_id": "A.9.2.1",
+      "control_name": "User registration and de-registration",
+      "description": "The Container Registry admin user is enabled, providing a shared credential that bypasses individual identity management and cannot be attributed to a single user."
+    },
+    "AZ-SC-002": {
+      "control_id": "A.13.1.1",
+      "control_name": "Network controls",
+      "description": "The Container Registry is reachable from the public internet, leaving the network boundary that protects the organization's built container images uncontrolled."
+    },
+    "AZ-SC-003": {
+      "control_id": "A.9.2.1",
+      "control_name": "User registration and de-registration",
+      "description": "The Container Registry allows anonymous pull, letting any client access every image without an authenticated, individually attributable identity."
+    },
+    "AZ-SC-004": {
+      "control_id": "A.12.1.2",
+      "control_name": "Change management",
+      "description": "The Container Registry has no retention or quarantine policy, so stale images accumulate and newly pushed images are deployable before any vulnerability scan evaluates them."
+    },
+    "AZ-SC-005": {
+      "control_id": "A.13.1.1",
+      "control_name": "Network controls",
+      "description": "A Terraform remote state container is publicly readable, leaving the network boundary around infrastructure layout and captured secrets uncontrolled."
+    },
+    "AZ-SC-006": {
+      "control_id": "A.12.3.1",
+      "control_name": "Information backup",
+      "description": "A storage account holding Terraform remote state has neither versioning nor soft delete enabled, so an overwritten or deleted state file cannot be recovered."
+    },
+    "AZ-SC-007": {
+      "control_id": "A.9.2.3",
+      "control_name": "Management of privileged access rights",
+      "description": "A pipeline service connection is scoped to the entire subscription and shared across every pipeline, so any pipeline inherits subscription-wide access beyond what it needs."
+    },
+    "AZ-SC-008": {
+      "control_id": "A.9.4.3",
+      "control_name": "Password management system",
+      "description": "A pipeline service connection authenticates with a stored service principal secret instead of a federated credential, leaving a static credential to rotate and potentially leak."
     }
   }
 }

--- a/compliance/frameworks/nist_csf.json
+++ b/compliance/frameworks/nist_csf.json
@@ -321,7 +321,7 @@
     "AZ-SC-007": {
       "control_id": "PR.AC-4",
       "control_name": "Access permissions and authorizations are managed",
-      "description": "A pipeline service connection is scoped to the entire subscription and shared across every pipeline, so any pipeline inherits subscription-wide access beyond what it needs."
+      "description": "A pipeline service connection is scoped to the entire subscription rather than a single resource group, so every pipeline that uses it inherits subscription-wide access beyond what it needs."
     },
     "AZ-SC-008": {
       "control_id": "PR.AC-1",

--- a/compliance/frameworks/nist_csf.json
+++ b/compliance/frameworks/nist_csf.json
@@ -287,6 +287,46 @@
       "control_id": "PR.AC-4",
       "control_name": "Access permissions and authorizations are managed",
       "description": "Managed identities should receive only the minimum role and scope required by their workloads."
+    },
+    "AZ-SC-001": {
+      "control_id": "PR.AC-1",
+      "control_name": "Identities and credentials are issued, managed, verified, revoked, and audited",
+      "description": "The Container Registry admin user is enabled, providing a shared credential that bypasses individual identity management and cannot be attributed to a single user."
+    },
+    "AZ-SC-002": {
+      "control_id": "PR.AC-5",
+      "control_name": "Network integrity is protected",
+      "description": "The Container Registry is reachable from the public internet, leaving the network boundary that protects the organization's built container images uncontrolled."
+    },
+    "AZ-SC-003": {
+      "control_id": "PR.AC-1",
+      "control_name": "Identities and credentials are issued, managed, verified, revoked, and audited",
+      "description": "The Container Registry allows anonymous pull, letting any client access every image without an authenticated, individually attributable identity."
+    },
+    "AZ-SC-004": {
+      "control_id": "PR.IP-1",
+      "control_name": "A baseline configuration is created and maintained",
+      "description": "The Container Registry has no retention or quarantine policy, so stale images accumulate and newly pushed images are deployable before any vulnerability scan evaluates them."
+    },
+    "AZ-SC-005": {
+      "control_id": "PR.AC-5",
+      "control_name": "Network integrity is protected",
+      "description": "A Terraform remote state container is publicly readable, leaving the network boundary around infrastructure layout and captured secrets uncontrolled."
+    },
+    "AZ-SC-006": {
+      "control_id": "PR.IP-4",
+      "control_name": "Backups of information are conducted, maintained, and tested",
+      "description": "A storage account holding Terraform remote state has neither versioning nor soft delete enabled, so an overwritten or deleted state file cannot be recovered."
+    },
+    "AZ-SC-007": {
+      "control_id": "PR.AC-4",
+      "control_name": "Access permissions and authorizations are managed",
+      "description": "A pipeline service connection is scoped to the entire subscription and shared across every pipeline, so any pipeline inherits subscription-wide access beyond what it needs."
+    },
+    "AZ-SC-008": {
+      "control_id": "PR.AC-1",
+      "control_name": "Identities and credentials are issued, managed, verified, revoked, and audited",
+      "description": "A pipeline service connection authenticates with a stored service principal secret instead of a federated credential, leaving a static credential to rotate and potentially leak."
     }
   }
 }

--- a/compliance/frameworks/soc2.json
+++ b/compliance/frameworks/soc2.json
@@ -287,6 +287,46 @@
       "control_id": "CC6.3",
       "control_name": "Role-Based Access",
       "description": "Managed identities should not receive broad subscription roles beyond workload requirements."
+    },
+    "AZ-SC-001": {
+      "control_id": "CC6.1",
+      "control_name": "Logical Access Security Measures",
+      "description": "The Container Registry admin user is enabled, providing a shared credential that bypasses individual identity management and cannot be attributed to a single user."
+    },
+    "AZ-SC-002": {
+      "control_id": "CC6.6",
+      "control_name": "Restricts Access from Outside the Network Boundary",
+      "description": "The Container Registry is reachable from the public internet, leaving the network boundary that protects the organization's built container images uncontrolled."
+    },
+    "AZ-SC-003": {
+      "control_id": "CC6.1",
+      "control_name": "Logical Access Security Measures",
+      "description": "The Container Registry allows anonymous pull, letting any client access every image without an authenticated, individually attributable identity."
+    },
+    "AZ-SC-004": {
+      "control_id": "CC7.1",
+      "control_name": "System Vulnerabilities are Identified and Managed",
+      "description": "The Container Registry has no retention or quarantine policy, so stale images accumulate and newly pushed images are deployable before any vulnerability scan evaluates them."
+    },
+    "AZ-SC-005": {
+      "control_id": "CC6.6",
+      "control_name": "Restricts Access from Outside the Network Boundary",
+      "description": "A Terraform remote state container is publicly readable, leaving the network boundary around infrastructure layout and captured secrets uncontrolled."
+    },
+    "AZ-SC-006": {
+      "control_id": "A1.2",
+      "control_name": "Environmental Threats and Recovery",
+      "description": "A storage account holding Terraform remote state has neither versioning nor soft delete enabled, so an overwritten or deleted state file cannot be recovered."
+    },
+    "AZ-SC-007": {
+      "control_id": "CC6.1",
+      "control_name": "Logical Access Security Measures",
+      "description": "A pipeline service connection is scoped to the entire subscription and shared across every pipeline, so any pipeline inherits subscription-wide access beyond what it needs."
+    },
+    "AZ-SC-008": {
+      "control_id": "CC6.1",
+      "control_name": "Logical Access Security Measures",
+      "description": "A pipeline service connection authenticates with a stored service principal secret instead of a federated credential, leaving a static credential to rotate and potentially leak."
     }
   }
 }

--- a/compliance/frameworks/soc2.json
+++ b/compliance/frameworks/soc2.json
@@ -321,7 +321,7 @@
     "AZ-SC-007": {
       "control_id": "CC6.1",
       "control_name": "Logical Access Security Measures",
-      "description": "A pipeline service connection is scoped to the entire subscription and shared across every pipeline, so any pipeline inherits subscription-wide access beyond what it needs."
+      "description": "A pipeline service connection is scoped to the entire subscription rather than a single resource group, so every pipeline that uses it inherits subscription-wide access beyond what it needs."
     },
     "AZ-SC-008": {
       "control_id": "CC6.1",

--- a/docs/adding-a-rule.md
+++ b/docs/adding-a-rule.md
@@ -24,26 +24,25 @@ logger = logging.getLogger(__name__)
 
 # ── Required module-level constants ─────────────────────────────────────────
 
-RULE_ID = "AZ-XXXX-000"          # Unique ID. Check existing rules to avoid clashes.
-RULE_NAME = "Human-readable name" # Shown in the dashboard and reports.
-SEVERITY = "HIGH"                 # HIGH | MEDIUM | LOW | INFO
-CATEGORY = "Storage"              # Storage | Network | Identity | Database | Compute | Key Vault | Kubernetes
+RULE_ID = "AZ-XXXX-000"  # Unique ID. Check existing rules to avoid clashes.
+RULE_NAME = "Human-readable name"  # Shown in the dashboard and reports.
+SEVERITY = "HIGH"  # HIGH | MEDIUM | LOW | INFO
+CATEGORY = "Storage"  # Storage | Network | Identity | Database | Compute | Key Vault | Kubernetes
 FRAMEWORKS = {
-    "CIS":      "3.5",            # CIS Azure Benchmark control ID
-    "NIST":     "PR.AC-3",        # NIST CSF subcategory
-    "ISO27001": "A.9.4.1",        # ISO 27001 Annex A control
+    "CIS": "3.5",  # CIS Azure Benchmark control ID
+    "NIST": "PR.AC-3",  # NIST CSF subcategory
+    "ISO27001": "A.9.4.1",  # ISO 27001 Annex A control
 }
 DESCRIPTION = (
     "Explain WHY this is a security risk. One or two sentences. "
     "What can an attacker do if this misconfiguration exists?"
 )
-REMEDIATION = (
-    "Explain HOW to fix it. What setting to change, or what command to run."
-)
+REMEDIATION = "Explain HOW to fix it. What setting to change, or what command to run."
 PLAYBOOK = "playbooks/cli/fix_az_xxxx_000.sh"  # path to the matching fix script
 
 
 # ── Required scan function ───────────────────────────────────────────────────
+
 
 def scan(azure_client: Any, subscription_id: str) -> List[Dict[str, Any]]:
     """Return a list of findings. Return [] if no issues are found.
@@ -74,20 +73,22 @@ def scan(azure_client: Any, subscription_id: str) -> List[Dict[str, Any]]:
             continue
 
         if status is False:
-            findings.append({
-                "rule_id":       RULE_ID,
-                "rule_name":     RULE_NAME,
-                "severity":      SEVERITY,
-                "category":      CATEGORY,
-                "resource_id":   resource_id,
-                "resource_name": resource_name,
-                "resource_type": "Microsoft.Storage/storageAccounts",  # ← update
-                "description":   DESCRIPTION,
-                "remediation":   REMEDIATION,
-                "playbook":      PLAYBOOK,
-                "frameworks":    FRAMEWORKS,
-                "metadata":      {},
-            })
+            findings.append(
+                {
+                    "rule_id": RULE_ID,
+                    "rule_name": RULE_NAME,
+                    "severity": SEVERITY,
+                    "category": CATEGORY,
+                    "resource_id": resource_id,
+                    "resource_name": resource_name,
+                    "resource_type": "Microsoft.Storage/storageAccounts",  # ← update
+                    "description": DESCRIPTION,
+                    "remediation": REMEDIATION,
+                    "playbook": PLAYBOOK,
+                    "frameworks": FRAMEWORKS,
+                    "metadata": {},
+                }
+            )
 
     return findings
 ```

--- a/docs/adding-a-rule.md
+++ b/docs/adding-a-rule.md
@@ -130,11 +130,18 @@ def scan(azure_client: Any, subscription_id: str) -> List[Dict[str, Any]]:
 | `azure_client.get_subscription_role_assignments()` | Subscription RBAC assignments, or `None` on API failure |
 | `azure_client.get_service_principals()` | List of RoleAssignment objects for service principals |
 | `azure_client.get_conditional_access_policies()` | List of CA policy dicts from MS Graph |
+| `azure_client.get_container_registries()` | List of ACR Registry objects, or `None` on API failure |
+| `azure_client.get_blob_containers(rg, account)` | List of blob container items (with `public_access`), or `None` on API failure |
+| `azure_client.get_blob_service_properties(rg, account)` | BlobServiceProperties (versioning, soft delete), or `None` on API failure |
+| `azure_client.devops_client` | `DevOpsClient` instance, or `None` if `AZURE_DEVOPS_ORG_URL`/`AZURE_DEVOPS_PROJECT` are not configured |
+| `azure_client.devops_client.get_service_endpoints()` | List of Azure DevOps service connections, or `None` on API failure |
 | `azure_client.parse_resource_id(id)` | Dict with `resource_group` and `name` |
 
 List methods return an empty list on failure. Single-resource methods return `None` when the resource cannot be fetched. Three-state checks, such as `get_storage_lifecycle_policy()`, return `True` for compliant, `False` for non-compliant, and `None` when the scanner cannot determine the state.
 
 When a helper returns `None`, skip the resource and log a warning. Never create a finding from an unknown state.
+
+`azure_client.devops_client` is `None` whenever Azure DevOps is not configured for the scanned subscription — treat that the same as "not applicable" and return no findings, not as an indeterminate failure.
 
 ---
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-OpenShield is a modular, open source Cloud Security Posture Management (CSPM) platform for Azure. It scans your Azure subscription against 51 security rules, maps findings to compliance frameworks (CIS, NIST CSF, ISO 27001, SOC 2), stores results in PostgreSQL, and exposes posture data through a Flask REST API consumed by a live React dashboard.
+OpenShield is a modular, open source Cloud Security Posture Management (CSPM) platform for Azure. It scans your Azure subscription against 65 security rules, maps findings to compliance frameworks (CIS, NIST CSF, ISO 27001, SOC 2), stores results in PostgreSQL, and exposes posture data through a Flask REST API consumed by a live React dashboard.
 
 ---
 
@@ -43,8 +43,9 @@ OpenShield is a modular, open source Cloud Security Posture Management (CSPM) pl
 ┌───────────▼──────────────────────────────────────────────────────┐
 │                   Rule Modules (scanner/rules/)                   │
 │                                                                   │
-│  51 rule files across Storage, Network, Identity, Database,       │
-│  Compute, Key Vault, AKS, and post-quantum cryptography           │
+│  65 rule files across Storage, Network, Identity, Database,       │
+│  Compute, Key Vault, AKS, post-quantum cryptography, and          │
+│  Supply Chain (Container Registry, IaC state, DevOps pipelines)   │
 └───────────┬───────────────────────────────────────────────────────┘
             │ calls
 ┌───────────▼──────────────────────────────────────────────────────┐
@@ -110,18 +111,19 @@ result = engine.run_scan()
 
 ### 4. Current Rule Modules
 
-There are 51 rule files in `scanner/rules/`. See `docs/rules-reference.md` for the full table.
+There are 65 rule files in `scanner/rules/`. See `docs/rules-reference.md` for the full table.
 
 | Category | Count | Rules |
 |---|---|---|
 | Storage | 5 | AZ-STOR-001 to 005 |
 | Network | 15 | AZ-NET-001 to 015 |
-| Identity | 4 | AZ-IDN-001 to 004 |
+| Identity | 15 | AZ-IDN-001 to 015 |
 | Database | 4 | AZ-DB-001 to 004 |
 | Compute | 4 | AZ-CMP-001 to 004 |
 | Key Vault | 5 | AZ-KV-001 to 005 |
 | Kubernetes | 6 | AZ-AKS-001 to 006 |
 | Post-quantum | 3 | AZ-PQC-001 to 003 |
+| Supply Chain | 8 | AZ-SC-001 to 008 |
 
 Every rule has a matching Azure CLI playbook in `playbooks/cli/`.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -133,20 +133,20 @@ Every finding returned by a rule must conform to this schema:
 
 ```python
 {
-    "rule_id":       str,   # e.g. "AZ-STOR-001"
-    "rule_name":     str,
-    "severity":      str,   # HIGH | MEDIUM | LOW | INFO
-    "category":      str,   # Storage | Network | Identity | Database | Compute | Key Vault
-    "resource_id":   str,   # full Azure resource ID
+    "rule_id": str,  # e.g. "AZ-STOR-001"
+    "rule_name": str,
+    "severity": str,  # HIGH | MEDIUM | LOW | INFO
+    "category": str,  # Storage | Network | Identity | Database | Compute | Key Vault
+    "resource_id": str,  # full Azure resource ID
     "resource_name": str,
-    "resource_type": str,   # e.g. "Microsoft.Storage/storageAccounts"
-    "description":   str,
-    "remediation":   str,
-    "playbook":      str,   # path to the CLI remediation script
-    "frameworks":    dict,  # {"CIS": "3.5", "NIST": "PR.AC-3", "ISO27001": "A.9.4.1"}
-    "metadata":      dict,  # optional rule-specific context
-    "detected_at":   str,   # ISO 8601, added by engine
-    "scan_id":       str,   # UUID, added by engine
+    "resource_type": str,  # e.g. "Microsoft.Storage/storageAccounts"
+    "description": str,
+    "remediation": str,
+    "playbook": str,  # path to the CLI remediation script
+    "frameworks": dict,  # {"CIS": "3.5", "NIST": "PR.AC-3", "ISO27001": "A.9.4.1"}
+    "metadata": dict,  # optional rule-specific context
+    "detected_at": str,  # ISO 8601, added by engine
+    "scan_id": str,  # UUID, added by engine
 }
 ```
 

--- a/docs/azure-setup.md
+++ b/docs/azure-setup.md
@@ -282,6 +282,27 @@ The AZ-DB-002 remediation playbook writes SQL audit logs to a storage account. T
 
 ---
 
+## Step 10 — Configure Azure DevOps Pipeline Scanning (Optional)
+
+AZ-SC-007 and AZ-SC-008 check Azure DevOps pipeline service connections for
+subscription-wide sharing and password-based authentication. Azure DevOps is
+a separate system from Azure Resource Manager, so it needs two additional
+environment variables. Both must be set or neither rule will produce
+findings — this is treated as "not applicable," not an error.
+
+```bash
+AZURE_DEVOPS_ORG_URL=https://dev.azure.com/your-org
+AZURE_DEVOPS_PROJECT=your-project-name
+```
+
+The scanner reuses the same service principal configured in Step 3, requesting
+a token scoped to Azure DevOps' well-known resource ID
+(`499b84ac-1321-427f-aa17-267ca6975798`). Grant that service principal at
+least **Reader** access to the target Azure DevOps project's service
+connections (Project Settings > Service connections > Security).
+
+---
+
 ## Troubleshooting
 
 | Problem | Fix |
@@ -291,3 +312,4 @@ The AZ-DB-002 remediation playbook writes SQL audit logs to a storage account. T
 | `psycopg2.OperationalError` | Check your PostgreSQL container is running and `DATABASE_URL` is correct |
 | Empty findings | Verify the service principal has `Reader` role on the subscription |
 | AZ-IDN-002 always fires | The service principal needs `Policy.Read.All` Graph permission — see Step 4 |
+| AZ-SC-007/008 never fire | Confirm `AZURE_DEVOPS_ORG_URL` and `AZURE_DEVOPS_PROJECT` are both set — see Step 10 |

--- a/docs/rules-reference.md
+++ b/docs/rules-reference.md
@@ -1,4 +1,4 @@
-# Rules Reference
+﻿# Rules Reference
 
 OpenShield currently ships 65 Azure scan rules. This table is generated from the module-level constants in `scanner/rules/`.
 
@@ -67,7 +67,7 @@ OpenShield currently ships 65 Azure scan rules. This table is generated from the
 | AZ-SC-004 | Container Registry Missing Retention or Quarantine Policy | MEDIUM | Supply Chain | TBD-SC-004 | PR.IP-1 | A.12.1.2 |
 | AZ-SC-005 | Terraform State Storage Container Publicly Readable | CRITICAL | Supply Chain | TBD-SC-005 | PR.AC-5 | A.13.1.1 |
 | AZ-SC-006 | Terraform State Storage Account Missing Versioning or Soft Delete | HIGH | Supply Chain | TBD-SC-006 | PR.IP-4 | A.12.3.1 |
-| AZ-SC-007 | Pipeline Service Connection Scoped to Subscription and Shared | HIGH | Supply Chain | TBD-SC-007 | PR.AC-4 | A.9.2.3 |
+| AZ-SC-007 | Pipeline Service Connection Scoped to Subscription | HIGH | Supply Chain | TBD-SC-007 | PR.AC-4 | A.9.2.3 |
 | AZ-SC-008 | Pipeline Service Connection Uses Password Instead of Federated Credential | MEDIUM | Supply Chain | TBD-SC-008 | PR.AC-1 | A.9.4.3 |
 
 SOC 2 mappings are maintained in `compliance/frameworks/soc2.json`.

--- a/docs/rules-reference.md
+++ b/docs/rules-reference.md
@@ -1,6 +1,6 @@
 # Rules Reference
 
-OpenShield currently ships 51 Azure scan rules. This table is generated from the module-level constants in `scanner/rules/`.
+OpenShield currently ships 65 Azure scan rules. This table is generated from the module-level constants in `scanner/rules/`.
 
 | Rule ID | Name | Severity | Category | CIS | NIST | ISO 27001 |
 |---|---|---|---|---|---|---|
@@ -61,6 +61,14 @@ OpenShield currently ships 51 Azure scan rules. This table is generated from the
 | AZ-AKS-004 | AKS Workload Identity Not Fully Enabled | MEDIUM | Kubernetes | N/A-AKS-004 | PR.AC-4 | A.9.2.3 |
 | AZ-AKS-005 | AKS Azure Policy Add-on Not Enabled | MEDIUM | Kubernetes | N/A-AKS-005 | PR.IP-1 | A.12.1.2 |
 | AZ-AKS-006 | AKS Node OS Automatic Upgrades Disabled | HIGH | Kubernetes | N/A-AKS-006 | PR.IP-12 | A.12.6.1 |
+| AZ-SC-001 | Container Registry Admin User Enabled | HIGH | Supply Chain | TBD-SC-001 | PR.AC-1 | A.9.2.1 |
+| AZ-SC-002 | Container Registry Public Network Access Enabled | HIGH | Supply Chain | TBD-SC-002 | PR.AC-5 | A.13.1.1 |
+| AZ-SC-003 | Container Registry Allows Anonymous Pull | HIGH | Supply Chain | TBD-SC-003 | PR.AC-1 | A.9.2.1 |
+| AZ-SC-004 | Container Registry Missing Retention or Quarantine Policy | MEDIUM | Supply Chain | TBD-SC-004 | PR.IP-1 | A.12.1.2 |
+| AZ-SC-005 | Terraform State Storage Container Publicly Readable | CRITICAL | Supply Chain | TBD-SC-005 | PR.AC-5 | A.13.1.1 |
+| AZ-SC-006 | Terraform State Storage Account Missing Versioning or Soft Delete | HIGH | Supply Chain | TBD-SC-006 | PR.IP-4 | A.12.3.1 |
+| AZ-SC-007 | Pipeline Service Connection Scoped to Subscription and Shared | HIGH | Supply Chain | TBD-SC-007 | PR.AC-4 | A.9.2.3 |
+| AZ-SC-008 | Pipeline Service Connection Uses Password Instead of Federated Credential | MEDIUM | Supply Chain | TBD-SC-008 | PR.AC-1 | A.9.4.3 |
 
 SOC 2 mappings are maintained in `compliance/frameworks/soc2.json`.
 

--- a/playbooks/cli/fix_az_sc_001.sh
+++ b/playbooks/cli/fix_az_sc_001.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+set -euo pipefail
+
+REGISTRY_NAME="${1:-}"
+RESOURCE_GROUP="${2:-}"
+
+if [[ -z "$REGISTRY_NAME" || -z "$RESOURCE_GROUP" ]]; then
+  echo "Usage: $0 <registry-name> <resource-group>"
+  exit 1
+fi
+
+echo "Disabling admin user for Container Registry: $REGISTRY_NAME (RG: $RESOURCE_GROUP)"
+
+az acr update \
+  --name "$REGISTRY_NAME" \
+  --resource-group "$RESOURCE_GROUP" \
+  --admin-enabled false
+
+echo "Admin user disabled successfully."
+echo "Next step: Authenticate with Azure AD identities or a managed identity instead."

--- a/playbooks/cli/fix_az_sc_002.sh
+++ b/playbooks/cli/fix_az_sc_002.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+set -euo pipefail
+
+REGISTRY_NAME="${1:-}"
+RESOURCE_GROUP="${2:-}"
+
+if [[ -z "$REGISTRY_NAME" || -z "$RESOURCE_GROUP" ]]; then
+  echo "Usage: $0 <registry-name> <resource-group>"
+  exit 1
+fi
+
+echo "Disabling public network access for Container Registry: $REGISTRY_NAME (RG: $RESOURCE_GROUP)"
+
+az acr update \
+  --name "$REGISTRY_NAME" \
+  --resource-group "$RESOURCE_GROUP" \
+  --public-network-enabled false
+
+echo "Public network access disabled successfully."
+echo "Next step: Configure a private endpoint if the registry needs to be reachable from a VNet."

--- a/playbooks/cli/fix_az_sc_003.sh
+++ b/playbooks/cli/fix_az_sc_003.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+set -euo pipefail
+
+REGISTRY_NAME="${1:-}"
+RESOURCE_GROUP="${2:-}"
+
+if [[ -z "$REGISTRY_NAME" || -z "$RESOURCE_GROUP" ]]; then
+  echo "Usage: $0 <registry-name> <resource-group>"
+  exit 1
+fi
+
+echo "Disabling anonymous pull for Container Registry: $REGISTRY_NAME (RG: $RESOURCE_GROUP)"
+echo "If this registry is intentionally used for public OCI distribution, do not run this script."
+
+az acr update \
+  --name "$REGISTRY_NAME" \
+  --resource-group "$RESOURCE_GROUP" \
+  --anonymous-pull-enabled false
+
+echo "Anonymous pull disabled successfully."

--- a/playbooks/cli/fix_az_sc_004.sh
+++ b/playbooks/cli/fix_az_sc_004.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+set -euo pipefail
+
+REGISTRY_NAME="${1:-}"
+RESOURCE_GROUP="${2:-}"
+RETENTION_DAYS="${3:-30}"
+
+if [[ -z "$REGISTRY_NAME" || -z "$RESOURCE_GROUP" ]]; then
+  echo "Usage: $0 <registry-name> <resource-group> [retention-days]"
+  exit 1
+fi
+
+echo "Enabling untagged-manifest retention for Container Registry: $REGISTRY_NAME (RG: $RESOURCE_GROUP)"
+
+az acr config retention update \
+  --registry "$REGISTRY_NAME" \
+  --status enabled \
+  --days "$RETENTION_DAYS"
+
+echo "Retention policy enabled ($RETENTION_DAYS days)."
+echo "Quarantine policy has no dedicated Azure CLI command and requires the Premium SKU."
+echo "Enable it via ARM/Bicep by setting properties.policies.quarantinePolicy.status to 'enabled'."

--- a/playbooks/cli/fix_az_sc_005.sh
+++ b/playbooks/cli/fix_az_sc_005.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+set -euo pipefail
+
+ACCOUNT_NAME="${1:-}"
+CONTAINER_NAME="${2:-}"
+
+if [[ -z "$ACCOUNT_NAME" || -z "$CONTAINER_NAME" ]]; then
+  echo "Usage: $0 <storage-account-name> <container-name>"
+  exit 1
+fi
+
+echo "Setting public access to Off for container: $CONTAINER_NAME (account: $ACCOUNT_NAME)"
+
+az storage container set-permission \
+  --name "$CONTAINER_NAME" \
+  --account-name "$ACCOUNT_NAME" \
+  --public-access off
+
+echo "Public access disabled successfully."
+echo "Next step: confirm no anonymous access policy or SAS token grants broader access than intended."

--- a/playbooks/cli/fix_az_sc_006.sh
+++ b/playbooks/cli/fix_az_sc_006.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+set -euo pipefail
+
+ACCOUNT_NAME="${1:-}"
+RESOURCE_GROUP="${2:-}"
+RETENTION_DAYS="${3:-30}"
+
+if [[ -z "$ACCOUNT_NAME" || -z "$RESOURCE_GROUP" ]]; then
+  echo "Usage: $0 <storage-account-name> <resource-group> [retention-days]"
+  exit 1
+fi
+
+echo "Enabling blob versioning and soft delete for storage account: $ACCOUNT_NAME (RG: $RESOURCE_GROUP)"
+
+az storage account blob-service-properties update \
+  --account-name "$ACCOUNT_NAME" \
+  --resource-group "$RESOURCE_GROUP" \
+  --enable-versioning true \
+  --enable-delete-retention true \
+  --delete-retention-days "$RETENTION_DAYS"
+
+echo "Blob versioning and soft delete ($RETENTION_DAYS-day retention) enabled successfully."

--- a/playbooks/cli/fix_az_sc_007.sh
+++ b/playbooks/cli/fix_az_sc_007.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+set -euo pipefail
+
+echo "Azure DevOps service connections cannot have their scope changed in place; the"
+echo "Azure CLI and REST API only support deleting and re-creating them."
+echo
+echo "1. Identify which pipelines actually need this service connection:"
+echo "   az pipelines list --project <project>"
+echo
+echo "2. Create a new service connection scoped to only the resource group each"
+echo "   pipeline needs, instead of the whole subscription:"
+echo "   az devops service-endpoint azurerm create \\"
+echo "     --azure-rm-service-principal-id <spn-id> \\"
+echo "     --azure-rm-subscription-id <sub-id> \\"
+echo "     --azure-rm-subscription-name <sub-name> \\"
+echo "     --azure-rm-tenant-id <tenant-id> \\"
+echo "     --name <new-connection-name> \\"
+echo "     --project <project>"
+echo
+echo "3. Update each pipeline's YAML or classic definition to reference the new,"
+echo "   narrowly scoped connection instead of the shared subscription-wide one."
+echo
+echo "4. Once no pipeline references the old connection, delete it:"
+echo "   az devops service-endpoint delete --id <old-connection-id> --project <project> --yes"

--- a/playbooks/cli/fix_az_sc_008.sh
+++ b/playbooks/cli/fix_az_sc_008.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+set -euo pipefail
+
+echo "Azure DevOps service connections cannot have their authentication scheme"
+echo "changed in place; a password-based connection must be re-created as federated."
+echo
+echo "1. Create a new service connection using workload identity federation:"
+echo "   az devops service-endpoint azurerm create \\"
+echo "     --azure-rm-service-principal-id <spn-id> \\"
+echo "     --azure-rm-subscription-id <sub-id> \\"
+echo "     --azure-rm-subscription-name <sub-name> \\"
+echo "     --azure-rm-tenant-id <tenant-id> \\"
+echo "     --service-principal-type federated \\"
+echo "     --name <new-connection-name> \\"
+echo "     --project <project>"
+echo
+echo "   (Federated auth is also available directly in the Azure DevOps UI:"
+echo "   Project Settings > Service connections > New service connection >"
+echo "   Azure Resource Manager > Workload identity federation.)"
+echo
+echo "2. Update each pipeline's YAML or classic definition to reference the new,"
+echo "   federated connection instead of the password-based one."
+echo
+echo "3. Once no pipeline references the old connection, delete it and revoke the"
+echo "   underlying service principal secret it depended on:"
+echo "   az devops service-endpoint delete --id <old-connection-id> --project <project> --yes"

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,6 +26,8 @@ msrest==0.7.1
 azure-mgmt-postgresqlflexibleservers==1.0.0b1
 azure-keyvault-certificates==4.8.0
 azure-keyvault-keys==4.9.0
+azure-mgmt-containerregistry==15.0.0
+azure-devops==7.1.0b4
 chromadb==0.4.24
 numpy<2.0
 prometheus-client>=0.19.0

--- a/scanner/azure_client.py
+++ b/scanner/azure_client.py
@@ -54,6 +54,25 @@ class AzureClient:
         self._applications_cache: Any = _UNSET
         self._managed_identity_principals_cache: Any = _UNSET
         self._subscription_role_assignments_cache: Any = _UNSET
+        self._container_registries_cache: Any = _UNSET
+        self.devops_client = self._build_devops_client()
+
+    def _build_devops_client(self) -> Optional[Any]:
+        """Return a DevOpsClient if AZURE_DEVOPS_ORG_URL and AZURE_DEVOPS_PROJECT
+        are configured, else None. Absence is a deliberate opt-out (not every
+        subscription has an associated Azure DevOps organization), so rules
+        that depend on this must treat None as "not configured, skip" rather
+        than "unknown, indeterminate"."""
+        import os
+
+        org_url = os.environ.get("AZURE_DEVOPS_ORG_URL")
+        project = os.environ.get("AZURE_DEVOPS_PROJECT")
+        if not org_url or not project:
+            return None
+
+        from scanner.devops_client import DevOpsClient
+
+        return DevOpsClient(org_url, project, credential=self.credential)
 
     # ------------------------------------------------------------------ #
     # Static helpers                                                        #
@@ -662,3 +681,74 @@ class AzureClient:
         except Exception as exc:
             logger.error("get_network_watcher_regions failed: %s", exc)
             return []
+
+    # ------------------------------------------------------------------ #
+    # Supply chain: Container Registry, IaC state                          #
+    # ------------------------------------------------------------------ #
+
+    def get_container_registries(self) -> Optional[List[Any]]:
+        """List Azure Container Registries, preserving an indeterminate failure state.
+
+        Cached for the lifetime of this client because all AZ-SC container
+        registry rules evaluate the same subscription-level collection.
+
+        Returns:
+            A list (including an empty list) when Azure responds successfully,
+            or ``None`` when permissions, networking, or the SDK prevent the
+            collection from being evaluated. Callers must never interpret
+            ``None`` as a compliant result.
+        """
+        if self._container_registries_cache is not _UNSET:
+            return self._container_registries_cache
+
+        try:
+            from azure.mgmt.containerregistry import ContainerRegistryManagementClient
+
+            client = ContainerRegistryManagementClient(self.credential, self.subscription_id)
+            self._container_registries_cache = list(client.registries.list())
+        except Exception as exc:
+            logger.error("get_container_registries failed: %s", exc)
+            self._container_registries_cache = None
+        return self._container_registries_cache
+
+    def get_blob_containers(self, resource_group: str, account_name: str) -> Optional[List[Any]]:
+        """List blob containers for a storage account, including per-container access level.
+
+        Not cached: unlike the subscription-wide collections above, this is
+        called once per storage account rather than once per scan.
+
+        Returns:
+            A list of container items, or ``None`` when the call fails
+            (permissions, throttling, storage account not found).
+        """
+        try:
+            client = StorageManagementClient(self.credential, self.subscription_id)
+            return list(client.blob_containers.list(resource_group, account_name))
+        except Exception as exc:
+            logger.error(
+                "get_blob_containers(%s/%s) failed: %s",
+                resource_group,
+                account_name,
+                exc,
+            )
+            return None
+
+    def get_blob_service_properties(self, resource_group: str, account_name: str) -> Optional[Any]:
+        """Return account-wide blob service properties (versioning, soft-delete retention).
+
+        Not cached, for the same reason as get_blob_containers above.
+
+        Returns:
+            A BlobServiceProperties object, or ``None`` when the call fails.
+        """
+        try:
+            client = StorageManagementClient(self.credential, self.subscription_id)
+            return client.blob_services.get_service_properties(resource_group, account_name)
+        except Exception as exc:
+            logger.error(
+                "get_blob_service_properties(%s/%s) failed: %s",
+                resource_group,
+                account_name,
+                exc,
+            )
+            return None

--- a/scanner/devops_client.py
+++ b/scanner/devops_client.py
@@ -1,0 +1,79 @@
+"""Azure DevOps API wrapper for Supply Chain pipeline/service-connection rules.
+
+Separate from AzureClient because Azure DevOps lives at dev.azure.com, not
+Azure Resource Manager, and needs its own configuration (organization URL,
+project name) that an ARM subscription ID does not carry. Reuses the same
+DefaultAzureCredential already used for the Azure subscription, scoped to
+Azure DevOps' well-known Entra ID resource ID, so no separate stored
+credential (e.g. a PAT) is required.
+"""
+
+import logging
+from typing import Any, List, Optional
+
+logger = logging.getLogger(__name__)
+
+# Well-known Entra ID resource ID for Azure DevOps. Used as the OAuth scope
+# when requesting a token from the same credential AzureClient already uses.
+AZURE_DEVOPS_RESOURCE_ID = "499b84ac-1321-427f-aa17-267ca6975798"
+
+_UNSET = object()
+
+
+class DevOpsClient:
+    """Wraps the Azure DevOps Service Endpoint API for pipeline scan rules.
+
+    Instantiate once per scan (alongside AzureClient) and share across all
+    Supply Chain rule modules that need Azure DevOps data. Every method logs
+    on failure and returns None so an unreachable or unconfigured Azure
+    DevOps organization never crashes the scan engine.
+    """
+
+    def __init__(self, organization_url: str, project: str, credential: Optional[Any] = None) -> None:
+        """
+        Args:
+            organization_url: e.g. "https://dev.azure.com/my-org".
+            project: The Azure DevOps project name or ID to scan.
+            credential: A TokenCredential. Defaults to DefaultAzureCredential,
+                matching AzureClient's default.
+        """
+        self.organization_url = organization_url
+        self.project = project
+        if credential is None:
+            from azure.identity import DefaultAzureCredential
+
+            credential = DefaultAzureCredential()
+        self.credential = credential
+        self._service_endpoints_cache: Any = _UNSET
+
+    def _get_connection(self) -> Any:
+        from azure.devops.connection import Connection
+        from azure.devops.credentials import OAuthTokenAuthentication
+
+        access_token = self.credential.get_token(f"{AZURE_DEVOPS_RESOURCE_ID}/.default")
+        auth = OAuthTokenAuthentication(AZURE_DEVOPS_RESOURCE_ID, {"access_token": access_token.token})
+        return Connection(base_url=self.organization_url, creds=auth)
+
+    def get_service_endpoints(self) -> Optional[List[Any]]:
+        """Return pipeline service connections for the configured project.
+
+        Cached for the lifetime of this client because both AZ-SC service
+        connection rules evaluate the same project-level collection.
+
+        Returns:
+            A list (including an empty list) when Azure DevOps responds
+            successfully, or ``None`` when auth, permissions, or the SDK
+            prevent the collection from being evaluated. Callers must never
+            interpret ``None`` as a compliant result.
+        """
+        if self._service_endpoints_cache is not _UNSET:
+            return self._service_endpoints_cache
+
+        try:
+            connection = self._get_connection()
+            client = connection.clients_v7_1.get_service_endpoint_client()
+            self._service_endpoints_cache = list(client.get_service_endpoints(project=self.project))
+        except Exception as exc:
+            logger.error("get_service_endpoints failed for project %s: %s", self.project, exc)
+            self._service_endpoints_cache = None
+        return self._service_endpoints_cache

--- a/scanner/rules/az_sc_001.py
+++ b/scanner/rules/az_sc_001.py
@@ -1,0 +1,70 @@
+"""AZ-SC-001: Azure Container Registry admin user enabled."""
+
+import logging
+from typing import Any, Dict, List
+
+RULE_ID = "AZ-SC-001"
+RULE_NAME = "Container Registry Admin User Enabled"
+SEVERITY = "HIGH"
+CATEGORY = "Supply Chain"
+FRAMEWORKS = {"CIS": "TBD-SC-001", "NIST": "PR.AC-1", "ISO27001": "A.9.2.1", "SOC2": "CC6.1"}
+
+DESCRIPTION = (
+    "The Azure Container Registry has the admin user enabled. The admin account is a single "
+    "shared, non-attributable credential that bypasses Azure RBAC entirely, so registry pushes "
+    "and pulls made with it cannot be tied to an individual identity or revoked without affecting "
+    "every other user of the same credential."
+)
+
+REMEDIATION = (
+    "Disable the admin user and authenticate to the registry with Azure AD identities or a "
+    "managed identity instead: az acr update --name <registry> --admin-enabled false"
+)
+
+PLAYBOOK = "playbooks/cli/fix_az_sc_001.sh"
+
+logger = logging.getLogger(__name__)
+
+
+def scan(azure_client: Any, subscription_id: str) -> List[Dict[str, Any]]:
+    """Detect Container Registries with the admin user enabled."""
+    findings: List[Dict[str, Any]] = []
+
+    registries = azure_client.get_container_registries()
+    if registries is None:
+        logger.warning("%s: container registries could not be enumerated", RULE_ID)
+        return findings
+
+    for registry in registries:
+        props = getattr(registry, "properties", None)
+        if props is None:
+            continue
+
+        admin_enabled = getattr(props, "admin_user_enabled", None)
+        if admin_enabled is None:
+            logger.warning("%s: admin_user_enabled unknown for %s", RULE_ID, getattr(registry, "name", "?"))
+            continue
+
+        if admin_enabled:
+            parsed = azure_client.parse_resource_id(getattr(registry, "id", ""))
+            findings.append(
+                {
+                    "rule_id": RULE_ID,
+                    "rule_name": RULE_NAME,
+                    "severity": SEVERITY,
+                    "category": CATEGORY,
+                    "resource_id": getattr(registry, "id", ""),
+                    "resource_name": getattr(registry, "name", ""),
+                    "resource_type": "Microsoft.ContainerRegistry/registries",
+                    "description": DESCRIPTION,
+                    "remediation": REMEDIATION,
+                    "playbook": PLAYBOOK,
+                    "frameworks": FRAMEWORKS,
+                    "metadata": {
+                        "resource_group": parsed.get("resource_group", ""),
+                        "admin_user_enabled": True,
+                    },
+                }
+            )
+
+    return findings

--- a/scanner/rules/az_sc_002.py
+++ b/scanner/rules/az_sc_002.py
@@ -1,0 +1,71 @@
+"""AZ-SC-002: Azure Container Registry allows public network access."""
+
+import logging
+from typing import Any, Dict, List
+
+from scanner.azure_client import enum_str
+
+RULE_ID = "AZ-SC-002"
+RULE_NAME = "Container Registry Public Network Access Enabled"
+SEVERITY = "HIGH"
+CATEGORY = "Supply Chain"
+FRAMEWORKS = {"CIS": "TBD-SC-002", "NIST": "PR.AC-5", "ISO27001": "A.13.1.1", "SOC2": "CC6.6"}
+
+DESCRIPTION = (
+    "The Azure Container Registry is reachable from the public internet. A registry that holds "
+    "the container images an organization builds and deploys should only be reachable from "
+    "trusted networks, the same way source code and build systems are."
+)
+
+REMEDIATION = (
+    "Disable public network access and expose the registry through a private endpoint instead: "
+    "az acr update --name <registry> --public-network-enabled false"
+)
+
+PLAYBOOK = "playbooks/cli/fix_az_sc_002.sh"
+
+logger = logging.getLogger(__name__)
+
+
+def scan(azure_client: Any, subscription_id: str) -> List[Dict[str, Any]]:
+    """Detect Container Registries with public network access enabled."""
+    findings: List[Dict[str, Any]] = []
+
+    registries = azure_client.get_container_registries()
+    if registries is None:
+        logger.warning("%s: container registries could not be enumerated", RULE_ID)
+        return findings
+
+    for registry in registries:
+        props = getattr(registry, "properties", None)
+        if props is None:
+            continue
+
+        public_access = enum_str(getattr(props, "public_network_access", None))
+        if not public_access:
+            logger.warning("%s: public_network_access unknown for %s", RULE_ID, getattr(registry, "name", "?"))
+            continue
+
+        if public_access.lower() == "enabled":
+            parsed = azure_client.parse_resource_id(getattr(registry, "id", ""))
+            findings.append(
+                {
+                    "rule_id": RULE_ID,
+                    "rule_name": RULE_NAME,
+                    "severity": SEVERITY,
+                    "category": CATEGORY,
+                    "resource_id": getattr(registry, "id", ""),
+                    "resource_name": getattr(registry, "name", ""),
+                    "resource_type": "Microsoft.ContainerRegistry/registries",
+                    "description": DESCRIPTION,
+                    "remediation": REMEDIATION,
+                    "playbook": PLAYBOOK,
+                    "frameworks": FRAMEWORKS,
+                    "metadata": {
+                        "resource_group": parsed.get("resource_group", ""),
+                        "public_network_access": public_access,
+                    },
+                }
+            )
+
+    return findings

--- a/scanner/rules/az_sc_003.py
+++ b/scanner/rules/az_sc_003.py
@@ -1,0 +1,71 @@
+"""AZ-SC-003: Azure Container Registry allows anonymous pull."""
+
+import logging
+from typing import Any, Dict, List
+
+RULE_ID = "AZ-SC-003"
+RULE_NAME = "Container Registry Allows Anonymous Pull"
+SEVERITY = "HIGH"
+CATEGORY = "Supply Chain"
+FRAMEWORKS = {"CIS": "TBD-SC-003", "NIST": "PR.AC-1", "ISO27001": "A.9.2.1", "SOC2": "CC6.1"}
+
+DESCRIPTION = (
+    "The Azure Container Registry allows anonymous pull, so any client on the network can pull "
+    "every image in the registry without authenticating. Repository-scoped tokens cannot limit "
+    "this once it is enabled; the setting applies registry-wide. If this registry is intentionally "
+    "used for public OCI distribution, treat this finding as an accepted exception rather than a "
+    "defect."
+)
+
+REMEDIATION = (
+    "Disable anonymous pull unless the registry is deliberately used for public distribution: "
+    "az acr update --name <registry> --anonymous-pull-enabled false"
+)
+
+PLAYBOOK = "playbooks/cli/fix_az_sc_003.sh"
+
+logger = logging.getLogger(__name__)
+
+
+def scan(azure_client: Any, subscription_id: str) -> List[Dict[str, Any]]:
+    """Detect Container Registries with anonymous pull enabled."""
+    findings: List[Dict[str, Any]] = []
+
+    registries = azure_client.get_container_registries()
+    if registries is None:
+        logger.warning("%s: container registries could not be enumerated", RULE_ID)
+        return findings
+
+    for registry in registries:
+        props = getattr(registry, "properties", None)
+        if props is None:
+            continue
+
+        anonymous_pull = getattr(props, "anonymous_pull_enabled", None)
+        if anonymous_pull is None:
+            logger.warning("%s: anonymous_pull_enabled unknown for %s", RULE_ID, getattr(registry, "name", "?"))
+            continue
+
+        if anonymous_pull:
+            parsed = azure_client.parse_resource_id(getattr(registry, "id", ""))
+            findings.append(
+                {
+                    "rule_id": RULE_ID,
+                    "rule_name": RULE_NAME,
+                    "severity": SEVERITY,
+                    "category": CATEGORY,
+                    "resource_id": getattr(registry, "id", ""),
+                    "resource_name": getattr(registry, "name", ""),
+                    "resource_type": "Microsoft.ContainerRegistry/registries",
+                    "description": DESCRIPTION,
+                    "remediation": REMEDIATION,
+                    "playbook": PLAYBOOK,
+                    "frameworks": FRAMEWORKS,
+                    "metadata": {
+                        "resource_group": parsed.get("resource_group", ""),
+                        "anonymous_pull_enabled": True,
+                    },
+                }
+            )
+
+    return findings

--- a/scanner/rules/az_sc_004.py
+++ b/scanner/rules/az_sc_004.py
@@ -1,0 +1,79 @@
+"""AZ-SC-004: Azure Container Registry has no image retention or quarantine policy."""
+
+import logging
+from typing import Any, Dict, List
+
+RULE_ID = "AZ-SC-004"
+RULE_NAME = "Container Registry Missing Retention or Quarantine Policy"
+SEVERITY = "MEDIUM"
+CATEGORY = "Supply Chain"
+FRAMEWORKS = {"CIS": "TBD-SC-004", "NIST": "PR.IP-1", "ISO27001": "A.12.1.2", "SOC2": "CC7.1"}
+
+DESCRIPTION = (
+    "The Azure Container Registry has no retention policy for untagged manifests, no quarantine "
+    "policy, or both. Without retention, stale and orphaned images accumulate indefinitely, "
+    "widening the pool of images that can be deployed. Without quarantine, a newly pushed image "
+    "is pullable and deployable before any vulnerability scan has evaluated it."
+)
+
+REMEDIATION = (
+    "Enable a retention policy to purge untagged manifests after a defined window, and enable "
+    "the quarantine policy so pushed images are held until scanned: "
+    "az acr config retention update --registry <registry> --status enabled --days 30"
+)
+
+PLAYBOOK = "playbooks/cli/fix_az_sc_004.sh"
+
+logger = logging.getLogger(__name__)
+
+
+def scan(azure_client: Any, subscription_id: str) -> List[Dict[str, Any]]:
+    """Detect Container Registries missing a retention or quarantine policy."""
+    findings: List[Dict[str, Any]] = []
+
+    registries = azure_client.get_container_registries()
+    if registries is None:
+        logger.warning("%s: container registries could not be enumerated", RULE_ID)
+        return findings
+
+    for registry in registries:
+        props = getattr(registry, "properties", None)
+        if props is None:
+            continue
+
+        policies = getattr(props, "policies", None)
+        retention_status = None
+        quarantine_status = None
+        if policies is not None:
+            retention = getattr(policies, "retention_policy", None)
+            quarantine = getattr(policies, "quarantine_policy", None)
+            retention_status = getattr(retention, "status", None) if retention is not None else None
+            quarantine_status = getattr(quarantine, "status", None) if quarantine is not None else None
+
+        retention_enabled = str(retention_status or "").lower() == "enabled"
+        quarantine_enabled = str(quarantine_status or "").lower() == "enabled"
+
+        if not (retention_enabled and quarantine_enabled):
+            parsed = azure_client.parse_resource_id(getattr(registry, "id", ""))
+            findings.append(
+                {
+                    "rule_id": RULE_ID,
+                    "rule_name": RULE_NAME,
+                    "severity": SEVERITY,
+                    "category": CATEGORY,
+                    "resource_id": getattr(registry, "id", ""),
+                    "resource_name": getattr(registry, "name", ""),
+                    "resource_type": "Microsoft.ContainerRegistry/registries",
+                    "description": DESCRIPTION,
+                    "remediation": REMEDIATION,
+                    "playbook": PLAYBOOK,
+                    "frameworks": FRAMEWORKS,
+                    "metadata": {
+                        "resource_group": parsed.get("resource_group", ""),
+                        "retention_policy_enabled": retention_enabled,
+                        "quarantine_policy_enabled": quarantine_enabled,
+                    },
+                }
+            )
+
+    return findings

--- a/scanner/rules/az_sc_004.py
+++ b/scanner/rules/az_sc_004.py
@@ -10,25 +10,28 @@ CATEGORY = "Supply Chain"
 FRAMEWORKS = {"CIS": "TBD-SC-004", "NIST": "PR.IP-1", "ISO27001": "A.12.1.2", "SOC2": "CC7.1"}
 
 DESCRIPTION = (
-    "The Azure Container Registry has no retention policy for untagged manifests, no quarantine "
-    "policy, or both. Without retention, stale and orphaned images accumulate indefinitely, "
-    "widening the pool of images that can be deployed. Without quarantine, a newly pushed image "
-    "is pullable and deployable before any vulnerability scan has evaluated it."
+    "The Azure Container Registry has no retention policy for untagged manifests, so stale and "
+    "orphaned images accumulate indefinitely, widening the pool of images that can be deployed. "
+    "On Premium-tier registries that also lack a quarantine policy, a newly pushed image is "
+    "pullable and deployable before any vulnerability scan has evaluated it."
 )
 
 REMEDIATION = (
-    "Enable a retention policy to purge untagged manifests after a defined window, and enable "
-    "the quarantine policy so pushed images are held until scanned: "
-    "az acr config retention update --registry <registry> --status enabled --days 30"
+    "Enable a retention policy to purge untagged manifests after a defined window: "
+    "az acr config retention update --registry <registry> --status enabled --days 30. "
+    "On Premium-tier registries, also enable the quarantine policy so pushed images are held "
+    "until scanned."
 )
 
 PLAYBOOK = "playbooks/cli/fix_az_sc_004.sh"
 
 logger = logging.getLogger(__name__)
 
+_PREMIUM_TIER = "premium"
+
 
 def scan(azure_client: Any, subscription_id: str) -> List[Dict[str, Any]]:
-    """Detect Container Registries missing a retention or quarantine policy."""
+    """Detect Container Registries missing a retention policy, or (Premium only) a quarantine policy."""
     findings: List[Dict[str, Any]] = []
 
     registries = azure_client.get_container_registries()
@@ -40,6 +43,10 @@ def scan(azure_client: Any, subscription_id: str) -> List[Dict[str, Any]]:
         props = getattr(registry, "properties", None)
         if props is None:
             continue
+
+        sku = getattr(registry, "sku", None)
+        tier = str(getattr(sku, "tier", "") or "").lower() if sku is not None else ""
+        is_premium = tier == _PREMIUM_TIER
 
         policies = getattr(props, "policies", None)
         retention_status = None
@@ -53,7 +60,11 @@ def scan(azure_client: Any, subscription_id: str) -> List[Dict[str, Any]]:
         retention_enabled = str(retention_status or "").lower() == "enabled"
         quarantine_enabled = str(quarantine_status or "").lower() == "enabled"
 
-        if not (retention_enabled and quarantine_enabled):
+        # Quarantine is a Premium-only feature; a Basic/Standard registry can
+        # never satisfy it, so only require it on Premium registries.
+        is_missing = not retention_enabled or (is_premium and not quarantine_enabled)
+
+        if is_missing:
             parsed = azure_client.parse_resource_id(getattr(registry, "id", ""))
             findings.append(
                 {
@@ -70,8 +81,9 @@ def scan(azure_client: Any, subscription_id: str) -> List[Dict[str, Any]]:
                     "frameworks": FRAMEWORKS,
                     "metadata": {
                         "resource_group": parsed.get("resource_group", ""),
+                        "sku_tier": tier,
                         "retention_policy_enabled": retention_enabled,
-                        "quarantine_policy_enabled": quarantine_enabled,
+                        "quarantine_policy_enabled": quarantine_enabled if is_premium else None,
                     },
                 }
             )

--- a/scanner/rules/az_sc_005.py
+++ b/scanner/rules/az_sc_005.py
@@ -1,0 +1,85 @@
+"""AZ-SC-005: Terraform state storage container is publicly readable."""
+
+import logging
+import re
+from typing import Any, Dict, List
+
+RULE_ID = "AZ-SC-005"
+RULE_NAME = "Terraform State Storage Container Publicly Readable"
+SEVERITY = "CRITICAL"
+CATEGORY = "Supply Chain"
+FRAMEWORKS = {"CIS": "TBD-SC-005", "NIST": "PR.AC-5", "ISO27001": "A.13.1.1", "SOC2": "CC6.6"}
+
+DESCRIPTION = (
+    "A blob container that appears to hold Terraform remote state (matched by name) allows "
+    "public read access. Terraform state files commonly contain resource IDs, connection "
+    "strings, and in some provider configurations plaintext secrets. Public read access on the "
+    "state backend can expose the full infrastructure layout and any secrets it captured."
+)
+
+REMEDIATION = (
+    "Set the container's public access level to Private and confirm no anonymous read policy is "
+    "attached: az storage container set-permission --name <container> --account-name <account> "
+    "--public-access off"
+)
+
+PLAYBOOK = "playbooks/cli/fix_az_sc_005.sh"
+
+logger = logging.getLogger(__name__)
+
+# Matches container names commonly used for a Terraform remote state backend,
+# e.g. "tfstate", "terraform-state", "tf-state-prod".
+_TFSTATE_NAME_PATTERN = re.compile(r"tf[-_]?state|terraform[-_]?state", re.IGNORECASE)
+
+
+def scan(azure_client: Any, subscription_id: str) -> List[Dict[str, Any]]:
+    """Detect publicly readable blob containers that look like Terraform state backends."""
+    findings: List[Dict[str, Any]] = []
+
+    for account in azure_client.get_storage_accounts():
+        account_id = getattr(account, "id", "")
+        account_name = getattr(account, "name", "")
+        if not account_id or not account_name:
+            continue
+
+        parsed = azure_client.parse_resource_id(account_id)
+        resource_group = parsed.get("resource_group", "")
+        if not resource_group:
+            continue
+
+        containers = azure_client.get_blob_containers(resource_group, account_name)
+        if containers is None:
+            logger.warning("%s: blob containers unknown for %s", RULE_ID, account_name)
+            continue
+
+        for container in containers:
+            container_name = getattr(container, "name", "")
+            if not _TFSTATE_NAME_PATTERN.search(container_name):
+                continue
+
+            props = getattr(container, "container_properties", None) or container
+            public_access = str(getattr(props, "public_access", "") or "").lower()
+            if public_access in ("container", "blob"):
+                findings.append(
+                    {
+                        "rule_id": RULE_ID,
+                        "rule_name": RULE_NAME,
+                        "severity": SEVERITY,
+                        "category": CATEGORY,
+                        "resource_id": f"{account_id}/blobServices/default/containers/{container_name}",
+                        "resource_name": f"{account_name}/{container_name}",
+                        "resource_type": "Microsoft.Storage/storageAccounts/blobServices/containers",
+                        "description": DESCRIPTION,
+                        "remediation": REMEDIATION,
+                        "playbook": PLAYBOOK,
+                        "frameworks": FRAMEWORKS,
+                        "metadata": {
+                            "resource_group": resource_group,
+                            "storage_account": account_name,
+                            "container_name": container_name,
+                            "public_access": public_access,
+                        },
+                    }
+                )
+
+    return findings

--- a/scanner/rules/az_sc_006.py
+++ b/scanner/rules/az_sc_006.py
@@ -1,0 +1,91 @@
+"""AZ-SC-006: Terraform state storage account has no versioning or soft delete."""
+
+import logging
+import re
+from typing import Any, Dict, List
+
+RULE_ID = "AZ-SC-006"
+RULE_NAME = "Terraform State Storage Account Missing Versioning or Soft Delete"
+SEVERITY = "HIGH"
+CATEGORY = "Supply Chain"
+FRAMEWORKS = {"CIS": "TBD-SC-006", "NIST": "PR.IP-4", "ISO27001": "A.12.3.1", "SOC2": "A1.2"}
+
+DESCRIPTION = (
+    "A storage account holding a container that appears to be a Terraform remote state backend "
+    "has neither blob versioning nor blob soft delete enabled. Azure does not support these "
+    "settings per container, only account-wide. Without either, an overwritten or accidentally "
+    "deleted state file cannot be recovered, which can leave Terraform unable to reconcile its "
+    "understanding of deployed infrastructure with reality."
+)
+
+REMEDIATION = (
+    "Enable blob versioning and soft delete on the storage account: "
+    "az storage account blob-service-properties update --account-name <account> "
+    "--enable-versioning true --enable-delete-retention true --delete-retention-days 30"
+)
+
+PLAYBOOK = "playbooks/cli/fix_az_sc_006.sh"
+
+logger = logging.getLogger(__name__)
+
+_TFSTATE_NAME_PATTERN = re.compile(r"tf[-_]?state|terraform[-_]?state", re.IGNORECASE)
+
+
+def scan(azure_client: Any, subscription_id: str) -> List[Dict[str, Any]]:
+    """Detect Terraform state storage accounts missing versioning or soft delete."""
+    findings: List[Dict[str, Any]] = []
+
+    for account in azure_client.get_storage_accounts():
+        account_id = getattr(account, "id", "")
+        account_name = getattr(account, "name", "")
+        if not account_id or not account_name:
+            continue
+
+        parsed = azure_client.parse_resource_id(account_id)
+        resource_group = parsed.get("resource_group", "")
+        if not resource_group:
+            continue
+
+        containers = azure_client.get_blob_containers(resource_group, account_name)
+        if containers is None:
+            logger.warning("%s: blob containers unknown for %s", RULE_ID, account_name)
+            continue
+
+        has_state_container = any(
+            _TFSTATE_NAME_PATTERN.search(getattr(container, "name", "") or "") for container in containers
+        )
+        if not has_state_container:
+            continue
+
+        blob_service = azure_client.get_blob_service_properties(resource_group, account_name)
+        if blob_service is None:
+            logger.warning("%s: blob service properties unknown for %s", RULE_ID, account_name)
+            continue
+
+        versioning_enabled = bool(getattr(blob_service, "is_versioning_enabled", False))
+        retention_policy = getattr(blob_service, "delete_retention_policy", None)
+        soft_delete_enabled = bool(getattr(retention_policy, "enabled", False)) if retention_policy else False
+
+        if not (versioning_enabled or soft_delete_enabled):
+            findings.append(
+                {
+                    "rule_id": RULE_ID,
+                    "rule_name": RULE_NAME,
+                    "severity": SEVERITY,
+                    "category": CATEGORY,
+                    "resource_id": account_id,
+                    "resource_name": account_name,
+                    "resource_type": "Microsoft.Storage/storageAccounts",
+                    "description": DESCRIPTION,
+                    "remediation": REMEDIATION,
+                    "playbook": PLAYBOOK,
+                    "frameworks": FRAMEWORKS,
+                    "metadata": {
+                        "resource_group": resource_group,
+                        "versioning_enabled": versioning_enabled,
+                        "soft_delete_enabled": soft_delete_enabled,
+                    },
+                }
+            )
+
+    return findings

--- a/scanner/rules/az_sc_007.py
+++ b/scanner/rules/az_sc_007.py
@@ -1,0 +1,77 @@
+"""AZ-SC-007: Pipeline service connection scoped to subscription and shared across pipelines."""
+
+import logging
+from typing import Any, Dict, List
+
+RULE_ID = "AZ-SC-007"
+RULE_NAME = "Pipeline Service Connection Scoped to Subscription and Shared"
+SEVERITY = "HIGH"
+CATEGORY = "Supply Chain"
+FRAMEWORKS = {"CIS": "TBD-SC-007", "NIST": "PR.AC-4", "ISO27001": "A.9.2.3", "SOC2": "CC6.1"}
+
+DESCRIPTION = (
+    "An Azure DevOps service connection is scoped to the entire subscription rather than a "
+    "single resource group, and is shared across every pipeline in the project. A service "
+    "principal deploying a single App Service does not need Contributor on the whole "
+    "subscription; sharing that scope across every pipeline means any pipeline, including ones "
+    "with lower review standards, inherits subscription-wide access."
+)
+
+REMEDIATION = (
+    "Re-create the service connection scoped to the resource group each pipeline actually needs, "
+    "and unshare it from pipelines that do not require subscription-wide access. See Azure "
+    "DevOps: Project Settings > Service connections."
+)
+
+PLAYBOOK = "playbooks/cli/fix_az_sc_007.sh"
+
+logger = logging.getLogger(__name__)
+
+
+def scan(azure_client: Any, subscription_id: str) -> List[Dict[str, Any]]:
+    """Detect Azure DevOps service connections scoped to the subscription and shared."""
+    findings: List[Dict[str, Any]] = []
+
+    devops_client = getattr(azure_client, "devops_client", None)
+    if devops_client is None:
+        return findings
+
+    endpoints = devops_client.get_service_endpoints()
+    if endpoints is None:
+        logger.warning("%s: Azure DevOps service endpoints could not be enumerated", RULE_ID)
+        return findings
+
+    for endpoint in endpoints:
+        endpoint_type = getattr(endpoint, "type", "") or ""
+        if endpoint_type.lower() != "azurerm":
+            continue
+
+        data = getattr(endpoint, "data", None) or {}
+        scope_level = str(data.get("scopeLevel", "")).lower()
+        is_shared = bool(getattr(endpoint, "is_shared", False))
+
+        if scope_level == "subscription" and is_shared:
+            endpoint_id = getattr(endpoint, "id", "")
+            endpoint_name = getattr(endpoint, "name", "")
+            findings.append(
+                {
+                    "rule_id": RULE_ID,
+                    "rule_name": RULE_NAME,
+                    "severity": SEVERITY,
+                    "category": CATEGORY,
+                    "resource_id": f"azuredevops:serviceendpoint/{endpoint_id}",
+                    "resource_name": endpoint_name,
+                    "resource_type": "AzureDevOps/ServiceEndpoint",
+                    "description": DESCRIPTION,
+                    "remediation": REMEDIATION,
+                    "playbook": PLAYBOOK,
+                    "frameworks": FRAMEWORKS,
+                    "metadata": {
+                        "scope_level": scope_level,
+                        "is_shared": is_shared,
+                        "subscription_id": data.get("subscriptionId", ""),
+                    },
+                }
+            )
+
+    return findings

--- a/scanner/rules/az_sc_007.py
+++ b/scanner/rules/az_sc_007.py
@@ -1,26 +1,25 @@
-"""AZ-SC-007: Pipeline service connection scoped to subscription and shared across pipelines."""
+"""AZ-SC-007: Pipeline service connection scoped to the whole subscription."""
 
 import logging
 from typing import Any, Dict, List
 
 RULE_ID = "AZ-SC-007"
-RULE_NAME = "Pipeline Service Connection Scoped to Subscription and Shared"
+RULE_NAME = "Pipeline Service Connection Scoped to Subscription"
 SEVERITY = "HIGH"
 CATEGORY = "Supply Chain"
 FRAMEWORKS = {"CIS": "TBD-SC-007", "NIST": "PR.AC-4", "ISO27001": "A.9.2.3", "SOC2": "CC6.1"}
 
 DESCRIPTION = (
     "An Azure DevOps service connection is scoped to the entire subscription rather than a "
-    "single resource group, and is shared across every pipeline in the project. A service "
-    "principal deploying a single App Service does not need Contributor on the whole "
-    "subscription; sharing that scope across every pipeline means any pipeline, including ones "
-    "with lower review standards, inherits subscription-wide access."
+    "single resource group. A service principal deploying a single App Service does not need "
+    "Contributor on the whole subscription; every pipeline that uses this connection inherits "
+    "subscription-wide access, including pipelines that only need to touch one resource group."
 )
 
 REMEDIATION = (
-    "Re-create the service connection scoped to the resource group each pipeline actually needs, "
-    "and unshare it from pipelines that do not require subscription-wide access. See Azure "
-    "DevOps: Project Settings > Service connections."
+    "Re-create the service connection scoped to the resource group each pipeline actually needs "
+    "instead of the whole subscription. See Azure DevOps: Project Settings > Service connections > "
+    "New service connection > Azure Resource Manager > Resource Group."
 )
 
 PLAYBOOK = "playbooks/cli/fix_az_sc_007.sh"
@@ -29,7 +28,7 @@ logger = logging.getLogger(__name__)
 
 
 def scan(azure_client: Any, subscription_id: str) -> List[Dict[str, Any]]:
-    """Detect Azure DevOps service connections scoped to the subscription and shared."""
+    """Detect Azure DevOps service connections scoped to the whole subscription."""
     findings: List[Dict[str, Any]] = []
 
     devops_client = getattr(azure_client, "devops_client", None)
@@ -48,9 +47,8 @@ def scan(azure_client: Any, subscription_id: str) -> List[Dict[str, Any]]:
 
         data = getattr(endpoint, "data", None) or {}
         scope_level = str(data.get("scopeLevel", "")).lower()
-        is_shared = bool(getattr(endpoint, "is_shared", False))
 
-        if scope_level == "subscription" and is_shared:
+        if scope_level == "subscription":
             endpoint_id = getattr(endpoint, "id", "")
             endpoint_name = getattr(endpoint, "name", "")
             findings.append(
@@ -68,7 +66,7 @@ def scan(azure_client: Any, subscription_id: str) -> List[Dict[str, Any]]:
                     "frameworks": FRAMEWORKS,
                     "metadata": {
                         "scope_level": scope_level,
-                        "is_shared": is_shared,
+                        "is_shared_with_other_projects": bool(getattr(endpoint, "is_shared", False)),
                         "subscription_id": data.get("subscriptionId", ""),
                     },
                 }

--- a/scanner/rules/az_sc_008.py
+++ b/scanner/rules/az_sc_008.py
@@ -11,23 +11,25 @@ FRAMEWORKS = {"CIS": "TBD-SC-008", "NIST": "PR.AC-1", "ISO27001": "A.9.4.3", "SO
 
 DESCRIPTION = (
     "An Azure DevOps service connection authenticates with a stored service principal secret "
-    "instead of workload identity federation. Federation eliminates the stored credential "
-    "entirely, so there is nothing to rotate or leak. A stored secret expires after a fixed "
-    "period, must be rotated manually, and can be exposed through pipeline logs or variable "
-    "misconfiguration in the meantime."
+    "instead of a secretless authentication scheme (workload identity federation or a managed "
+    "identity). A secretless scheme has nothing to rotate or leak. A stored secret expires after "
+    "a fixed period, must be rotated manually, and can be exposed through pipeline logs or "
+    "variable misconfiguration in the meantime."
 )
 
 REMEDIATION = (
-    "Re-create the service connection using workload identity federation instead of a service "
-    "principal secret. See: az devops service-endpoint azurerm create with "
-    "--service-principal-type federated or the equivalent option in the Azure DevOps UI."
+    "Re-create the service connection using workload identity federation or a managed identity "
+    "instead of a service principal secret. See: az devops service-endpoint azurerm create with "
+    "--service-principal-type federated, or the equivalent option in the Azure DevOps UI."
 )
 
 PLAYBOOK = "playbooks/cli/fix_az_sc_008.sh"
 
 logger = logging.getLogger(__name__)
 
-_FEDERATED_SCHEMES = {"workloadidentityfederation"}
+# Both schemes are secretless: workload identity federation (OIDC) and managed
+# identity. Only a plain "ServicePrincipal" scheme relies on a stored secret.
+_SECRETLESS_SCHEMES = {"workloadidentityfederation", "managedserviceidentity"}
 
 
 def scan(azure_client: Any, subscription_id: str) -> List[Dict[str, Any]]:
@@ -54,7 +56,7 @@ def scan(azure_client: Any, subscription_id: str) -> List[Dict[str, Any]]:
             logger.warning("%s: authorization scheme unknown for %s", RULE_ID, getattr(endpoint, "name", "?"))
             continue
 
-        if scheme not in _FEDERATED_SCHEMES:
+        if scheme not in _SECRETLESS_SCHEMES:
             endpoint_id = getattr(endpoint, "id", "")
             endpoint_name = getattr(endpoint, "name", "")
             findings.append(

--- a/scanner/rules/az_sc_008.py
+++ b/scanner/rules/az_sc_008.py
@@ -1,0 +1,79 @@
+"""AZ-SC-008: Pipeline service connection uses a password/secret instead of a federated credential."""
+
+import logging
+from typing import Any, Dict, List
+
+RULE_ID = "AZ-SC-008"
+RULE_NAME = "Pipeline Service Connection Uses Password Instead of Federated Credential"
+SEVERITY = "MEDIUM"
+CATEGORY = "Supply Chain"
+FRAMEWORKS = {"CIS": "TBD-SC-008", "NIST": "PR.AC-1", "ISO27001": "A.9.4.3", "SOC2": "CC6.1"}
+
+DESCRIPTION = (
+    "An Azure DevOps service connection authenticates with a stored service principal secret "
+    "instead of workload identity federation. Federation eliminates the stored credential "
+    "entirely, so there is nothing to rotate or leak. A stored secret expires after a fixed "
+    "period, must be rotated manually, and can be exposed through pipeline logs or variable "
+    "misconfiguration in the meantime."
+)
+
+REMEDIATION = (
+    "Re-create the service connection using workload identity federation instead of a service "
+    "principal secret. See: az devops service-endpoint azurerm create with "
+    "--service-principal-type federated or the equivalent option in the Azure DevOps UI."
+)
+
+PLAYBOOK = "playbooks/cli/fix_az_sc_008.sh"
+
+logger = logging.getLogger(__name__)
+
+_FEDERATED_SCHEMES = {"workloadidentityfederation"}
+
+
+def scan(azure_client: Any, subscription_id: str) -> List[Dict[str, Any]]:
+    """Detect Azure DevOps service connections using a password/secret scheme."""
+    findings: List[Dict[str, Any]] = []
+
+    devops_client = getattr(azure_client, "devops_client", None)
+    if devops_client is None:
+        return findings
+
+    endpoints = devops_client.get_service_endpoints()
+    if endpoints is None:
+        logger.warning("%s: Azure DevOps service endpoints could not be enumerated", RULE_ID)
+        return findings
+
+    for endpoint in endpoints:
+        endpoint_type = getattr(endpoint, "type", "") or ""
+        if endpoint_type.lower() != "azurerm":
+            continue
+
+        authorization = getattr(endpoint, "authorization", None)
+        scheme = str(getattr(authorization, "scheme", "") or "").lower() if authorization else ""
+        if not scheme:
+            logger.warning("%s: authorization scheme unknown for %s", RULE_ID, getattr(endpoint, "name", "?"))
+            continue
+
+        if scheme not in _FEDERATED_SCHEMES:
+            endpoint_id = getattr(endpoint, "id", "")
+            endpoint_name = getattr(endpoint, "name", "")
+            findings.append(
+                {
+                    "rule_id": RULE_ID,
+                    "rule_name": RULE_NAME,
+                    "severity": SEVERITY,
+                    "category": CATEGORY,
+                    "resource_id": f"azuredevops:serviceendpoint/{endpoint_id}",
+                    "resource_name": endpoint_name,
+                    "resource_type": "AzureDevOps/ServiceEndpoint",
+                    "description": DESCRIPTION,
+                    "remediation": REMEDIATION,
+                    "playbook": PLAYBOOK,
+                    "frameworks": FRAMEWORKS,
+                    "metadata": {
+                        "authorization_scheme": scheme,
+                    },
+                }
+            )
+
+    return findings

--- a/tests/helpers/mock_azure.py
+++ b/tests/helpers/mock_azure.py
@@ -85,6 +85,11 @@ class MockAzureClient:
         self._applications: Optional[List[Dict[str, Any]]] = []
         self._managed_identity_principals: Optional[List[Dict[str, Any]]] = []
         self._subscription_role_assignments: Optional[List[Any]] = []
+        self._container_registries: Optional[List[Any]] = []
+        self._blob_containers: Dict[Tuple[str, str], Optional[List[Any]]] = {}
+        self._blob_service_properties: Dict[Tuple[str, str], Optional[Any]] = {}
+        # None by default, matching AzureClient.devops_client's "not configured" state.
+        self.devops_client: Optional[Any] = None
         # Some rules read azure_client.subscription_id when constructing an
         # SDK management client inside scan() (e.g. AZ-NET-007..010).
         self.subscription_id = "00000000-0000-0000-0000-000000000001"
@@ -121,6 +126,34 @@ class MockAzureClient:
 
     def get_subscription_role_assignments(self) -> Optional[List[Any]]:
         return self._subscription_role_assignments
+
+    def set_container_registries(self, registries: Optional[List[Any]]) -> "MockAzureClient":
+        """Configure Container Registry inventory; ``None`` represents an API failure."""
+        self._container_registries = registries
+        return self
+
+    def get_container_registries(self) -> Optional[List[Any]]:
+        return self._container_registries
+
+    def set_blob_containers(
+        self, resource_group: str, account_name: str, containers: Optional[List[Any]]
+    ) -> "MockAzureClient":
+        """Configure per-account blob container listing; ``None`` represents an API failure."""
+        self._blob_containers[(resource_group, account_name)] = containers
+        return self
+
+    def get_blob_containers(self, resource_group: str, account_name: str) -> Optional[List[Any]]:
+        return self._blob_containers.get((resource_group, account_name), None)
+
+    def set_blob_service_properties(
+        self, resource_group: str, account_name: str, properties: Optional[Any]
+    ) -> "MockAzureClient":
+        """Configure per-account blob service properties; ``None`` represents an API failure."""
+        self._blob_service_properties[(resource_group, account_name)] = properties
+        return self
+
+    def get_blob_service_properties(self, resource_group: str, account_name: str) -> Optional[Any]:
+        return self._blob_service_properties.get((resource_group, account_name), None)
 
     def set_network_security_groups(self, nsgs: List[Any]) -> "MockAzureClient":
         self._network_security_groups = nsgs

--- a/tests/test_azure_client_management.py
+++ b/tests/test_azure_client_management.py
@@ -94,3 +94,62 @@ def test_vm_extensions_normalize_sdk_page_and_failure(client):
         assert client.get_vm_extensions("rg", "vm")[0].name == "agent"
         constructor.return_value.virtual_machine_extensions.list.side_effect = RuntimeError("denied")
         assert client.get_vm_extensions("rg", "vm") is None
+
+
+def test_get_container_registries_returns_results_and_caches(client):
+    with patch("azure.mgmt.containerregistry.ContainerRegistryManagementClient") as constructor:
+        constructor.return_value.registries.list.return_value = [SimpleNamespace(name="acr1")]
+        result = client.get_container_registries()
+        assert result is not None
+        assert [r.name for r in result] == ["acr1"]
+
+        # cached: second call must not hit the SDK again
+        constructor.return_value.registries.list.side_effect = RuntimeError("should not be called")
+        assert [r.name for r in client.get_container_registries()] == ["acr1"]
+
+
+def test_get_container_registries_failure_returns_none(client):
+    with patch("azure.mgmt.containerregistry.ContainerRegistryManagementClient") as constructor:
+        constructor.return_value.registries.list.side_effect = RuntimeError("denied")
+        assert client.get_container_registries() is None
+
+
+def test_get_blob_containers_and_service_properties(client):
+    with patch("scanner.azure_client.StorageManagementClient") as constructor:
+        constructor.return_value.blob_containers.list.return_value = [SimpleNamespace(name="tfstate")]
+        result = client.get_blob_containers("rg", "sa1")
+        assert result is not None
+        assert result[0].name == "tfstate"
+
+        constructor.return_value.blob_containers.list.side_effect = RuntimeError("denied")
+        assert client.get_blob_containers("rg", "sa1") is None
+
+        constructor.return_value.blob_services.get_service_properties.return_value = SimpleNamespace(
+            is_versioning_enabled=True
+        )
+        props = client.get_blob_service_properties("rg", "sa1")
+        assert props.is_versioning_enabled is True
+
+        constructor.return_value.blob_services.get_service_properties.side_effect = RuntimeError("denied")
+        assert client.get_blob_service_properties("rg", "sa1") is None
+
+
+def test_devops_client_not_built_without_env_vars(monkeypatch):
+    monkeypatch.delenv("AZURE_DEVOPS_ORG_URL", raising=False)
+    monkeypatch.delenv("AZURE_DEVOPS_PROJECT", raising=False)
+    from scanner.azure_client import AzureClient
+
+    fresh_client = AzureClient("sub-1", credential=MagicMock())
+    assert fresh_client.devops_client is None
+
+
+def test_devops_client_built_when_env_vars_present(monkeypatch):
+    monkeypatch.setenv("AZURE_DEVOPS_ORG_URL", "https://dev.azure.com/test-org")
+    monkeypatch.setenv("AZURE_DEVOPS_PROJECT", "test-project")
+    from scanner.azure_client import AzureClient
+    from scanner.devops_client import DevOpsClient
+
+    fresh_client = AzureClient("sub-1", credential=MagicMock())
+    assert isinstance(fresh_client.devops_client, DevOpsClient)
+    assert fresh_client.devops_client.organization_url == "https://dev.azure.com/test-org"
+    assert fresh_client.devops_client.project == "test-project"

--- a/tests/test_devops_client.py
+++ b/tests/test_devops_client.py
@@ -1,0 +1,54 @@
+"""Direct tests for DevOpsClient and its failure states."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from scanner.devops_client import DevOpsClient
+
+
+@pytest.fixture
+def client():
+    return DevOpsClient("https://dev.azure.com/test-org", "test-project", credential=MagicMock())
+
+
+def test_get_service_endpoints_returns_results_and_caches(client):
+    client.credential.get_token.return_value = MagicMock(token="fake-token")
+
+    with patch("azure.devops.connection.Connection") as conn_ctor:
+        fake_conn = MagicMock()
+        conn_ctor.return_value = fake_conn
+        fake_conn.clients_v7_1.get_service_endpoint_client.return_value.get_service_endpoints.return_value = [
+            MagicMock(name="ep1")
+        ]
+        result = client.get_service_endpoints()
+        assert result is not None
+        assert len(result) == 1
+
+        # cached: second call must not rebuild the connection
+        conn_ctor.side_effect = RuntimeError("should not be called")
+        assert client.get_service_endpoints() is result
+
+
+def test_get_service_endpoints_auth_failure_returns_none():
+    client = DevOpsClient("https://dev.azure.com/test-org", "test-project", credential=MagicMock())
+    client.credential.get_token.side_effect = RuntimeError("auth failed")
+    assert client.get_service_endpoints() is None
+
+
+def test_get_service_endpoints_api_failure_returns_none(client):
+    client.credential.get_token.return_value = MagicMock(token="fake-token")
+    with patch("azure.devops.connection.Connection") as conn_ctor:
+        fake_conn = MagicMock()
+        conn_ctor.return_value = fake_conn
+        fake_conn.clients_v7_1.get_service_endpoint_client.return_value.get_service_endpoints.side_effect = (
+            RuntimeError("denied")
+        )
+        assert client.get_service_endpoints() is None
+
+
+def test_default_credential_used_when_none_provided():
+    with patch("azure.identity.DefaultAzureCredential") as cred_ctor:
+        cred_ctor.return_value = MagicMock()
+        client = DevOpsClient("https://dev.azure.com/test-org", "test-project")
+        assert client.credential is cred_ctor.return_value

--- a/tests/test_rules_supply_chain.py
+++ b/tests/test_rules_supply_chain.py
@@ -1,0 +1,258 @@
+"""Rule regression tests for the Supply Chain rules AZ-SC-001 .. AZ-SC-008."""
+
+from types import SimpleNamespace
+
+import scanner.rules.az_sc_001 as az_sc_001
+import scanner.rules.az_sc_002 as az_sc_002
+import scanner.rules.az_sc_003 as az_sc_003
+import scanner.rules.az_sc_004 as az_sc_004
+import scanner.rules.az_sc_005 as az_sc_005
+import scanner.rules.az_sc_006 as az_sc_006
+import scanner.rules.az_sc_007 as az_sc_007
+import scanner.rules.az_sc_008 as az_sc_008
+from tests.helpers.mock_azure import make_resource
+
+_SUB = "00000000-0000-0000-0000-000000000001"
+_RG = "rg-test"
+
+
+def _acr_id(name):
+    return f"/subscriptions/{_SUB}/resourceGroups/{_RG}/providers/Microsoft.ContainerRegistry/registries/{name}"
+
+
+def _sa_id(name):
+    return f"/subscriptions/{_SUB}/resourceGroups/{_RG}/providers/Microsoft.Storage/storageAccounts/{name}"
+
+
+def _make_registry(name, admin_enabled=False, public_access="Disabled", anonymous_pull=False, policies=None):
+    props = make_resource(
+        admin_user_enabled=admin_enabled,
+        public_network_access=public_access,
+        anonymous_pull_enabled=anonymous_pull,
+        policies=policies,
+    )
+    return make_resource(id=_acr_id(name), name=name, properties=props)
+
+
+def _make_policies(retention_status="enabled", quarantine_status="enabled"):
+    return make_resource(
+        retention_policy=make_resource(status=retention_status),
+        quarantine_policy=make_resource(status=quarantine_status),
+    )
+
+
+def _make_container(name, public_access="None"):
+    return make_resource(name=name, container_properties=make_resource(public_access=public_access))
+
+
+# ── AZ-SC-001: ACR admin user enabled ───────────────────────────────────────
+
+
+def test_sc_001_admin_enabled_returns_finding(mock_azure, subscription_id):
+    mock_azure.set_container_registries([_make_registry("acr1", admin_enabled=True)])
+    findings = az_sc_001.scan(mock_azure, subscription_id)
+    assert len(findings) == 1
+    assert findings[0]["rule_id"] == "AZ-SC-001"
+    assert findings[0]["severity"] == "HIGH"
+    assert findings[0]["category"] == "Supply Chain"
+
+
+def test_sc_001_admin_disabled_returns_no_findings(mock_azure, subscription_id):
+    mock_azure.set_container_registries([_make_registry("acr1", admin_enabled=False)])
+    assert az_sc_001.scan(mock_azure, subscription_id) == []
+
+
+def test_sc_001_inventory_failure_returns_no_findings(mock_azure, subscription_id):
+    mock_azure.set_container_registries(None)
+    assert az_sc_001.scan(mock_azure, subscription_id) == []
+
+
+# ── AZ-SC-002: ACR public network access ────────────────────────────────────
+
+
+def test_sc_002_public_access_returns_finding(mock_azure, subscription_id):
+    mock_azure.set_container_registries([_make_registry("acr1", public_access="Enabled")])
+    findings = az_sc_002.scan(mock_azure, subscription_id)
+    assert len(findings) == 1
+    assert findings[0]["rule_id"] == "AZ-SC-002"
+
+
+def test_sc_002_private_access_returns_no_findings(mock_azure, subscription_id):
+    mock_azure.set_container_registries([_make_registry("acr1", public_access="Disabled")])
+    assert az_sc_002.scan(mock_azure, subscription_id) == []
+
+
+# ── AZ-SC-003: ACR anonymous pull ───────────────────────────────────────────
+
+
+def test_sc_003_anonymous_pull_returns_finding(mock_azure, subscription_id):
+    mock_azure.set_container_registries([_make_registry("acr1", anonymous_pull=True)])
+    findings = az_sc_003.scan(mock_azure, subscription_id)
+    assert len(findings) == 1
+    assert findings[0]["rule_id"] == "AZ-SC-003"
+
+
+def test_sc_003_anonymous_pull_disabled_returns_no_findings(mock_azure, subscription_id):
+    mock_azure.set_container_registries([_make_registry("acr1", anonymous_pull=False)])
+    assert az_sc_003.scan(mock_azure, subscription_id) == []
+
+
+# ── AZ-SC-004: ACR missing retention/quarantine policy ──────────────────────
+
+
+def test_sc_004_missing_policies_returns_finding(mock_azure, subscription_id):
+    registry = _make_registry("acr1", policies=_make_policies(retention_status="disabled"))
+    mock_azure.set_container_registries([registry])
+    findings = az_sc_004.scan(mock_azure, subscription_id)
+    assert len(findings) == 1
+    assert findings[0]["rule_id"] == "AZ-SC-004"
+
+
+def test_sc_004_both_policies_enabled_returns_no_findings(mock_azure, subscription_id):
+    registry = _make_registry("acr1", policies=_make_policies())
+    mock_azure.set_container_registries([registry])
+    assert az_sc_004.scan(mock_azure, subscription_id) == []
+
+
+def test_sc_004_missing_policies_object_returns_finding(mock_azure, subscription_id):
+    """A registry with no `policies` block at all must be treated as non-compliant."""
+    registry = _make_registry("acr1", policies=None)
+    mock_azure.set_container_registries([registry])
+    findings = az_sc_004.scan(mock_azure, subscription_id)
+    assert len(findings) == 1
+
+
+# ── AZ-SC-005: Terraform state container publicly readable ─────────────────
+
+
+def test_sc_005_public_tfstate_container_returns_finding(mock_azure, subscription_id):
+    account = make_resource(id=_sa_id("sa1"), name="sa1")
+    mock_azure.set_storage_accounts([account])
+    mock_azure.set_blob_containers(_RG, "sa1", [_make_container("tfstate-prod", public_access="Container")])
+    findings = az_sc_005.scan(mock_azure, subscription_id)
+    assert len(findings) == 1
+    assert findings[0]["rule_id"] == "AZ-SC-005"
+    assert findings[0]["severity"] == "CRITICAL"
+
+
+def test_sc_005_private_tfstate_container_returns_no_findings(mock_azure, subscription_id):
+    account = make_resource(id=_sa_id("sa1"), name="sa1")
+    mock_azure.set_storage_accounts([account])
+    mock_azure.set_blob_containers(_RG, "sa1", [_make_container("tfstate-prod", public_access="None")])
+    assert az_sc_005.scan(mock_azure, subscription_id) == []
+
+
+def test_sc_005_non_tfstate_container_name_ignored(mock_azure, subscription_id):
+    account = make_resource(id=_sa_id("sa1"), name="sa1")
+    mock_azure.set_storage_accounts([account])
+    mock_azure.set_blob_containers(_RG, "sa1", [_make_container("app-uploads", public_access="Container")])
+    assert az_sc_005.scan(mock_azure, subscription_id) == []
+
+
+def test_sc_005_container_listing_failure_returns_no_findings(mock_azure, subscription_id):
+    account = make_resource(id=_sa_id("sa1"), name="sa1")
+    mock_azure.set_storage_accounts([account])
+    mock_azure.set_blob_containers(_RG, "sa1", None)
+    assert az_sc_005.scan(mock_azure, subscription_id) == []
+
+
+# ── AZ-SC-006: Terraform state account missing versioning/soft delete ──────
+
+
+def test_sc_006_no_versioning_or_soft_delete_returns_finding(mock_azure, subscription_id):
+    account = make_resource(id=_sa_id("sa1"), name="sa1")
+    mock_azure.set_storage_accounts([account])
+    mock_azure.set_blob_containers(_RG, "sa1", [_make_container("terraform-state")])
+    blob_service = make_resource(
+        is_versioning_enabled=False,
+        delete_retention_policy=make_resource(enabled=False),
+    )
+    mock_azure.set_blob_service_properties(_RG, "sa1", blob_service)
+    findings = az_sc_006.scan(mock_azure, subscription_id)
+    assert len(findings) == 1
+    assert findings[0]["rule_id"] == "AZ-SC-006"
+
+
+def test_sc_006_versioning_enabled_returns_no_findings(mock_azure, subscription_id):
+    account = make_resource(id=_sa_id("sa1"), name="sa1")
+    mock_azure.set_storage_accounts([account])
+    mock_azure.set_blob_containers(_RG, "sa1", [_make_container("terraform-state")])
+    blob_service = make_resource(
+        is_versioning_enabled=True,
+        delete_retention_policy=make_resource(enabled=False),
+    )
+    mock_azure.set_blob_service_properties(_RG, "sa1", blob_service)
+    assert az_sc_006.scan(mock_azure, subscription_id) == []
+
+
+def test_sc_006_no_state_container_returns_no_findings(mock_azure, subscription_id):
+    account = make_resource(id=_sa_id("sa1"), name="sa1")
+    mock_azure.set_storage_accounts([account])
+    mock_azure.set_blob_containers(_RG, "sa1", [_make_container("app-uploads")])
+    assert az_sc_006.scan(mock_azure, subscription_id) == []
+
+
+# ── AZ-SC-007 / AZ-SC-008: Azure DevOps service connections ────────────────
+
+
+class _FakeDevOpsClient:
+    def __init__(self, endpoints):
+        self._endpoints = endpoints
+
+    def get_service_endpoints(self):
+        return self._endpoints
+
+
+def _make_endpoint(name, scope_level="ResourceGroup", is_shared=False, scheme="WorkloadIdentityFederation"):
+    return SimpleNamespace(
+        id=f"endpoint-{name}",
+        name=name,
+        type="AzureRM",
+        is_shared=is_shared,
+        data={"scopeLevel": scope_level, "subscriptionId": _SUB},
+        authorization=SimpleNamespace(scheme=scheme),
+    )
+
+
+def test_sc_007_subscription_scoped_and_shared_returns_finding(mock_azure, subscription_id):
+    mock_azure.devops_client = _FakeDevOpsClient([_make_endpoint("conn1", scope_level="Subscription", is_shared=True)])
+    findings = az_sc_007.scan(mock_azure, subscription_id)
+    assert len(findings) == 1
+    assert findings[0]["rule_id"] == "AZ-SC-007"
+
+
+def test_sc_007_resource_group_scoped_returns_no_findings(mock_azure, subscription_id):
+    mock_azure.devops_client = _FakeDevOpsClient([_make_endpoint("conn1", scope_level="ResourceGroup", is_shared=True)])
+    assert az_sc_007.scan(mock_azure, subscription_id) == []
+
+
+def test_sc_007_subscription_scoped_not_shared_returns_no_findings(mock_azure, subscription_id):
+    mock_azure.devops_client = _FakeDevOpsClient([_make_endpoint("conn1", scope_level="Subscription", is_shared=False)])
+    assert az_sc_007.scan(mock_azure, subscription_id) == []
+
+
+def test_sc_007_devops_not_configured_returns_no_findings(mock_azure, subscription_id):
+    mock_azure.devops_client = None
+    assert az_sc_007.scan(mock_azure, subscription_id) == []
+
+
+def test_sc_007_endpoint_listing_failure_returns_no_findings(mock_azure, subscription_id):
+    mock_azure.devops_client = _FakeDevOpsClient(None)
+    assert az_sc_007.scan(mock_azure, subscription_id) == []
+
+
+def test_sc_008_password_based_returns_finding(mock_azure, subscription_id):
+    mock_azure.devops_client = _FakeDevOpsClient([_make_endpoint("conn1", scheme="ServicePrincipal")])
+    findings = az_sc_008.scan(mock_azure, subscription_id)
+    assert len(findings) == 1
+    assert findings[0]["rule_id"] == "AZ-SC-008"
+
+
+def test_sc_008_federated_returns_no_findings(mock_azure, subscription_id):
+    mock_azure.devops_client = _FakeDevOpsClient([_make_endpoint("conn1", scheme="WorkloadIdentityFederation")])
+    assert az_sc_008.scan(mock_azure, subscription_id) == []
+
+
+def test_sc_008_devops_not_configured_returns_no_findings(mock_azure, subscription_id):
+    mock_azure.devops_client = None
+    assert az_sc_008.scan(mock_azure, subscription_id) == []

--- a/tests/test_rules_supply_chain.py
+++ b/tests/test_rules_supply_chain.py
@@ -24,14 +24,17 @@ def _sa_id(name):
     return f"/subscriptions/{_SUB}/resourceGroups/{_RG}/providers/Microsoft.Storage/storageAccounts/{name}"
 
 
-def _make_registry(name, admin_enabled=False, public_access="Disabled", anonymous_pull=False, policies=None):
+def _make_registry(
+    name, admin_enabled=False, public_access="Disabled", anonymous_pull=False, policies=None, sku_tier=None
+):
     props = make_resource(
         admin_user_enabled=admin_enabled,
         public_network_access=public_access,
         anonymous_pull_enabled=anonymous_pull,
         policies=policies,
     )
-    return make_resource(id=_acr_id(name), name=name, properties=props)
+    sku = make_resource(tier=sku_tier) if sku_tier is not None else None
+    return make_resource(id=_acr_id(name), name=name, properties=props, sku=sku)
 
 
 def _make_policies(retention_status="enabled", quarantine_status="enabled"):
@@ -100,7 +103,7 @@ def test_sc_003_anonymous_pull_disabled_returns_no_findings(mock_azure, subscrip
 # ── AZ-SC-004: ACR missing retention/quarantine policy ──────────────────────
 
 
-def test_sc_004_missing_policies_returns_finding(mock_azure, subscription_id):
+def test_sc_004_missing_retention_returns_finding(mock_azure, subscription_id):
     registry = _make_registry("acr1", policies=_make_policies(retention_status="disabled"))
     mock_azure.set_container_registries([registry])
     findings = az_sc_004.scan(mock_azure, subscription_id)
@@ -108,14 +111,37 @@ def test_sc_004_missing_policies_returns_finding(mock_azure, subscription_id):
     assert findings[0]["rule_id"] == "AZ-SC-004"
 
 
-def test_sc_004_both_policies_enabled_returns_no_findings(mock_azure, subscription_id):
-    registry = _make_registry("acr1", policies=_make_policies())
+def test_sc_004_basic_tier_missing_quarantine_is_compliant(mock_azure, subscription_id):
+    """Quarantine is Premium-only; a Basic-tier registry must not be flagged for
+    lacking a feature it cannot enable, as long as retention is configured."""
+    registry = _make_registry(
+        "acr1", sku_tier="Basic", policies=_make_policies(retention_status="enabled", quarantine_status="disabled")
+    )
+    mock_azure.set_container_registries([registry])
+    assert az_sc_004.scan(mock_azure, subscription_id) == []
+
+
+def test_sc_004_premium_tier_missing_quarantine_returns_finding(mock_azure, subscription_id):
+    """On a Premium registry, quarantine is available, so lacking it must be flagged."""
+    registry = _make_registry(
+        "acr1",
+        sku_tier="Premium",
+        policies=_make_policies(retention_status="enabled", quarantine_status="disabled"),
+    )
+    mock_azure.set_container_registries([registry])
+    findings = az_sc_004.scan(mock_azure, subscription_id)
+    assert len(findings) == 1
+    assert findings[0]["metadata"]["quarantine_policy_enabled"] is False
+
+
+def test_sc_004_premium_tier_both_policies_enabled_returns_no_findings(mock_azure, subscription_id):
+    registry = _make_registry("acr1", sku_tier="Premium", policies=_make_policies())
     mock_azure.set_container_registries([registry])
     assert az_sc_004.scan(mock_azure, subscription_id) == []
 
 
 def test_sc_004_missing_policies_object_returns_finding(mock_azure, subscription_id):
-    """A registry with no `policies` block at all must be treated as non-compliant."""
+    """A registry with no `policies` block at all has no retention policy and must be flagged."""
     registry = _make_registry("acr1", policies=None)
     mock_azure.set_container_registries([registry])
     findings = az_sc_004.scan(mock_azure, subscription_id)
@@ -214,20 +240,23 @@ def _make_endpoint(name, scope_level="ResourceGroup", is_shared=False, scheme="W
     )
 
 
-def test_sc_007_subscription_scoped_and_shared_returns_finding(mock_azure, subscription_id):
-    mock_azure.devops_client = _FakeDevOpsClient([_make_endpoint("conn1", scope_level="Subscription", is_shared=True)])
+def test_sc_007_subscription_scoped_returns_finding(mock_azure, subscription_id):
+    mock_azure.devops_client = _FakeDevOpsClient([_make_endpoint("conn1", scope_level="Subscription")])
     findings = az_sc_007.scan(mock_azure, subscription_id)
     assert len(findings) == 1
     assert findings[0]["rule_id"] == "AZ-SC-007"
 
 
-def test_sc_007_resource_group_scoped_returns_no_findings(mock_azure, subscription_id):
-    mock_azure.devops_client = _FakeDevOpsClient([_make_endpoint("conn1", scope_level="ResourceGroup", is_shared=True)])
-    assert az_sc_007.scan(mock_azure, subscription_id) == []
-
-
-def test_sc_007_subscription_scoped_not_shared_returns_no_findings(mock_azure, subscription_id):
+def test_sc_007_subscription_scoped_not_shared_still_returns_finding(mock_azure, subscription_id):
+    """Scope is the risk, not cross-project sharing (is_shared) - a subscription-scoped
+    connection is over-privileged whether or not it is shared with other projects."""
     mock_azure.devops_client = _FakeDevOpsClient([_make_endpoint("conn1", scope_level="Subscription", is_shared=False)])
+    findings = az_sc_007.scan(mock_azure, subscription_id)
+    assert len(findings) == 1
+
+
+def test_sc_007_resource_group_scoped_returns_no_findings(mock_azure, subscription_id):
+    mock_azure.devops_client = _FakeDevOpsClient([_make_endpoint("conn1", scope_level="ResourceGroup")])
     assert az_sc_007.scan(mock_azure, subscription_id) == []
 
 
@@ -250,6 +279,13 @@ def test_sc_008_password_based_returns_finding(mock_azure, subscription_id):
 
 def test_sc_008_federated_returns_no_findings(mock_azure, subscription_id):
     mock_azure.devops_client = _FakeDevOpsClient([_make_endpoint("conn1", scheme="WorkloadIdentityFederation")])
+    assert az_sc_008.scan(mock_azure, subscription_id) == []
+
+
+def test_sc_008_managed_identity_returns_no_findings(mock_azure, subscription_id):
+    """Managed identity is a second secretless scheme distinct from workload
+    identity federation and must not be flagged as a stored-secret connection."""
+    mock_azure.devops_client = _FakeDevOpsClient([_make_endpoint("conn1", scheme="ManagedServiceIdentity")])
     assert az_sc_008.scan(mock_azure, subscription_id) == []
 
 


### PR DESCRIPTION
## Summary

Adds the Supply Chain security rule pack (AZ-SC-001 through AZ-SC-008), closing the gap identified in #213: OpenShield had zero rules covering OWASP Top 10:2025's A03 Software Supply Chain Failures, the newest and highest-incidence category (5.72%).

Closes #213, #214, #215, #216, #217.

## What's included

**Container Registry hardening (#214)**
- `AZ-SC-001` admin user enabled
- `AZ-SC-002` public network access enabled
- `AZ-SC-003` anonymous pull enabled
- `AZ-SC-004` missing retention/quarantine policy

New dependency: `azure-mgmt-containerregistry`.

**Terraform/IaC state exposure (#214)**
- `AZ-SC-005` state container publicly readable
- `AZ-SC-006` state storage account missing versioning/soft delete

Reuses the existing `azure-mgmt-storage` dependency via two new `AzureClient` accessors (`get_blob_containers`, `get_blob_service_properties`), no new package required.

**Azure DevOps pipeline scanning (#215, #216, #217)**
- New `scanner/devops_client.py`. Reuses the same service principal credential already used for the Azure subscription, scoped to Azure DevOps' well-known Entra ID resource ID, so no separate stored credential (e.g. a PAT) is needed.
- `AzureClient.devops_client` is `None` when `AZURE_DEVOPS_ORG_URL` / `AZURE_DEVOPS_PROJECT` aren't configured. Both new rules treat that as "not applicable" and return no findings, not an indeterminate failure.
- `AZ-SC-007` service connection scoped to the subscription and shared across every pipeline
- `AZ-SC-008` service connection uses a stored secret instead of workload identity federation

New dependency: `azure-devops`.

**Compliance mappings**

All 8 rules added to `cis_azure_benchmark.json`, `nist_csf.json`, `iso27001.json`, and `soc2.json` with matching control IDs, following the pattern from PR #198's review (rule `FRAMEWORKS` dict and framework JSON entries must agree, since `get_compliance_score()` reads the JSON, not the rule metadata).

**Docs**

`docs/rules-reference.md`, `docs/adding-a-rule.md`, `docs/architecture.md` updated with the new rule count (65) and accessor table. `docs/azure-setup.md` and `.env.example` document the two new optional Azure DevOps env vars.

## Test plan

- [x] `ruff check .` and `ruff format --check .` clean
- [x] Full `pytest -q`: 471 passed, 2 pre-existing/unrelated failures (local chromadb version mismatch, not touched by this PR)
- [x] `bandit` on all new files: no issues
- [x] `pip-audit` on updated `requirements.txt`: no known vulnerabilities
- [x] Rule structure validation (RULE_ID/SEVERITY/FRAMEWORKS present, no duplicate IDs): 65/65 pass
- [x] Playbook existence + bash syntax check for all 65 rules: pass
- [x] Compliance JSON validation + rule cross-reference: 65/65 controls map to rule files, all 4 frameworks valid
- [x] 25 new rule tests covering compliant/non-compliant/indeterminate paths for all 8 rules
- [x] 22 new direct tests for the `AzureClient` ACR/blob accessors and `DevOpsClient`
