### PR TITLE
Potential fix for code scanning alert no. 31: Clear-text logging of sensitive information

### DIFF
--- a/scanner/rules/az_idn_006.py
+++ b/scanner/rules/az_idn_006.py
@@ -71,9 +71,8 @@ def scan(azure_client: Any, subscription_id: str) -> List[Dict[str, Any]]:
                     already_expired = end_dt < now
                 except ValueError:
                     logger.debug(
-                        "AZ-IDN-006: Invalid endDateTime for app_id=%s: %r",
+                        "AZ-IDN-006: Invalid endDateTime format for app_id=%s",
                         app_id,
-                        end_dt_str,
                     )
 
             if not (age_days >= EXPIRY_THRESHOLD_DAYS or no_expiry or already_expired):


### PR DESCRIPTION
Potential fix for [https://github.com/openshield-org/openshield/security/code-scanning/31](https://github.com/openshield-org/openshield/security/code-scanning/31)

To fix this safely without changing functionality, keep the error handling behavior but stop logging raw `end_dt_str`. Replace the current debug statement so it logs only non-sensitive context (for example `app_id`) and a generic message indicating invalid `endDateTime` format. This preserves observability (you still know which app had bad data) while eliminating clear-text output of tainted credential-derived content.

In `scanner/rules/az_idn_006.py`, edit the `except ValueError:` block around lines 73–77:
- remove `%r` placeholder and `end_dt_str` argument
- keep `app_id` in the log for correlation
- no new imports or dependencies are needed


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
