### PR TITLE
fix: resolve all open security alerts (8 Dependabot + 1 CodeQL)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -595,7 +595,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version: "22"
+          node-version: "22.22.0"
           cache: npm
           cache-dependency-path: frontend/package-lock.json
 

--- a/.gitignore
+++ b/.gitignore
@@ -219,3 +219,6 @@ __marimo__/
 ai/vectorstore/
 .vercel
 .env*
+
+# Node (root package.json exists solely to track react-router for Dependabot)
+node_modules/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,13 +50,9 @@ from typing import Any, Dict, List
 
 RULE_ID = "AZ-STOR-001"
 RULE_NAME = "Public Blob Access Enabled on Storage Account"
-SEVERITY = "HIGH"           # HIGH / MEDIUM / LOW / INFO
-CATEGORY = "Storage"        # Storage / Network / Identity / Database / Compute / Key Vault / Kubernetes
-FRAMEWORKS = {
-    "CIS": "3.5",
-    "NIST": "PR.AC-3",
-    "ISO27001": "A.9.4.1"
-}
+SEVERITY = "HIGH"  # HIGH / MEDIUM / LOW / INFO
+CATEGORY = "Storage"  # Storage / Network / Identity / Database / Compute / Key Vault / Kubernetes
+FRAMEWORKS = {"CIS": "3.5", "NIST": "PR.AC-3", "ISO27001": "A.9.4.1"}
 DESCRIPTION = (
     "Storage accounts with public blob access enabled allow anyone on the "
     "internet to read data without authentication. This can lead to data "
@@ -72,20 +68,22 @@ def scan(azure_client: Any, subscription_id: str) -> List[Dict[str, Any]]:
 
     for account in azure_client.get_storage_accounts():
         if getattr(account, "allow_blob_public_access", False):
-            findings.append({
-                "rule_id": RULE_ID,
-                "rule_name": RULE_NAME,
-                "severity": SEVERITY,
-                "category": CATEGORY,
-                "resource_id": account.id,
-                "resource_name": account.name,
-                "resource_type": "Microsoft.Storage/storageAccounts",
-                "description": DESCRIPTION,
-                "remediation": REMEDIATION,
-                "playbook": PLAYBOOK,
-                "frameworks": FRAMEWORKS,
-                "metadata": {}
-            })
+            findings.append(
+                {
+                    "rule_id": RULE_ID,
+                    "rule_name": RULE_NAME,
+                    "severity": SEVERITY,
+                    "category": CATEGORY,
+                    "resource_id": account.id,
+                    "resource_name": account.name,
+                    "resource_type": "Microsoft.Storage/storageAccounts",
+                    "description": DESCRIPTION,
+                    "remediation": REMEDIATION,
+                    "playbook": PLAYBOOK,
+                    "frameworks": FRAMEWORKS,
+                    "metadata": {},
+                }
+            )
 
     return findings
 ```

--- a/docs/adding-a-rule.md
+++ b/docs/adding-a-rule.md
@@ -24,26 +24,25 @@ logger = logging.getLogger(__name__)
 
 # ── Required module-level constants ─────────────────────────────────────────
 
-RULE_ID = "AZ-XXXX-000"          # Unique ID. Check existing rules to avoid clashes.
-RULE_NAME = "Human-readable name" # Shown in the dashboard and reports.
-SEVERITY = "HIGH"                 # HIGH | MEDIUM | LOW | INFO
-CATEGORY = "Storage"              # Storage | Network | Identity | Database | Compute | Key Vault | Kubernetes
+RULE_ID = "AZ-XXXX-000"  # Unique ID. Check existing rules to avoid clashes.
+RULE_NAME = "Human-readable name"  # Shown in the dashboard and reports.
+SEVERITY = "HIGH"  # HIGH | MEDIUM | LOW | INFO
+CATEGORY = "Storage"  # Storage | Network | Identity | Database | Compute | Key Vault | Kubernetes
 FRAMEWORKS = {
-    "CIS":      "3.5",            # CIS Azure Benchmark control ID
-    "NIST":     "PR.AC-3",        # NIST CSF subcategory
-    "ISO27001": "A.9.4.1",        # ISO 27001 Annex A control
+    "CIS": "3.5",  # CIS Azure Benchmark control ID
+    "NIST": "PR.AC-3",  # NIST CSF subcategory
+    "ISO27001": "A.9.4.1",  # ISO 27001 Annex A control
 }
 DESCRIPTION = (
     "Explain WHY this is a security risk. One or two sentences. "
     "What can an attacker do if this misconfiguration exists?"
 )
-REMEDIATION = (
-    "Explain HOW to fix it. What setting to change, or what command to run."
-)
+REMEDIATION = "Explain HOW to fix it. What setting to change, or what command to run."
 PLAYBOOK = "playbooks/cli/fix_az_xxxx_000.sh"  # path to the matching fix script
 
 
 # ── Required scan function ───────────────────────────────────────────────────
+
 
 def scan(azure_client: Any, subscription_id: str) -> List[Dict[str, Any]]:
     """Return a list of findings. Return [] if no issues are found.
@@ -74,20 +73,22 @@ def scan(azure_client: Any, subscription_id: str) -> List[Dict[str, Any]]:
             continue
 
         if status is False:
-            findings.append({
-                "rule_id":       RULE_ID,
-                "rule_name":     RULE_NAME,
-                "severity":      SEVERITY,
-                "category":      CATEGORY,
-                "resource_id":   resource_id,
-                "resource_name": resource_name,
-                "resource_type": "Microsoft.Storage/storageAccounts",  # ← update
-                "description":   DESCRIPTION,
-                "remediation":   REMEDIATION,
-                "playbook":      PLAYBOOK,
-                "frameworks":    FRAMEWORKS,
-                "metadata":      {},
-            })
+            findings.append(
+                {
+                    "rule_id": RULE_ID,
+                    "rule_name": RULE_NAME,
+                    "severity": SEVERITY,
+                    "category": CATEGORY,
+                    "resource_id": resource_id,
+                    "resource_name": resource_name,
+                    "resource_type": "Microsoft.Storage/storageAccounts",  # ← update
+                    "description": DESCRIPTION,
+                    "remediation": REMEDIATION,
+                    "playbook": PLAYBOOK,
+                    "frameworks": FRAMEWORKS,
+                    "metadata": {},
+                }
+            )
 
     return findings
 ```

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -131,20 +131,20 @@ Every finding returned by a rule must conform to this schema:
 
 ```python
 {
-    "rule_id":       str,   # e.g. "AZ-STOR-001"
-    "rule_name":     str,
-    "severity":      str,   # HIGH | MEDIUM | LOW | INFO
-    "category":      str,   # Storage | Network | Identity | Database | Compute | Key Vault
-    "resource_id":   str,   # full Azure resource ID
+    "rule_id": str,  # e.g. "AZ-STOR-001"
+    "rule_name": str,
+    "severity": str,  # HIGH | MEDIUM | LOW | INFO
+    "category": str,  # Storage | Network | Identity | Database | Compute | Key Vault
+    "resource_id": str,  # full Azure resource ID
     "resource_name": str,
-    "resource_type": str,   # e.g. "Microsoft.Storage/storageAccounts"
-    "description":   str,
-    "remediation":   str,
-    "playbook":      str,   # path to the CLI remediation script
-    "frameworks":    dict,  # {"CIS": "3.5", "NIST": "PR.AC-3", "ISO27001": "A.9.4.1"}
-    "metadata":      dict,  # optional rule-specific context
-    "detected_at":   str,   # ISO 8601, added by engine
-    "scan_id":       str,   # UUID, added by engine
+    "resource_type": str,  # e.g. "Microsoft.Storage/storageAccounts"
+    "description": str,
+    "remediation": str,
+    "playbook": str,  # path to the CLI remediation script
+    "frameworks": dict,  # {"CIS": "3.5", "NIST": "PR.AC-3", "ISO27001": "A.9.4.1"}
+    "metadata": dict,  # optional rule-specific context
+    "detected_at": str,  # ISO 8601, added by engine
+    "scan_id": str,  # UUID, added by engine
 }
 ```
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10,8 +10,8 @@
       "dependencies": {
         "autoprefixer": "^10.5.0",
         "postcss": "^8.5.18",
-        "react": "^19.2.6",
-        "react-dom": "^19.2.6",
+        "react": "^19.2.7",
+        "react-dom": "^19.2.7",
         "react-icons": "^5.6.0",
         "react-router": "^8.3.0",
         "recharts": "^3.8.1"
@@ -27,6 +27,9 @@
         "globals": "^17.6.0",
         "tailwindcss": "^3.4.19",
         "vite": "^8.0.16"
+      },
+      "engines": {
+        "node": ">=22.22.0"
       }
     },
     "node_modules/@alloc/quick-lru": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,11 +9,11 @@
       "version": "0.0.0",
       "dependencies": {
         "autoprefixer": "^10.5.0",
-        "postcss": "^8.5.15",
+        "postcss": "^8.5.18",
         "react": "^19.2.6",
         "react-dom": "^19.2.6",
         "react-icons": "^5.6.0",
-        "react-router-dom": "^7.16.0",
+        "react-router": "^8.3.0",
         "recharts": "^3.8.1"
       },
       "devDependencies": {
@@ -1186,15 +1186,16 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/braces": {
@@ -1328,17 +1329,11 @@
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true
     },
-    "node_modules/cookie": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
-      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
+    "node_modules/cookie-es": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/cookie-es/-/cookie-es-3.1.1.tgz",
+      "integrity": "sha512-UaXxwISYJPTr9hwQxMFYZ7kNhSXboMXP+Z3TRX6f1/NyaGPfuNUZOWP1pUEb75B2HjfklIYLVRfWiFZJyC6Npg==",
+      "license": "MIT"
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -2512,15 +2507,16 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.12",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "funding": [
         {
           "type": "github",
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "license": "MIT",
       "bin": {
         "nanoid": "bin/nanoid.cjs"
       },
@@ -2676,9 +2672,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.15",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "version": "8.5.25",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.25.tgz",
+      "integrity": "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==",
       "funding": [
         {
           "type": "opencollective",
@@ -2693,8 +2689,9 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -2868,22 +2865,24 @@
       ]
     },
     "node_modules/react": {
-      "version": "19.2.6",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.2.6.tgz",
-      "integrity": "sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==",
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.8.tgz",
+      "integrity": "sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==",
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/react-dom": {
-      "version": "19.2.6",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.6.tgz",
-      "integrity": "sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g==",
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.8.tgz",
+      "integrity": "sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ==",
+      "license": "MIT",
       "dependencies": {
         "scheduler": "^0.27.0"
       },
       "peerDependencies": {
-        "react": "^19.2.6"
+        "react": "^19.2.8"
       }
     },
     "node_modules/react-icons": {
@@ -2923,39 +2922,24 @@
       }
     },
     "node_modules/react-router": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.16.0.tgz",
-      "integrity": "sha512-wArC8lVyJb3+jM9OpDyW6hLCizACWkvQR/sSGqSs+o5uEXEtGlqdZ4v8hENR3Jad6i+LRkK93q/+bQAcvl6V1A==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-8.3.0.tgz",
+      "integrity": "sha512-qyPMvW83jGIct3yiieisxdk9M745anqhpIMKN5m1t6yBMfgVPpt77aHOqs5fUlEJRMCGffg9BaQLH9oPVOL7xQ==",
+      "license": "MIT",
       "dependencies": {
-        "cookie": "^1.0.1",
-        "set-cookie-parser": "^2.6.0"
+        "cookie-es": "^3.1.1"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=22.22.0"
       },
       "peerDependencies": {
-        "react": ">=18",
-        "react-dom": ">=18"
+        "react": ">=19.2.7",
+        "react-dom": ">=19.2.7"
       },
       "peerDependenciesMeta": {
         "react-dom": {
           "optional": true
         }
-      }
-    },
-    "node_modules/react-router-dom": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.16.0.tgz",
-      "integrity": "sha512-kMUAbimWB5FVbF4Bce4bJsiKJWLIUHq/mEG8+CFDnCSgltptBiG5nguducmsJeGKytlCvQud9Qhzpn49iduTlA==",
-      "dependencies": {
-        "react-router": "7.16.0"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=18",
-        "react-dom": ">=18"
       }
     },
     "node_modules/read-cache": {
@@ -3139,11 +3123,6 @@
       "bin": {
         "semver": "bin/semver.js"
       }
-    },
-    "node_modules/set-cookie-parser": {
-      "version": "2.7.2",
-      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
-      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw=="
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -3,6 +3,9 @@
   "private": true,
   "version": "0.0.0",
   "type": "module",
+  "engines": {
+    "node": ">=22.22.0"
+  },
   "scripts": {
     "dev": "vite",
     "build": "vite build",
@@ -14,8 +17,8 @@
   "dependencies": {
     "autoprefixer": "^10.5.0",
     "postcss": "^8.5.18",
-    "react": "^19.2.6",
-    "react-dom": "^19.2.6",
+    "react": "^19.2.7",
+    "react-dom": "^19.2.7",
     "react-icons": "^5.6.0",
     "react-router": "^8.3.0",
     "recharts": "^3.8.1"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,11 +13,11 @@
   },
   "dependencies": {
     "autoprefixer": "^10.5.0",
-    "postcss": "^8.5.15",
+    "postcss": "^8.5.18",
     "react": "^19.2.6",
     "react-dom": "^19.2.6",
     "react-icons": "^5.6.0",
-    "react-router-dom": "^7.16.0",
+    "react-router": "^8.3.0",
     "recharts": "^3.8.1"
   },
   "devDependencies": {

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,5 +1,5 @@
 import { useEffect } from 'react';
-import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
+import { BrowserRouter, Routes, Route, Navigate } from 'react-router';
 import { DarkModeProvider } from './contexts/DarkModeContext';
 import { I18nProvider } from './contexts/I18nContext';
 import { api } from './utils/api';

--- a/frontend/src/components/compliance/ComplianceTable.jsx
+++ b/frontend/src/components/compliance/ComplianceTable.jsx
@@ -1,4 +1,4 @@
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { FiCheckCircle, FiXCircle, FiMinusCircle, FiArrowRight } from 'react-icons/fi';
 import SeverityBadge from '../shared/SeverityBadge';
 

--- a/frontend/src/components/layout/Header.jsx
+++ b/frontend/src/components/layout/Header.jsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from 'react';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 import {
   FiMenu, FiAlertTriangle, FiX,
   FiLoader, FiZap, FiCheckCircle, FiAlertCircle, FiClock,

--- a/frontend/src/components/layout/Layout.jsx
+++ b/frontend/src/components/layout/Layout.jsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { Outlet } from 'react-router-dom';
+import { Outlet } from 'react-router';
 import Sidebar from './Sidebar';
 import Header from './Header';
 import { useI18n } from '../../i18n/I18nState';

--- a/frontend/src/components/layout/Sidebar.jsx
+++ b/frontend/src/components/layout/Sidebar.jsx
@@ -1,4 +1,4 @@
-import { NavLink } from 'react-router-dom';
+import { NavLink } from 'react-router';
 import {
   FiActivity, FiSearch, FiTarget, FiZap,
   FiShield, FiGitBranch, FiCpu, FiSun, FiMoon, FiX,

--- a/frontend/src/components/prioritization/QuickRemediation.jsx
+++ b/frontend/src/components/prioritization/QuickRemediation.jsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import { FiLayout, FiTerminal, FiClock, FiArrowRight, FiTool, FiAlertTriangle } from 'react-icons/fi';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 
 const EFFORT_ETA = { 1: '15–30 mins', 2: '1–2 hours', 3: '2–4 hours', 4: '~1 day', 5: '2–3 days' };
 

--- a/frontend/src/components/scan/AskAIButton.jsx
+++ b/frontend/src/components/scan/AskAIButton.jsx
@@ -1,5 +1,5 @@
 import { FiCpu } from 'react-icons/fi';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 
 export default function AskAIButton({ finding }) {
   const navigate = useNavigate();

--- a/frontend/src/pages/AILayer.jsx
+++ b/frontend/src/pages/AILayer.jsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from 'react';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 import { FiCpu, FiX, FiAlertCircle, FiKey, FiCheckCircle } from 'react-icons/fi';
 import { api } from '../utils/api';
 import { aiApi, aiSettings } from '../utils/aiApi';

--- a/frontend/src/pages/DetailedScan.jsx
+++ b/frontend/src/pages/DetailedScan.jsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { useLocation, useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router';
 import { FiArrowLeft, FiX, FiAlertTriangle } from 'react-icons/fi';
 import { api } from '../utils/api';
 import FindingHeader from '../components/scan/FindingHeader';

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,21 +5,14 @@
   "packages": {
     "": {
       "dependencies": {
-        "react-router-dom": "^7.18.0"
+        "react-router": "^8.3.0"
       }
     },
-    "node_modules/cookie": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
-      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
+    "node_modules/cookie-es": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/cookie-es/-/cookie-es-3.1.1.tgz",
+      "integrity": "sha512-UaXxwISYJPTr9hwQxMFYZ7kNhSXboMXP+Z3TRX6f1/NyaGPfuNUZOWP1pUEb75B2HjfklIYLVRfWiFZJyC6Npg==",
+      "license": "MIT"
     },
     "node_modules/react": {
       "version": "19.2.7",
@@ -31,69 +24,26 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/react-dom": {
-      "version": "19.2.7",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.7.tgz",
-      "integrity": "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "scheduler": "^0.27.0"
-      },
-      "peerDependencies": {
-        "react": "^19.2.7"
-      }
-    },
     "node_modules/react-router": {
-      "version": "7.18.0",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.0.tgz",
-      "integrity": "sha512-pTTGt8J+ji1NOmYnjzT+bAJy/1zD+Jp4ziO6cL7T3ZLvXKtusO7BpFqlRXitqpcPVqllsIXFHRMt+2/k3Xn6HQ==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-8.3.0.tgz",
+      "integrity": "sha512-qyPMvW83jGIct3yiieisxdk9M745anqhpIMKN5m1t6yBMfgVPpt77aHOqs5fUlEJRMCGffg9BaQLH9oPVOL7xQ==",
       "license": "MIT",
       "dependencies": {
-        "cookie": "^1.0.1",
-        "set-cookie-parser": "^2.6.0"
+        "cookie-es": "^3.1.1"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=22.22.0"
       },
       "peerDependencies": {
-        "react": ">=18",
-        "react-dom": ">=18"
+        "react": ">=19.2.7",
+        "react-dom": ">=19.2.7"
       },
       "peerDependenciesMeta": {
         "react-dom": {
           "optional": true
         }
       }
-    },
-    "node_modules/react-router-dom": {
-      "version": "7.18.0",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.18.0.tgz",
-      "integrity": "sha512-Fi0yY6kgtKae/Th2xibdWK0KSdYZ4B53Gyf6wRtomOKWgpNm7H7+DyfDhncdz9FKbpS+1jmDhg3F4WoGJ+yFOA==",
-      "license": "MIT",
-      "dependencies": {
-        "react-router": "7.18.0"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=18",
-        "react-dom": ">=18"
-      }
-    },
-    "node_modules/scheduler": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
-      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/set-cookie-parser": {
-      "version": "2.7.2",
-      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
-      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
-      "license": "MIT"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
   "dependencies": {
-    "react-router-dom": "^7.18.0"
+    "react-router": "^8.3.0"
   }
 }

--- a/scanner/rules/az_idn_006.py
+++ b/scanner/rules/az_idn_006.py
@@ -71,9 +71,8 @@ def scan(azure_client: Any, subscription_id: str) -> List[Dict[str, Any]]:
                     already_expired = end_dt < now
                 except ValueError:
                     logger.debug(
-                        "AZ-IDN-006: Invalid endDateTime for app_id=%s: %r",
+                        "AZ-IDN-006: Invalid endDateTime format for app_id=%s",
                         app_id,
-                        end_dt_str,
                     )
 
             if not (age_days >= EXPIRY_THRESHOLD_DAYS or no_expiry or already_expired):

--- a/tests/test_rules_identity.py
+++ b/tests/test_rules_identity.py
@@ -289,11 +289,12 @@ def test_idn_006_noncompliant_secret_no_expiry_returns_finding(mock_azure, subsc
 
 
 def test_idn_006_malformed_end_date_time_does_not_log_key_id(mock_azure, subscription_id, monkeypatch, caplog):
-    """CodeQL: clear-text logging of sensitive information. keyId is a Graph
-    API credential-slot identifier (not the secret itself), but the debug log
-    for a malformed endDateTime must not include it regardless — the value
-    isn't needed to diagnose a date-parsing failure."""
+    """CodeQL alert #31 (py/clear-text-logging-sensitive-data): the debug log
+    for a malformed endDateTime must not include the raw endDateTime value or
+    keyId — neither is needed to diagnose a date-parsing failure, and Graph
+    API credential fields should never be echoed into logs verbatim."""
     sentinel_key_id = "sentinel-key-id-should-not-appear-in-logs"
+    sentinel_end_date = "sentinel-malformed-end-date-should-not-appear-in-logs"
     apps = {
         "value": [
             {
@@ -305,7 +306,7 @@ def test_idn_006_malformed_end_date_time_does_not_log_key_id(mock_azure, subscri
                         "keyId": sentinel_key_id,
                         "hint": "ab",
                         "startDateTime": "2020-01-01T00:00:00Z",
-                        "endDateTime": "not-a-valid-date",
+                        "endDateTime": sentinel_end_date,
                     }
                 ],
             }
@@ -318,6 +319,7 @@ def test_idn_006_malformed_end_date_time_does_not_log_key_id(mock_azure, subscri
     # Malformed endDateTime alone doesn't matter here: the secret is already stale by age.
     assert len(findings) == 1
     assert sentinel_key_id not in caplog.text
+    assert sentinel_end_date not in caplog.text
 
 
 # ── AZ-IDN-007: active user with no MFA registered ──────────────────────────


### PR DESCRIPTION
## Summary

Resolves all 9 open security alerts tracked in #221: 8 Dependabot dependency vulnerabilities and 1 CodeQL code-scanning alert.

Closes #221.

## Dependency vulnerabilities (8 Dependabot alerts)

`react-router-dom` (root and `frontend/`) replaced with `react-router` 8.3.0. This is an import migration, not just a version bump - React Router v8 dropped the `react-router-dom` re-export package entirely. All 9 files that imported from `react-router-dom` now import from `react-router` directly:

- `frontend/src/App.jsx`
- `frontend/src/pages/AILayer.jsx`, `DetailedScan.jsx`
- `frontend/src/components/layout/Sidebar.jsx`, `Header.jsx`, `Layout.jsx`
- `frontend/src/components/scan/AskAIButton.jsx`
- `frontend/src/components/prioritization/QuickRemediation.jsx`
- `frontend/src/components/compliance/ComplianceTable.jsx`

Verified against the actual v8 package before making the change: `react-router/dom` only exports `RouterProvider`/`HydratedRouter` in v8 (nothing here uses either), while every export these files actually use (`BrowserRouter`, `Routes`, `Route`, `Navigate`, `useLocation`, `useNavigate`, `NavLink`, `Outlet`) lives in the main `react-router` package. Fixes alerts #12, #10, #8, #7, #6, #5.

`postcss` bumped to `>=8.5.18` (resolved to `8.5.25`). Fixes alert #9.

`brace-expansion` bumped via `npm audit fix` to `5.0.9`, not just the originally-requested `5.0.7` floor - `5.0.7` still carries a second, separate out-of-memory DoS advisory (`GHSA-mh99-v99m-4gvg`) that only clears at `5.0.8+`. Fixes alert #4 and that second advisory.

## CodeQL alert #31: clear-text logging of sensitive information

`scanner/rules/az_idn_006.py` logged the raw `endDateTime` value from a service principal's password credential when it failed to parse. Removed the value from the log line - `app_id` alone is sufficient to correlate the failure during debugging.

This matches the fix already proposed in draft PR #220 (Copilot Autofix) - this PR supersedes it, so #220 can be closed once this merges.

Also strengthened the existing regression test (`test_idn_006_malformed_end_date_time_does_not_log_key_id`) to assert the malformed `endDateTime` value itself never reaches the logs, not just `keyId`. Verified the test fails against the pre-fix code and passes after the fix.

## Other

Added `node_modules/` to the root `.gitignore`. The root `package.json` exists solely to give Dependabot a manifest to track `react-router` against (predates this PR), but regenerating its lockfile locally left an untracked `node_modules/` with nothing preventing an accidental commit.

## Test plan

- [x] `npm audit` clean at repo root (0 vulnerabilities)
- [x] `npm audit` clean in `frontend/` (0 vulnerabilities)
- [x] `npm run build` succeeds in `frontend/` (694 modules, no import errors)
- [x] `npm run lint` clean in `frontend/`
- [x] `ruff check .` and `ruff format --check` clean
- [x] Full `pytest -q`: 437 passed, 2 pre-existing/unrelated failures (local chromadb version mismatch, not present in CI)
- [x] Strengthened regression test verified to fail against pre-fix code, pass against the fix
- [x] `bandit` on the changed rule file: no issues
