### PR TITLE
Fix cryptography vulnerability CVE-2026-69247 (#225)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ OpenShield uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Security
 
+- Upgraded cryptography to 50.0.0 to address CVE-2026-69247
 - AI provider errors no longer expose upstream response details
 - Request body limits, AI rate limiting, and playbook path validation added
 - GitHub Actions dependencies pinned to immutable commit SHAs

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,7 @@ pyjwt==2.13.0
 requests==2.34.2
 PyYAML==6.0.3
 gunicorn==26.0.0
-cryptography==49.0.0
+cryptography==50.0.0
 msrest==0.7.1
 azure-mgmt-postgresqlflexibleservers==1.0.0b1
 azure-keyvault-certificates==4.8.0


### PR DESCRIPTION
## Summary

Upgrades the direct `cryptography` dependency from 49.0.0 to 50.0.0 to remediate CVE-2026-69247 reported by Dependabot alert #13.

## What changed

- Updated the `cryptography` pin to the first patched release.
- Added the remediation to the Unreleased security changelog.

## Verification

- `pip-audit` reports no known vulnerabilities.
- Backend suite: 480 passed, 2 skipped, 84.21% coverage.
- Ruff, Bandit, frontend lint/build, and website tests pass.

Closes #225