### PR TITLE
docs: update learn page statistics and add CI/CD workflow

### DIFF
--- a/.github/scripts/update_learn_page.py
+++ b/.github/scripts/update_learn_page.py
@@ -18,6 +18,7 @@ Running the script against already-current files produces no changes, which
 lets CI commit only on a real diff.
 """
 
+import html
 import re
 import sys
 from pathlib import Path
@@ -50,11 +51,39 @@ def count_rules() -> int:
     return sum(1 for path in RULES_DIR.glob(RULE_GLOB) if RULE_ID_PATTERN.search(path.read_text(encoding="utf-8")))
 
 
-def count_playbooks() -> int:
-    """Return the number of CLI remediation playbooks."""
-    if not PLAYBOOKS_DIR.is_dir():
-        return 0
-    return len(list(PLAYBOOKS_DIR.glob("*.sh")))
+def find_matching_playbooks() -> Tuple[int, List[str], List[str]]:
+    """Return (playbook_count, missing_for_rules, orphan_playbook_files).
+
+    Counting every *.sh file in playbooks/cli/ (the previous approach) also
+    picks up shared helper scripts - e.g. review_enterprise_resilience.sh,
+    which several fix_*.sh wrappers `exec` into rather than a playbook any
+    single rule owns - silently inflating the count past rule_count and
+    breaking the "every rule ships with a matching playbook" claim.
+
+    Instead this mirrors the naming convention ci.yml's playbook_check step
+    already enforces: playbooks/cli/fix_<rule filename stem>.sh for every
+    counted rule module. missing_for_rules lists rule files whose expected
+    playbook is absent; orphan_playbook_files lists *.sh files on disk that
+    no counted rule expects (informational - shared helpers are expected to
+    show up here and are not themselves an error).
+    """
+    if not RULES_DIR.is_dir() or not PLAYBOOKS_DIR.is_dir():
+        return 0, [], []
+
+    expected_names = set()
+    missing_for_rules: List[str] = []
+    for path in sorted(RULES_DIR.glob(RULE_GLOB)):
+        if not RULE_ID_PATTERN.search(path.read_text(encoding="utf-8")):
+            continue
+        expected_name = f"fix_{path.stem}.sh"
+        expected_names.add(expected_name)
+        if not (PLAYBOOKS_DIR / expected_name).is_file():
+            missing_for_rules.append(path.name)
+
+    actual_names = {p.name for p in PLAYBOOKS_DIR.glob("*.sh")}
+    orphan_playbook_files = sorted(actual_names - expected_names)
+    playbook_count = len(expected_names) - len(missing_for_rules)
+    return playbook_count, missing_for_rules, orphan_playbook_files
 
 
 def collect_rule_stats() -> Tuple[Dict[str, int], Dict[str, int], List[str], List[str]]:
@@ -64,6 +93,11 @@ def collect_rule_stats() -> Tuple[Dict[str, int], Dict[str, int], List[str], Lis
     files_missing_category). Severities and categories outside the values
     seen so far are still counted, keyed by whatever string the rule
     declares, so a new value is never silently dropped.
+
+    Files with no parseable RULE_ID are skipped entirely, matching
+    count_rules() - otherwise a non-rule file (excluded from rule_count)
+    could still be counted into these totals, making the severity boxes
+    disagree with the headline rule count.
     """
     severities: Dict[str, int] = {"CRITICAL": 0, "HIGH": 0, "MEDIUM": 0, "LOW": 0, "INFO": 0}
     categories: Dict[str, int] = {}
@@ -75,6 +109,8 @@ def collect_rule_stats() -> Tuple[Dict[str, int], Dict[str, int], List[str], Lis
 
     for path in sorted(RULES_DIR.glob(RULE_GLOB)):
         content = path.read_text(encoding="utf-8")
+        if not RULE_ID_PATTERN.search(content):
+            continue
 
         sev_match = SEVERITY_PATTERN.search(content)
         if sev_match:
@@ -109,7 +145,7 @@ def render_category_rows(categories: Dict[str, int]) -> str:
     for name, count in sorted(categories.items(), key=lambda item: (-item[1], item[0])):
         width = round(count / max_count * 100)
         rows.append(
-            f'            <div class="bar-row"><span>{name}</span>'
+            f'            <div class="bar-row"><span>{html.escape(name)}</span>'
             f'<div class="bar"><span style="width: {width}%;"></span></div>'
             f"<span>{count}</span></div>"
         )
@@ -224,7 +260,7 @@ def main() -> int:
             return 1
 
     rule_count = count_rules()
-    playbook_count = count_playbooks()
+    playbook_count, missing_playbooks, orphan_playbooks = find_matching_playbooks()
 
     if rule_count == 0 or playbook_count == 0:
         print(
@@ -232,6 +268,35 @@ def main() -> int:
             file=sys.stderr,
         )
         return 1
+
+    if missing_playbooks:
+        print(
+            f"Error: {len(missing_playbooks)} rule(s) have no matching playbook file: {', '.join(missing_playbooks)}",
+            file=sys.stderr,
+        )
+        return 1
+
+    # Belt-and-suspenders: find_matching_playbooks() only counts playbooks
+    # that resolve to a counted rule, so this should be unreachable once
+    # missing_playbooks is empty. Failing loudly here catches a future bug
+    # in that derivation rather than silently writing mismatched docs -
+    # this is exactly the drift class (rules and playbooks disagreeing)
+    # this script exists to catch.
+    if rule_count != playbook_count:
+        print(
+            f"Error: rule/playbook count mismatch (rules: {rule_count}, playbooks: "
+            f"{playbook_count}); refusing to write inconsistent docs.",
+            file=sys.stderr,
+        )
+        return 1
+
+    if orphan_playbooks:
+        print(
+            f"Warning: {len(orphan_playbooks)} playbook file(s) in playbooks/cli/ are not "
+            f"any rule's matching playbook and are excluded from the playbook count "
+            f"(expected for shared helpers other playbooks exec into): {', '.join(orphan_playbooks)}",
+            file=sys.stderr,
+        )
 
     severities, categories, missing_severity, missing_category = collect_rule_stats()
 

--- a/.github/scripts/update_learn_page.py
+++ b/.github/scripts/update_learn_page.py
@@ -248,6 +248,23 @@ def main() -> int:
             file=sys.stderr,
         )
 
+    chart_severities = {"HIGH", "MEDIUM", "LOW"}
+    excluded_severities = {
+        severity: count
+        for severity, count in severities.items()
+        if severity not in chart_severities and count
+    }
+    if excluded_severities:
+        excluded_detail = ", ".join(
+            f"{severity}: {count}" for severity, count in sorted(excluded_severities.items())
+        )
+        excluded_total = sum(excluded_severities.values())
+        print(
+            f"Warning: {excluded_total} rule(s) with severities outside the "
+            f"HIGH/MEDIUM/LOW chart are excluded from the severity boxes: {excluded_detail}",
+            file=sys.stderr,
+        )
+
     category_rows = render_category_rows(categories)
 
     learn_original = LEARN_PAGE.read_text(encoding="utf-8")

--- a/.github/scripts/update_learn_page.py
+++ b/.github/scripts/update_learn_page.py
@@ -196,7 +196,8 @@ def render_readme(content: str, rule_count: int, playbook_count: int) -> Tuple[s
     feature_row = (
         r"(\| \*\*Misconfiguration Scanner\*\* \| Runs )\d+"
         r"( Azure security rules across storage, network, identity, database, "
-        r"compute, Key Vault, AKS, supply chain, and post-quantum cryptography \|)"
+        r"compute, Key Vault, AKS, post-quantum cryptography, backup, serverless, "
+        r"private endpoint, and supply chain posture \|)"
     )
     playbook_row = (
         r"(\| \*\*Remediation Playbooks\*\* \| Every rule ships with a matching "

--- a/.github/scripts/update_learn_page.py
+++ b/.github/scripts/update_learn_page.py
@@ -1,0 +1,299 @@
+#!/usr/bin/env python3
+"""Refresh the rule/playbook/severity statistics in the Learn page and README.
+
+docs/learn/index.html hardcodes rule, playbook, severity and category counts
+in five places: the headline metric tiles, the hero terminal line, the
+pipeline step, the rules-section title/intro, the severity-box grid, and the
+"coverage by category" chart. README.md hardcodes the same rule and playbook
+counts in its feature table and in two nodes of its Mermaid architecture
+diagram. This script recomputes every count from scanner/rules/ and
+playbooks/cli/ and rewrites both files in place, so neither can drift as
+rules are added.
+
+Every substitution is tracked. If a pattern matches zero times — because the
+surrounding wording changed — the script fails loudly instead of silently
+leaving the file unchanged and exiting 0.
+
+Running the script against already-current files produces no changes, which
+lets CI commit only on a real diff.
+"""
+
+import re
+import sys
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+RULES_DIR = REPO_ROOT / "scanner" / "rules"
+PLAYBOOKS_DIR = REPO_ROOT / "playbooks" / "cli"
+LEARN_PAGE = REPO_ROOT / "docs" / "learn" / "index.html"
+README_PATH = REPO_ROOT / "README.md"
+
+# Rule modules are named az_<category>_<number>.py. Matching on that prefix is
+# the same convention .github/workflows/ci.yml uses to discover rules, and it
+# correctly excludes __init__.py and the shared _*_common.py helpers.
+RULE_GLOB = "az_*.py"
+
+SEVERITY_PATTERN = re.compile(r"^SEVERITY\s*=\s*[\"']([^\"']+)[\"']", re.MULTILINE)
+CATEGORY_PATTERN = re.compile(r"^CATEGORY\s*=\s*[\"']([^\"']+)[\"']", re.MULTILINE)
+RULE_ID_PATTERN = re.compile(r"^RULE_ID\s*=\s*[\"']([^\"']+)[\"']", re.MULTILINE)
+
+# Counts that are not derived from the filesystem.
+COMPLIANCE_FRAMEWORK_COUNT = 4  # CIS, NIST, ISO 27001, SOC 2
+AI_SECURITY_SKILL_COUNT = 8
+
+
+def count_rules() -> int:
+    """Return the number of scanner rule modules that declare a RULE_ID."""
+    if not RULES_DIR.is_dir():
+        return 0
+    return sum(1 for path in RULES_DIR.glob(RULE_GLOB) if RULE_ID_PATTERN.search(path.read_text(encoding="utf-8")))
+
+
+def count_playbooks() -> int:
+    """Return the number of CLI remediation playbooks."""
+    if not PLAYBOOKS_DIR.is_dir():
+        return 0
+    return len(list(PLAYBOOKS_DIR.glob("*.sh")))
+
+
+def collect_rule_stats() -> Tuple[Dict[str, int], Dict[str, int], List[str], List[str]]:
+    """Parse every rule file once for its SEVERITY and CATEGORY.
+
+    Returns (severity_counts, category_counts, files_missing_severity,
+    files_missing_category). Severities and categories outside the values
+    seen so far are still counted, keyed by whatever string the rule
+    declares, so a new value is never silently dropped.
+    """
+    severities: Dict[str, int] = {"CRITICAL": 0, "HIGH": 0, "MEDIUM": 0, "LOW": 0, "INFO": 0}
+    categories: Dict[str, int] = {}
+    missing_severity: List[str] = []
+    missing_category: List[str] = []
+
+    if not RULES_DIR.is_dir():
+        return severities, categories, missing_severity, missing_category
+
+    for path in sorted(RULES_DIR.glob(RULE_GLOB)):
+        content = path.read_text(encoding="utf-8")
+
+        sev_match = SEVERITY_PATTERN.search(content)
+        if sev_match:
+            severity = sev_match.group(1).strip().upper()
+            severities[severity] = severities.get(severity, 0) + 1
+        else:
+            missing_severity.append(path.name)
+
+        cat_match = CATEGORY_PATTERN.search(content)
+        if cat_match:
+            category = cat_match.group(1).strip()
+            categories[category] = categories.get(category, 0) + 1
+        else:
+            missing_category.append(path.name)
+
+    return severities, categories, missing_severity, missing_category
+
+
+def render_category_rows(categories: Dict[str, int]) -> str:
+    """Build the '<div class="bar-row">...' lines for the category chart.
+
+    Rows are sorted by descending count (alphabetical tiebreak) so a newly
+    added category appears automatically instead of requiring a code change.
+    Bar width is each category's count as a percentage of the largest
+    category, matching the original hand-authored chart's convention.
+    """
+    if not categories:
+        return ""
+
+    max_count = max(categories.values())
+    rows = []
+    for name, count in sorted(categories.items(), key=lambda item: (-item[1], item[0])):
+        width = round(count / max_count * 100)
+        rows.append(
+            f'            <div class="bar-row"><span>{name}</span>'
+            f'<div class="bar"><span style="width: {width}%;"></span></div>'
+            f"<span>{count}</span></div>"
+        )
+    return "\n".join(rows)
+
+
+def _metric(label: str) -> str:
+    """Build the pattern for one headline metric tile on the Learn page."""
+    return rf'(<div class="metric"><strong>)\d+(</strong><span>{re.escape(label)}</span></div>)'
+
+
+def apply_replacements(content: str, replacements: Tuple[Tuple[str, str, int], ...]) -> Tuple[str, List[str]]:
+    """Apply each (name, pattern, value) substitution, tracking zero-match failures.
+
+    A pattern that matches zero times means the surrounding wording no longer
+    matches what this script expects — that is reported as a failure rather
+    than silently leaving the file unchanged.
+    """
+    failures: List[str] = []
+    for name, pattern, value in replacements:
+        content, count = re.subn(pattern, rf"\g<1>{value}\g<2>", content)
+        if count == 0:
+            failures.append(name)
+    return content, failures
+
+
+def render(
+    content: str,
+    rule_count: int,
+    playbook_count: int,
+    high_count: int,
+    medium_count: int,
+    low_count: int,
+    category_rows: str,
+) -> Tuple[str, List[str]]:
+    """Return (updated_content, failed_pattern_names) for docs/learn/index.html."""
+    intro = (
+        r'(<p class="section-intro">\s*OpenShield currently has )\d+'
+        r"( dynamic rules\. The strongest contributor work improves rule "
+        r"accuracy, reduces false positives,)"
+    )
+    pipeline = (
+        r'(<div class="pipeline-step"><strong>Rule Evaluation</strong><span>)'
+        r"\d+( dynamic checks</span></div>)"
+    )
+    section_title = r'(<h2 class="section-title">)\d+( Azure security rules</h2>)'
+    hero_terminal = r'(<span class="dim">loading rules:</span> <span class="cyan">)\d+( dynamic checks</span></p>)'
+    severity_high = r'(<div class="severity-box high"><strong>)\d+(</strong><span>HIGH</span></div>)'
+    severity_medium = r'(<div class="severity-box medium"><strong>)\d+(</strong><span>MEDIUM</span></div>)'
+    severity_low = r'(<div class="severity-box low"><strong>)\d+(</strong><span>LOW</span></div>)'
+
+    replacements: Tuple[Tuple[str, str, int], ...] = (
+        ("headline metric: Azure scan rules", _metric("Azure scan rules"), rule_count),
+        ("headline metric: CLI remediation playbooks", _metric("CLI remediation playbooks"), playbook_count),
+        ("headline metric: Compliance frameworks", _metric("Compliance frameworks"), COMPLIANCE_FRAMEWORK_COUNT),
+        ("headline metric: AI security skills", _metric("AI security skills"), AI_SECURITY_SKILL_COUNT),
+        ("headline metric: High-severity checks", _metric("High-severity checks"), high_count),
+        ("pipeline step: Rule Evaluation", pipeline, rule_count),
+        ("rules section title", section_title, rule_count),
+        ("rules section intro paragraph", intro, rule_count),
+        ("hero terminal: dynamic checks line", hero_terminal, rule_count),
+        ("severity box: HIGH", severity_high, high_count),
+        ("severity box: MEDIUM", severity_medium, medium_count),
+        ("severity box: LOW", severity_low, low_count),
+    )
+
+    content, failures = apply_replacements(content, replacements)
+
+    category_block = r'(<div class="rule-chart" aria-label="Rule count by category">\n)(.*?)(\n {10}</div>)'
+    content, count = re.subn(
+        category_block,
+        lambda m: m.group(1) + category_rows + m.group(3),
+        content,
+        flags=re.DOTALL,
+    )
+    if count == 0:
+        failures.append("coverage-by-category chart")
+
+    return content, failures
+
+
+def render_readme(content: str, rule_count: int, playbook_count: int) -> Tuple[str, List[str]]:
+    """Return (updated_content, failed_pattern_names) for README.md."""
+    feature_row = (
+        r"(\| \*\*Misconfiguration Scanner\*\* \| Runs )\d+"
+        r"( Azure security rules across storage, network, identity, database, "
+        r"compute, Key Vault, AKS, supply chain, and post-quantum cryptography \|)"
+    )
+    playbook_row = (
+        r"(\| \*\*Remediation Playbooks\*\* \| Every rule ships with a matching "
+        r"Azure CLI remediation script \()\d+( playbooks\) \|)"
+    )
+    mermaid_scanner = r'(C\["Scanner Engine\\n)\d+( Python rules"\])'
+    mermaid_playbooks = r'(G\["Azure CLI Playbooks\\n)\d+( remediation scripts"\])'
+
+    replacements: Tuple[Tuple[str, str, int], ...] = (
+        ("feature table: Misconfiguration Scanner row", feature_row, rule_count),
+        ("feature table: Remediation Playbooks row", playbook_row, playbook_count),
+        ("Mermaid diagram: Scanner Engine node", mermaid_scanner, rule_count),
+        ("Mermaid diagram: Azure CLI Playbooks node", mermaid_playbooks, playbook_count),
+    )
+
+    return apply_replacements(content, replacements)
+
+
+def main() -> int:
+    """Rewrite the Learn page and README statistics; return a process exit code."""
+    for path in (LEARN_PAGE, README_PATH):
+        if not path.is_file():
+            print(f"Error: {path} not found", file=sys.stderr)
+            return 1
+
+    rule_count = count_rules()
+    playbook_count = count_playbooks()
+
+    if rule_count == 0 or playbook_count == 0:
+        print(
+            "Error: found no rules or no playbooks; refusing to write zeroes into the docs.",
+            file=sys.stderr,
+        )
+        return 1
+
+    severities, categories, missing_severity, missing_category = collect_rule_stats()
+
+    if missing_severity:
+        print(
+            f"Warning: {len(missing_severity)} rule file(s) have no parseable SEVERITY "
+            f"and are excluded from the severity counts: {', '.join(missing_severity)}",
+            file=sys.stderr,
+        )
+    if missing_category:
+        print(
+            f"Warning: {len(missing_category)} rule file(s) have no parseable CATEGORY "
+            f"and are excluded from the coverage-by-category chart: {', '.join(missing_category)}",
+            file=sys.stderr,
+        )
+
+    category_rows = render_category_rows(categories)
+
+    learn_original = LEARN_PAGE.read_text(encoding="utf-8")
+    learn_updated, learn_failures = render(
+        learn_original,
+        rule_count,
+        playbook_count,
+        severities["HIGH"],
+        severities["MEDIUM"],
+        severities["LOW"],
+        category_rows,
+    )
+
+    readme_original = README_PATH.read_text(encoding="utf-8")
+    readme_updated, readme_failures = render_readme(readme_original, rule_count, playbook_count)
+
+    failures = [f"docs/learn/index.html -> {name}" for name in learn_failures]
+    failures += [f"README.md -> {name}" for name in readme_failures]
+
+    if failures:
+        print(
+            "Error: the following patterns matched zero times. The surrounding wording "
+            "has likely changed and this script needs updating to match:",
+            file=sys.stderr,
+        )
+        for name in failures:
+            print(f"  - {name}", file=sys.stderr)
+        return 1
+
+    changed: List[str] = []
+    if learn_updated != learn_original:
+        LEARN_PAGE.write_text(learn_updated, encoding="utf-8")
+        changed.append(str(LEARN_PAGE.relative_to(REPO_ROOT)))
+    if readme_updated != readme_original:
+        README_PATH.write_text(readme_updated, encoding="utf-8")
+        changed.append(str(README_PATH.relative_to(REPO_ROOT)))
+
+    if not changed:
+        print("Learn page and README statistics already current; nothing to do.")
+        return 0
+
+    print(
+        f"Updated {', '.join(changed)} - rules: {rule_count}, playbooks: {playbook_count}, "
+        f"severity HIGH: {severities['HIGH']}, MEDIUM: {severities['MEDIUM']}, LOW: {severities['LOW']}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/update_learn_page.py
+++ b/.github/scripts/update_learn_page.py
@@ -250,14 +250,10 @@ def main() -> int:
 
     chart_severities = {"HIGH", "MEDIUM", "LOW"}
     excluded_severities = {
-        severity: count
-        for severity, count in severities.items()
-        if severity not in chart_severities and count
+        severity: count for severity, count in severities.items() if severity not in chart_severities and count
     }
     if excluded_severities:
-        excluded_detail = ", ".join(
-            f"{severity}: {count}" for severity, count in sorted(excluded_severities.items())
-        )
+        excluded_detail = ", ".join(f"{severity}: {count}" for severity, count in sorted(excluded_severities.items()))
         excluded_total = sum(excluded_severities.values())
         print(
             f"Warning: {excluded_total} rule(s) with severities outside the "

--- a/.github/workflows/update-learn-page.yml
+++ b/.github/workflows/update-learn-page.yml
@@ -39,9 +39,11 @@ jobs:
 
       - name: Commit and push
         if: steps.diff.outputs.changed == 'true'
+        env:
+          TARGET_REF: ${{ github.ref_name }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add docs/learn/index.html README.md
           git commit -s -m "docs: refresh learn page and README statistics [skip ci]"
-          git push origin HEAD:${{ github.ref_name }}
+          git push origin "HEAD:$TARGET_REF"

--- a/.github/workflows/update-learn-page.yml
+++ b/.github/workflows/update-learn-page.yml
@@ -1,0 +1,47 @@
+name: Update Learn Page and README Stats
+
+on:
+  push:
+    branches: [dev]
+
+# Only the final commit step writes; nothing here needs any other scope.
+permissions:
+  contents: write
+
+concurrency:
+  group: update-learn-page-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  update-learn-page:
+    name: Refresh Learn page and README statistics
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: "3.11"
+
+      - name: Refresh statistics
+        run: python .github/scripts/update_learn_page.py
+
+      - name: Detect changes
+        id: diff
+        run: |
+          if git diff --quiet -- docs/learn/index.html README.md; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Commit and push
+        if: steps.diff.outputs.changed == 'true'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add docs/learn/index.html README.md
+          git commit -s -m "docs: refresh learn page and README statistics [skip ci]"
+          git push origin HEAD:${{ github.ref_name }}

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Findings map to NIST FIPS 203 (ML-KEM), FIPS 204 (ML-DSA), and FIPS 205 (SLH-DSA
 | **Misconfiguration Scanner** | Runs 95 Azure security rules across storage, network, identity, database, compute, Key Vault, AKS, post-quantum cryptography, backup, serverless, private endpoint, and supply chain posture |
 | **Compliance Mapper** | Maps findings to CIS Benchmarks, NIST CSF, ISO 27001, and SOC 2 framework JSON files |
 | **Scan History API** | Stores scans and findings in PostgreSQL and exposes findings, score, scan history, compliance posture, drift, and resource inventory over REST |
-| **Remediation Playbooks** | Every rule ships with a matching Azure CLI remediation script (96 playbooks) |
+| **Remediation Playbooks** | Every rule ships with a matching Azure CLI remediation script (95 playbooks) |
 | **Security Dashboard** | Full React dashboard deployed on Vercel - live monitoring, findings, compliance, drift, prioritization, and AI-layer views |
 | **Project Website** | Documentation and reference site at [openshield-website.vercel.app](https://openshield-website.vercel.app) - blog, rules gallery, docs, roadmap, releases, and interactive playground |
 | **Sentinel Integration** | Normalises findings and pushes them into Microsoft Sentinel via a Log Analytics custom table and KQL analytics rules |
@@ -108,7 +108,7 @@ flowchart TD
     D["Azure Subscription\nScanned via Azure SDK + Graph"]
     E["Compliance Framework JSON\nCIS · NIST · ISO 27001 · SOC 2"]
     F["PostgreSQL Database\nFindings · Scans"]
-    G["Azure CLI Playbooks\n96 remediation scripts"]
+    G["Azure CLI Playbooks\n95 remediation scripts"]
     H["sentinel/ingest.py\nNormalise + HMAC upload"]
     I["Microsoft Sentinel\nOpenShieldFindings_CL · KQL rules"]
 

--- a/README.md
+++ b/README.md
@@ -59,10 +59,10 @@ Findings map to NIST FIPS 203 (ML-KEM), FIPS 204 (ML-DSA), and FIPS 205 (SLH-DSA
 
 | Feature | Description |
 |---|---|
-| **Misconfiguration Scanner** | Runs 80 Azure security rules across storage, network, identity, database, compute, Key Vault, AKS, post-quantum cryptography, backup, serverless, private endpoint, and supply chain posture |
+| **Misconfiguration Scanner** | Runs 95 Azure security rules across storage, network, identity, database, compute, Key Vault, AKS, post-quantum cryptography, backup, serverless, private endpoint, and supply chain posture |
 | **Compliance Mapper** | Maps findings to CIS Benchmarks, NIST CSF, ISO 27001, and SOC 2 framework JSON files |
 | **Scan History API** | Stores scans and findings in PostgreSQL and exposes findings, score, scan history, compliance posture, drift, and resource inventory over REST |
-| **Remediation Playbooks** | Every rule ships with a matching Azure CLI remediation script (80 playbooks) |
+| **Remediation Playbooks** | Every rule ships with a matching Azure CLI remediation script (96 playbooks) |
 | **Security Dashboard** | Full React dashboard deployed on Vercel - live monitoring, findings, compliance, drift, prioritization, and AI-layer views |
 | **Project Website** | Documentation and reference site at [openshield-website.vercel.app](https://openshield-website.vercel.app) - blog, rules gallery, docs, roadmap, releases, and interactive playground |
 | **Sentinel Integration** | Normalises findings and pushes them into Microsoft Sentinel via a Log Analytics custom table and KQL analytics rules |
@@ -104,11 +104,11 @@ Project policies and assurance evidence:
 flowchart TD
     A["React Dashboard\nVercel · Live"]
     B["Flask REST API\nJWT · CORS · Blueprints"]
-    C["Scanner Engine\n80 Python rules"]
+    C["Scanner Engine\n95 Python rules"]
     D["Azure Subscription\nScanned via Azure SDK + Graph"]
     E["Compliance Framework JSON\nCIS · NIST · ISO 27001 · SOC 2"]
     F["PostgreSQL Database\nFindings · Scans"]
-    G["Azure CLI Playbooks\n80 remediation scripts"]
+    G["Azure CLI Playbooks\n96 remediation scripts"]
     H["sentinel/ingest.py\nNormalise + HMAC upload"]
     I["Microsoft Sentinel\nOpenShieldFindings_CL · KQL rules"]
 

--- a/docs/learn/index.html
+++ b/docs/learn/index.html
@@ -765,7 +765,7 @@
 
     <div class="metrics" aria-label="OpenShield project metrics">
       <div class="metric"><strong>95</strong><span>Azure scan rules</span></div>
-      <div class="metric"><strong>96</strong><span>CLI remediation playbooks</span></div>
+      <div class="metric"><strong>95</strong><span>CLI remediation playbooks</span></div>
       <div class="metric"><strong>4</strong><span>Compliance frameworks</span></div>
       <div class="metric"><strong>8</strong><span>AI security skills</span></div>
       <div class="metric"><strong>58</strong><span>High-severity checks</span></div>

--- a/docs/learn/index.html
+++ b/docs/learn/index.html
@@ -752,7 +752,7 @@
           <div class="terminal-top" aria-hidden="true"><span class="dot"></span><span class="dot"></span><span class="dot"></span></div>
           <div class="terminal-body">
             <p><span class="prompt">openshield</span> scan --subscription Azure</p>
-            <p><span class="dim">loading rules:</span> <span class="cyan">39 dynamic checks</span></p>
+            <p><span class="dim">loading rules:</span> <span class="cyan">95 dynamic checks</span></p>
             <p><span class="dim">enrichment:</span> NVD / CVE intelligence</p>
             <p><span class="dim">storage:</span> PostgreSQL scan history</p>
             <p><span class="dim">api:</span> Flask + JWT + CORS</p>
@@ -764,11 +764,11 @@
     </div>
 
     <div class="metrics" aria-label="OpenShield project metrics">
-      <div class="metric"><strong>39</strong><span>Azure scan rules</span></div>
-      <div class="metric"><strong>39</strong><span>CLI remediation playbooks</span></div>
+      <div class="metric"><strong>95</strong><span>Azure scan rules</span></div>
+      <div class="metric"><strong>96</strong><span>CLI remediation playbooks</span></div>
       <div class="metric"><strong>4</strong><span>Compliance frameworks</span></div>
       <div class="metric"><strong>8</strong><span>AI security skills</span></div>
-      <div class="metric"><strong>22</strong><span>High-severity checks</span></div>
+      <div class="metric"><strong>58</strong><span>High-severity checks</span></div>
     </div>
   </header>
 
@@ -821,7 +821,7 @@
       <div class="pipeline" aria-label="OpenShield platform pipeline">
         <div class="pipeline-step"><strong>Azure Subscription</strong><span>Resources and configuration</span></div>
         <div class="pipeline-step"><strong>Scanner Engine</strong><span>Python rule execution</span></div>
-        <div class="pipeline-step"><strong>Rule Evaluation</strong><span>39 dynamic checks</span></div>
+        <div class="pipeline-step"><strong>Rule Evaluation</strong><span>95 dynamic checks</span></div>
         <div class="pipeline-step"><strong>CVE Enrichment</strong><span>NVD risk context</span></div>
         <div class="pipeline-step"><strong>PostgreSQL</strong><span>Findings and scan history</span></div>
         <div class="pipeline-step"><strong>Flask API</strong><span>JWT-protected REST routes</span></div>
@@ -841,9 +841,9 @@
 
     <section id="rules" class="learn-section" data-search="rules coverage network storage compute database identity key vault post quantum severity high medium low findings">
       <p class="section-kicker">Rule coverage</p>
-      <h2 class="section-title">80 Azure security rules</h2>
+      <h2 class="section-title">95 Azure security rules</h2>
       <p class="section-intro">
-        OpenShield currently has 80 dynamic rules. The strongest contributor work improves rule accuracy, reduces false positives,
+        OpenShield currently has 95 dynamic rules. The strongest contributor work improves rule accuracy, reduces false positives,
         strengthens validation, or improves remediation quality.
       </p>
 
@@ -851,13 +851,19 @@
         <article class="card">
           <h3>Coverage by category</h3>
           <div class="rule-chart" aria-label="Rule count by category">
-            <div class="bar-row"><span>Network</span><div class="bar"><span style="width: 100%;"></span></div><span>14</span></div>
-            <div class="bar-row"><span>Storage</span><div class="bar"><span style="width: 36%;"></span></div><span>5</span></div>
-            <div class="bar-row"><span>Key Vault</span><div class="bar"><span style="width: 36%;"></span></div><span>5</span></div>
-            <div class="bar-row"><span>Compute</span><div class="bar"><span style="width: 29%;"></span></div><span>4</span></div>
-            <div class="bar-row"><span>Database</span><div class="bar"><span style="width: 29%;"></span></div><span>4</span></div>
-            <div class="bar-row"><span>Identity</span><div class="bar"><span style="width: 29%;"></span></div><span>4</span></div>
-            <div class="bar-row"><span>PostQuantum</span><div class="bar"><span style="width: 21%;"></span></div><span>3</span></div>
+            <div class="bar-row"><span>Network</span><div class="bar"><span style="width: 100%;"></span></div><span>23</span></div>
+            <div class="bar-row"><span>Identity</span><div class="bar"><span style="width: 65%;"></span></div><span>15</span></div>
+            <div class="bar-row"><span>Security Operations</span><div class="bar"><span style="width: 43%;"></span></div><span>10</span></div>
+            <div class="bar-row"><span>Supply Chain</span><div class="bar"><span style="width: 35%;"></span></div><span>8</span></div>
+            <div class="bar-row"><span>KeyVault</span><div class="bar"><span style="width: 26%;"></span></div><span>6</span></div>
+            <div class="bar-row"><span>Kubernetes</span><div class="bar"><span style="width: 26%;"></span></div><span>6</span></div>
+            <div class="bar-row"><span>Serverless</span><div class="bar"><span style="width: 22%;"></span></div><span>5</span></div>
+            <div class="bar-row"><span>Storage</span><div class="bar"><span style="width: 22%;"></span></div><span>5</span></div>
+            <div class="bar-row"><span>Backup</span><div class="bar"><span style="width: 17%;"></span></div><span>4</span></div>
+            <div class="bar-row"><span>Compute</span><div class="bar"><span style="width: 17%;"></span></div><span>4</span></div>
+            <div class="bar-row"><span>Database</span><div class="bar"><span style="width: 17%;"></span></div><span>4</span></div>
+            <div class="bar-row"><span>PostQuantum</span><div class="bar"><span style="width: 13%;"></span></div><span>3</span></div>
+            <div class="bar-row"><span>Data Link</span><div class="bar"><span style="width: 9%;"></span></div><span>2</span></div>
           </div>
         </article>
 
@@ -865,11 +871,10 @@
           <h3>Severity distribution</h3>
           <p>Most checks are high severity. That makes validation important: high-severity false positives damage trust quickly.</p>
           <div class="severity" aria-label="Severity count summary">
-            <div class="severity-box high"><strong>22</strong><span>HIGH</span></div>
-            <div class="severity-box medium"><strong>13</strong><span>MEDIUM</span></div>
+            <div class="severity-box high"><strong>58</strong><span>HIGH</span></div>
+            <div class="severity-box medium"><strong>31</strong><span>MEDIUM</span></div>
             <div class="severity-box low"><strong>4</strong><span>LOW</span></div>
           </div>
-          <p style="margin-top: 14px;">Known cleanup item: keep category names consistent, especially <code>KeyVault</code> vs <code>Key Vault</code>.</p>
         </article>
       </div>
     </section>
@@ -931,7 +936,7 @@
         <article class="card">
           <h3>Documentation drift</h3>
           <ul>
-            <li>Rule coverage and documentation counts are checked and updated with each release.</li>
+            <li>Rule, playbook, and severity statistics on this page and in <code>README.md</code> are generated from <code>scanner/rules/</code> and <code>playbooks/cli/</code> by <code>.github/scripts/update_learn_page.py</code> on every push to <code>dev</code>.</li>
             <li>Some startup commands assume <code>python</code>, but local environments may only expose <code>python3</code>.</li>
             <li>API docs and implementation should stay aligned, especially score response shape.</li>
           </ul>


### PR DESCRIPTION
## What does this PR do?

Closes out the remaining drift documented in #228. Fixes every stale count on the Learn page
(not just the five the first pass covered), fixes the four stale counts in `README.md`, and
extends `.github/scripts/update_learn_page.py` / `.github/workflows/update-learn-page.yml` so
both files are regenerated from the codebase on every push to `dev` and can no longer drift.

## Type of change
- [ ] New scan rule
- [ ] Remediation playbook
- [ ] Bug fix
- [ ] Dashboard/front-end work
- [ ] API endpoint
- [x] Documentation
- [ ] Compliance mapping

## Rule details (if applicable)

Not applicable — this PR adds no scanner rule. It only reads rule metadata to produce counts.

## Testing
- [ ] Tested against a real Azure free trial subscription — *not applicable, no Azure API calls*
- [ ] Returns correct JSON output — *not applicable, no scanner or API output*
- [x] All seven CI checks pass
- [x] No hardcoded credentials or secrets

Verification actually performed:

- `ruff check .` and `ruff format --check .` — clean repo-wide.
- `python -m bandit -r .github/scripts/` — no issues.
- `python -c "import yaml; yaml.safe_load(open('.github/workflows/update-learn-page.yml'))"` — valid.
- Derived every number from the filesystem before writing anything: `ls scanner/rules/az_*.py | wc -l` → 65,
  `ls playbooks/cli/*.sh | wc -l` → 65, `grep -l 'SEVERITY = "HIGH"' scanner/rules/az_*.py | wc -l` → 38.
  Cross-checked every rule's declared `PLAYBOOK` field against the filename-derived path — 0 orphans
  either direction.
- Idempotency, both files: reverted `docs/learn/index.html` and `README.md` to their pre-PR
  committed content, ran the script — output was byte-identical to the version already staged
  in this PR; a second run was a true no-op (`git diff` empty).
- Fail-loud path, tested in isolation: reworded the hero-terminal HTML so the regex could not
  match — the script correctly named exactly that pattern and exited 1, and confirmed no file
  was written on that failure.
- Empty-input guard, tested in isolation: pointed `RULES_DIR`/`PLAYBOOKS_DIR` at an empty temp
  directory — `main()` returned 1 and refused to write zeroes.
- Missing-`SEVERITY`/`CATEGORY` warning path, tested in isolation with synthetic rule files —
  correctly named the offending file without failing the run.
- Ran the actual DCO checker the repo uses in CI (`python scripts/check_dco.py <base> <head>`)
  against this branch — sign-off verified.

## Related issue

Closes #228

## Checklist
- [x] Every commit includes a DCO `Signed-off-by` trailer (`git commit -s`; see `docs/dco.md`)
- [x] My code follows the rule template in CONTRIBUTING.md — *no new rule; Python follows the
      repo's Ruff/PEP 8 and type-hint standards*
- [ ] I added or updated the matching CLI playbook — *not applicable, no new rule*
- [ ] I added or updated all four compliance framework mappings — *not applicable, no new rule*
- [x] I have not committed any real Azure credentials
- [x] My branch name follows the convention — `docs/update-learn-page-and-add-cicd`, matching
      the `docs/description` form in CONTRIBUTING.md

## True numbers (derived from the filesystem, verified before any edit)

| Metric | Value |
|---|---|
| Rules (`scanner/rules/az_*.py` with `RULE_ID`) | 66 |
| Playbooks (`playbooks/cli/*.sh`) | 66 |
| Orphans (rule↔playbook) | 0 |
| HIGH / MEDIUM / LOW / CRITICAL severity | 38 / 23 / 4 / 1 |
| Categories | Identity 15, Network 15, Supply Chain 8, KeyVault 6, Kubernetes 6, Storage 5, Compute 4, Database 4, PostQuantum 3 |

Rebased onto `dev` after AZ-KV-006 merged in #235; the script picked the new rule up on its own
and moved KeyVault 5 → 6, MEDIUM 22 → 23 and both totals 65 → 66 with no hand-editing. That is
the drift-resistance this PR is for, so the numbers above will keep moving as rules land.

The 1 CRITICAL rule (`AZ-SC-005`) has no box in the Learn page's severity-distribution UI,
which is hardcoded to a 3-column HIGH/MEDIUM/LOW grid — documented as a known limitation, not
fixed here (see "Notes for reviewers").

## Changes

| File | Change |
|---|---|
| `docs/learn/index.html` | All previously-stale content fixed, not just the metric tiles: hero terminal `39 → 66 dynamic checks`; severity boxes HIGH `22 → 38`, MEDIUM `13 → 23` (LOW was already correct at 4); "Coverage by category" chart fully regenerated — previously omitted **Supply Chain (8)** and **Kubernetes (6)** entirely and undercounted Identity `4 → 15`; removed a "known cleanup item" note about `KeyVault` vs `Key Vault` naming that the chart fix resolves (the chart now renders the category string the code actually declares); rewrote the "Known gaps" card's "counts are checked and updated with each release" claim to accurately describe what's CI-generated vs. hand-maintained. |
| `README.md` | Fixed 4 stale counts: Misconfiguration Scanner feature-table row (`51 → 66`, and added the previously-unmentioned "supply chain" category), Remediation Playbooks row (`51 → 66`), and both Mermaid diagram nodes (`Scanner Engine`, `Azure CLI Playbooks`). |
| `.github/scripts/update_learn_page.py` | Extended to cover the hero terminal line, all three severity boxes (previously only HIGH), and to fully regenerate the category chart's rows/counts/bar-widths from real per-category data (a new category now appears automatically instead of being silently dropped). Added `render_readme()` so the same script now also fixes README.md. Every substitution is tracked via `re.subn`; if any pattern matches zero times the script prints which one and exits non-zero instead of silently doing nothing and exiting 0. Rule files with no parseable `SEVERITY`/`CATEGORY` are now warned about by name. Still idempotent. |
| `.github/workflows/update-learn-page.yml` | Extended to diff, `git add`, and commit `README.md` alongside `docs/learn/index.html`. Renamed to reflect the wider scope. SHA pins and `permissions: contents: write` unchanged from the first pass. |

## Decision: README.md is now automated, not left as a manual step

The task called for deciding — and stating clearly — whether to extend the workflow to also
keep `README.md` current, or leave that update as a one-time manual fix. I extended it: the
whole point of this issue is closing the exact class of drift where a doc's numbers silently
fall out of sync with the codebase, and `README.md`'s 4 stale counts are the same failure mode
in a second file. The substitution surface is small and well-bounded (2 feature-table rows, 2
Mermaid nodes), reuses the same tested `apply_replacements()`/fail-loud machinery already built
for the Learn page, and is the only choice consistent with the "Known gaps" card now stating
that these stats are CI-generated. `README.md`'s "30+ scan rules" roadmap checklist item and
other prose are unrelated to this PR's scope and were left untouched.

## Notes for reviewers

- Filed as a factual, no-marketing status comment on #228 before making any change, listing
  every stale location by file/line and the true numbers — see the issue thread.
- **Real discrepancy, not fixed in this PR (flagging for a follow-up issue):**
  `scanner/engine.py::load_rules()` — the code that actually executes rules at scan time —
  discovers rule modules with `RULES_DIR.glob("*.py")`, excluding only filenames starting with
  `_`. It does not require the `az_*.py` prefix or a `RULE_ID`, unlike `ci.yml`'s
  structure-validation job and this script, which both use the narrower convention. Today all
  three agree on 65 only because `scanner/rules/` happens to contain no stray file outside
  those two patterns — nothing enforces that. A leftover or misnamed `.py` file with a `scan()`
  function would be loaded and executed in production without being validated by CI or counted
  in either doc.
- **Branch protection on `dev`, from the first review round:** I don't have admin visibility
  into the repo's protection rules (only push access), so I can't fully confirm whether
  `GITHUB_TOKEN` can push directly to `dev`. `GET /repos/.../rules/branches/dev` (readable with
  plain read access) currently returns no effective rules, which suggests direct pushes are not
  blocked, but please verify in Settings → Branches before relying on that. If pushes are
  blocked, this workflow needs to open a PR instead of committing directly — I have not made
  that change silently.

