### PR TITLE
feat(scanner): add Azure Resource Graph inventory foundation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ OpenShield uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- Azure Network Layer Assurance API with 20-domain coverage, network-rule classification, and authoritative IP forwarding and direct Internet route checks
 - Azure Resource Graph inventory snapshots as the first OpenShield Evidence Graph foundation
 - Azure Data Link Layer Assurance API with LLC and MAC coverage plus ExpressRoute Direct MACsec checks
 - Azure public-cloud Physical Layer Assurance API with complete OSI and IEEE PHY domain, sublayer, and provider-evidence coverage

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ OpenShield uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- Azure Resource Graph inventory snapshots as the first OpenShield Evidence Graph foundation
 - Azure Data Link Layer Assurance API with LLC and MAC coverage plus ExpressRoute Direct MACsec checks
 - Azure public-cloud Physical Layer Assurance API with complete OSI and IEEE PHY domain, sublayer, and provider-evidence coverage
 - Semgrep SAST integrated into GitHub Actions CI as an open-source, account-free complement to CodeQL

--- a/docs/openshield-evidence-graph.md
+++ b/docs/openshield-evidence-graph.md
@@ -11,21 +11,115 @@ OpenShield currently evaluates many security controls independently. The propose
 resources, identities, permissions, exposures, findings, infrastructure code, and remediation evidence into one
 traceable security model.
 
-```text
-Azure Resource Graph and targeted SDK evidence
-                    |
-                    v
-          Normalised evidence snapshot
-                    |
-                    v
-          Evidence-backed attack paths
-                    |
-                    v
-        Reviewed, controlled remediation
-                    |
-                    v
-             Rescan and verification
+## Target architecture
+
+The target is a hybrid scanner. ARG performs broad resource discovery, Python remains the orchestration and rule
+engine, and Azure SDK calls are retained only where ARG cannot supply the required evidence.
+
+```mermaid
+flowchart TB
+    subgraph Scope[Customer Azure boundary]
+        A[Azure tenant]
+        B[Authorised subscriptions]
+        C[Least-privilege read credential]
+        A --> B --> C
+    end
+
+    subgraph Collection[Phase 1 - inventory foundation]
+        D[ARG KQL batch query]
+        E[Pagination and bounded retry]
+        F[Truncation and repeated-token guards]
+        G[Normalised inventory snapshot]
+        H{Snapshot status}
+        I[COMPLETE]
+        J[PARTIAL]
+        K[FAILED]
+        C --> D --> E --> F --> G --> H
+        H --> I
+        H --> J
+        H --> K
+    end
+
+    subgraph Evaluation[Hybrid security evaluation]
+        L[ARG-compatible resource evidence]
+        M[Missing security properties]
+        N[Targeted Azure SDK enrichment]
+        O[Python rule engine]
+        P[Findings with snapshot and resource provenance]
+        Q[Score, API, database and dashboard]
+        I --> L --> O
+        I --> M --> N --> O
+        O --> P --> Q
+        R[Current SDK rule path retained during migration]
+        C --> R --> O
+    end
+
+    subgraph Graph[Future evidence reasoning]
+        S[Evidence graph nodes and validated edges]
+        T[Toxic-combination and attack-path detection]
+        U[Prioritised path with evidence and blast radius]
+        P --> S --> T --> U
+    end
+
+    subgraph Code[Future Code-to-Cloud-to-Code]
+        V[Terraform and Bicep source mapping]
+        W[Repository, commit, file and line evidence]
+        X[Reviewable remediation pull request]
+        S --> V --> W --> X
+    end
+
+    subgraph Remediation[Future dual-gated remediation]
+        Y[Security and operational impact preview]
+        Z[Human approval]
+        AA[Short-lived scoped write credential]
+        AB[Execute approved playbook]
+        AC[Rescan and verify]
+        U --> Y
+        X --> Y --> Z --> AA --> AB --> AC
+        AC --> D
+    end
+
+    subgraph Trust[Cross-cutting customer trust controls]
+        T1[Tenant and subscription isolation]
+        T2[Read-only collection by default]
+        T3[Complete, partial and failed states remain explicit]
+        T4[No Phase 1 persistence or external LLM transfer]
+        T5[Future tamper-evident approval and action audit]
+    end
+
+    T1 -. protects .-> G
+    T2 -. constrains .-> D
+    T2 -. constrains .-> N
+    T3 -. controls .-> H
+    T4 -. limits .-> G
+    T5 -. records .-> Y
+    T5 -. records .-> AC
+
+    classDef implemented fill:#dbeafe,stroke:#2563eb,color:#111827
+    classDef current fill:#fef3c7,stroke:#d97706,color:#111827
+    classDef next fill:#dcfce7,stroke:#16a34a,color:#111827
+    classDef future fill:#f3e8ff,stroke:#9333ea,color:#111827
+    classDef trust fill:#f1f5f9,stroke:#475569,color:#111827
+
+    class D,E,F,G,H,I,J,K implemented
+    class C,O,P,Q,R current
+    class L,M,N next
+    class S,T,U,V,W,X,Y,Z,AA,AB,AC future
+    class T1,T2,T3,T4,T5 trust
 ```
+
+Diagram status:
+
+- **Blue:** implemented by PR #250.
+- **Amber:** existing OpenShield components retained during migration.
+- **Green:** the next integration step required for a fair end-to-end speed benchmark.
+- **Purple:** later Evidence Graph, Code-to-Cloud, and controlled-remediation phases.
+- **Grey:** customer-trust controls that apply across the architecture.
+
+The live Azure for Students benchmark returned five resources with a 0.438-second median ARG inventory time. The
+existing Python scanner ran 68 rules and returned 643 findings in 113.167 seconds. These results demonstrate the
+inventory opportunity but are not presented as an end-to-end speedup until migrated rules produce equivalent
+findings from the shared snapshot.
 
 ## Customer Trust Layer
 

--- a/docs/openshield-evidence-graph.md
+++ b/docs/openshield-evidence-graph.md
@@ -1,0 +1,132 @@
+# OpenShield Evidence Graph
+
+## Status
+
+This document is an architecture proposal tracked by issue #249. Azure Resource Graph inventory is Phase 1. Attack-path correlation,
+Code-to-Cloud tracing, and controlled remediation are future phases and are not presented as implemented features.
+
+## Purpose
+
+OpenShield currently evaluates many security controls independently. The proposed Evidence Graph will connect Azure
+resources, identities, permissions, exposures, findings, infrastructure code, and remediation evidence into one
+traceable security model.
+
+```text
+Azure Resource Graph and targeted SDK evidence
+                    |
+                    v
+          Normalised evidence snapshot
+                    |
+                    v
+          Evidence-backed attack paths
+                    |
+                    v
+        Reviewed, controlled remediation
+                    |
+                    v
+             Rescan and verification
+```
+
+## Customer Trust Layer
+
+The Evidence Graph must be built on controls that protect customer environments and keep evidence attributable.
+
+- **Tenant isolation:** every record carries a tenant, subscription, and snapshot boundary. Cross-boundary records are
+  rejected rather than silently combined.
+- **Read-only collection:** ARG inventory and normal scanning use read permissions and do not change Azure resources.
+- **Approved temporary write access:** a future remediation path must request narrowly scoped, short-lived access only
+  after human approval.
+- **Tamper-evident audit:** future execution must record the proposal, approval, identity, action, and verified outcome.
+
+Phase 1 keeps collected data in the scanner process. It does not send the snapshot to an LLM or another external
+service, and it does not persist the snapshot until a tenant-scoped storage design is approved.
+
+Open source code provides inspectability, but these runtime boundaries are still required before an enterprise can
+trust the platform with cloud metadata or remediation access.
+
+## Phase 1: High-speed Azure resource scanning
+
+Phase 1 uses Azure Resource Graph for broad, batched discovery across authorised subscriptions. ARG results are
+normalised into a bounded snapshot containing resource identity, type, location, tenant, subscription, resource
+group, tags, properties, collection time, pagination count, and collection errors.
+
+ARG does not expose every security-relevant property. OpenShield will therefore use a hybrid model:
+
+```text
+ARG batch discovery -> normalised snapshot -> targeted Azure SDK enrichment
+```
+
+The current SDK scanner remains available while ARG completeness is measured. No existing rule is migrated until its
+required evidence is confirmed to be present or safely enriched.
+
+### Failure semantics
+
+- `COMPLETE`: every requested ARG page was collected, including a valid empty result.
+- `PARTIAL`: some resources were collected, but a later page, scope, or record could not be trusted.
+- `FAILED`: collection failed before any ARG page was accepted.
+
+A partial or failed collection must never be represented as a clean security result.
+
+### Benchmark protocol
+
+Performance claims must be measured against a defined environment. Record:
+
+- number of authorised subscriptions;
+- total resources returned;
+- ARG page count and collection duration;
+- resource types and required fields missing from ARG;
+- targeted SDK calls required after discovery;
+- throttling, partial-scope, and permission errors;
+- equivalent current-scanner collection time.
+
+The proposed sub-30-second scan time is a benchmark target, not a guarantee.
+
+## Phase 2: Evidence-based attack paths
+
+Resources become graph nodes and validated relationships become edges. Every edge must retain its source, collection
+time, and confidence. The first proof should connect one realistic combination, such as public exposure,
+overprivileged identity, and access to sensitive data, into one prioritised path.
+
+Deterministic security logic should construct and score the path. An LLM may explain verified evidence but must not
+invent relationships.
+
+## Phase 3: Code-to-Cloud-to-Code
+
+Runtime resources will be traced to Terraform or Bicep using deployment metadata, resource addresses, source ranges,
+repository identity, and commit identity. Resource-name similarity alone is insufficient evidence. A proposed fix
+must be delivered as a reviewable pull request rather than an unreviewed code change.
+
+## Phase 4: Dual-gated remediation
+
+A future remediation workflow must:
+
+1. Preview the expected security and operational effect.
+2. Require explicit human approval.
+3. Obtain temporary, narrowly scoped write access.
+4. Execute only the approved operation.
+5. Rescan and verify whether the attack path was broken.
+6. Preserve before-and-after evidence in the audit record.
+
+Simulation and deployment previews reduce risk but cannot prove zero production disruption.
+
+## Initial success criteria
+
+- A tenant-isolated ARG snapshot can cover one or more authorised subscriptions.
+- Pagination, throttling, empty results, partial results, and failures remain distinguishable.
+- Resource completeness and scan duration are measured against the existing scanner.
+- One later attack path can cite evidence from the snapshot for every relationship.
+- No production resource is modified during Phase 1.
+
+## Non-goals for Phase 1
+
+- Replacing every Azure SDK call.
+- Building the complete attack graph.
+- Generating infrastructure remediation pull requests.
+- Executing production changes.
+- Claiming a performance target before benchmark evidence exists.
+
+## References
+
+- [Azure Resource Graph overview](https://learn.microsoft.com/azure/governance/resource-graph/overview)
+- [ARG pagination API](https://learn.microsoft.com/rest/api/azureresourcegraph/resourcegraph/resources/resources)
+- [ARG throttling guidance](https://learn.microsoft.com/azure/governance/resource-graph/concepts/guidance-for-throttled-requests)

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ azure-mgmt-storage==21.0.0
 azure-mgmt-network==25.0.0
 azure-mgmt-compute==30.0.0
 azure-mgmt-resource==23.0.0
+azure-mgmt-resourcegraph==8.0.1
 azure-mgmt-sql==3.0.1
 azure-mgmt-keyvault==10.3.0
 azure-mgmt-rdbms==10.1.0

--- a/scanner/arg_inventory.py
+++ b/scanner/arg_inventory.py
@@ -1,0 +1,307 @@
+"""Azure Resource Graph inventory collection for Evidence Graph snapshots."""
+
+from __future__ import annotations
+
+import time
+import uuid
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from enum import Enum
+from typing import Any
+
+from azure.core.exceptions import HttpResponseError
+from azure.mgmt.resourcegraph import ResourceGraphClient
+from azure.mgmt.resourcegraph.models import QueryRequest, QueryRequestOptions
+
+
+DEFAULT_QUERY = """
+Resources
+| project id, name, type, location, subscriptionId, resourceGroup, tenantId, tags, properties
+| order by id asc
+""".strip()
+
+
+class InventoryStatus(str, Enum):
+    """Completion state for an ARG inventory snapshot."""
+
+    COMPLETE = "COMPLETE"
+    PARTIAL = "PARTIAL"
+    FAILED = "FAILED"
+
+
+@dataclass(frozen=True)
+class InventoryResource:
+    """A tenant-scoped Azure resource captured within one snapshot boundary."""
+
+    snapshot_id: str
+    tenant_id: str
+    subscription_id: str
+    resource_id: str
+    resource_type: str
+    name: str
+    location: str
+    resource_group: str
+    tags: dict[str, Any]
+    properties: dict[str, Any]
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-compatible resource record."""
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class InventorySnapshot:
+    """Evidence boundary for one ARG collection operation."""
+
+    snapshot_id: str
+    tenant_id: str
+    requested_subscriptions: tuple[str, ...]
+    status: InventoryStatus
+    collected_at: str
+    duration_ms: int
+    pages: int
+    resources: tuple[InventoryResource, ...]
+    errors: tuple[str, ...]
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-compatible snapshot without losing status context."""
+        payload = asdict(self)
+        payload["status"] = self.status.value
+        payload["resource_count"] = len(self.resources)
+        return payload
+
+
+class ArgInventoryClient:
+    """Collect paginated, tenant-isolated resource snapshots through ARG."""
+
+    def __init__(
+        self,
+        credential: Any | None = None,
+        *,
+        client: Any | None = None,
+        page_size: int = 1000,
+        max_retries: int = 3,
+        sleep: Callable[[float], None] = time.sleep,
+        monotonic: Callable[[], float] = time.monotonic,
+    ) -> None:
+        if client is None and credential is None:
+            raise ValueError("credential is required when no Resource Graph client is supplied")
+        if not 1 <= page_size <= 1000:
+            raise ValueError("page_size must be between 1 and 1000")
+        if max_retries < 0:
+            raise ValueError("max_retries cannot be negative")
+
+        self.client = client or ResourceGraphClient(credential)
+        self.page_size = page_size
+        self.max_retries = max_retries
+        self._sleep = sleep
+        self._monotonic = monotonic
+
+    def close(self) -> None:
+        """Close the underlying SDK transport when the collector owns its lifecycle."""
+        close = getattr(self.client, "close", None)
+        if callable(close):
+            close()
+
+    def __enter__(self) -> ArgInventoryClient:
+        return self
+
+    def __exit__(self, exc_type: Any, exc: Any, traceback: Any) -> None:
+        self.close()
+
+    def collect(
+        self,
+        *,
+        tenant_id: str,
+        subscription_ids: Sequence[str],
+        query: str = DEFAULT_QUERY,
+    ) -> InventorySnapshot:
+        """Collect one isolated snapshot across the authorised subscriptions."""
+        tenant_id = _normalise_uuid(tenant_id, "tenant_id")
+        subscriptions = _normalise_subscriptions(subscription_ids)
+        if not query.strip():
+            raise ValueError("query must not be empty")
+
+        snapshot_id = str(uuid.uuid4())
+        started = self._monotonic()
+        collected_at = datetime.now(timezone.utc).isoformat()
+        resources: list[InventoryResource] = []
+        errors: list[str] = []
+        seen_resources: set[tuple[str, str]] = set()
+        seen_tokens: set[str] = set()
+        skip_token: str | None = None
+        pages = 0
+
+        while True:
+            request = QueryRequest(
+                subscriptions=list(subscriptions),
+                query=query,
+                options=QueryRequestOptions(
+                    top=self.page_size,
+                    skip_token=skip_token,
+                    result_format="objectArray",
+                    allow_partial_scopes=True,
+                ),
+            )
+            try:
+                response = self._query_with_retry(request)
+            except HttpResponseError as exc:
+                errors.append(_safe_http_error(exc))
+                break
+
+            pages += 1
+            rows = getattr(response, "data", []) or []
+            if not isinstance(rows, list):
+                errors.append(f"page {pages}: ARG returned an unexpected data shape")
+                break
+
+            for index, row in enumerate(rows):
+                try:
+                    resource = _normalise_resource(
+                        row,
+                        snapshot_id=snapshot_id,
+                        tenant_id=tenant_id,
+                        authorised_subscriptions=set(subscriptions),
+                    )
+                except ValueError as exc:
+                    errors.append(f"page {pages} row {index}: {exc}")
+                    continue
+
+                key = (resource.subscription_id, resource.resource_id.lower())
+                if key in seen_resources:
+                    continue
+                seen_resources.add(key)
+                resources.append(resource)
+
+            for partial_error in _response_errors(response):
+                errors.append(f"page {pages}: {partial_error}")
+
+            next_token = str(getattr(response, "skip_token", "") or "")
+            if not next_token:
+                break
+            if next_token in seen_tokens:
+                errors.append("ARG returned a repeated pagination token")
+                break
+            seen_tokens.add(next_token)
+            skip_token = next_token
+
+        duration_ms = max(0, round((self._monotonic() - started) * 1000))
+        if errors and not pages:
+            status = InventoryStatus.FAILED
+        elif errors:
+            status = InventoryStatus.PARTIAL
+        else:
+            status = InventoryStatus.COMPLETE
+
+        return InventorySnapshot(
+            snapshot_id=snapshot_id,
+            tenant_id=tenant_id,
+            requested_subscriptions=subscriptions,
+            status=status,
+            collected_at=collected_at,
+            duration_ms=duration_ms,
+            pages=pages,
+            resources=tuple(resources),
+            errors=tuple(errors),
+        )
+
+    def _query_with_retry(self, request: QueryRequest) -> Any:
+        """Retry throttled or temporarily unavailable requests with bounded backoff."""
+        for attempt in range(self.max_retries + 1):
+            try:
+                return self.client.resources(request)
+            except HttpResponseError as exc:
+                status_code = getattr(exc, "status_code", None)
+                if status_code not in {429, 503} or attempt >= self.max_retries:
+                    raise
+                self._sleep(_retry_delay(exc, attempt))
+        raise RuntimeError("unreachable retry state")
+
+
+def _normalise_uuid(value: str, field: str) -> str:
+    """Validate and canonicalise an Azure tenant or subscription identifier."""
+    try:
+        return str(uuid.UUID(str(value).strip()))
+    except (ValueError, AttributeError) as exc:
+        raise ValueError(f"{field} must be a valid UUID") from exc
+
+
+def _normalise_subscriptions(subscription_ids: Sequence[str]) -> tuple[str, ...]:
+    """Return a stable, non-empty and duplicate-free subscription scope."""
+    if isinstance(subscription_ids, (str, bytes)) or not subscription_ids:
+        raise ValueError("subscription_ids must be a non-empty sequence")
+    return tuple(dict.fromkeys(_normalise_uuid(item, "subscription_id") for item in subscription_ids))
+
+
+def _normalise_resource(
+    row: Any,
+    *,
+    snapshot_id: str,
+    tenant_id: str,
+    authorised_subscriptions: set[str],
+) -> InventoryResource:
+    """Validate an ARG row and bind it to the requested tenant and snapshot."""
+    if not isinstance(row, Mapping):
+        raise ValueError("resource must be an object")
+
+    resource_id = _required_string(row, "id")
+    resource_type = _required_string(row, "type")
+    name = _required_string(row, "name")
+    subscription_id = _normalise_uuid(_required_string(row, "subscriptionId"), "subscriptionId")
+    if subscription_id not in authorised_subscriptions:
+        raise ValueError("resource belongs to an unauthorised subscription")
+
+    returned_tenant = str(row.get("tenantId") or "").strip()
+    if returned_tenant and _normalise_uuid(returned_tenant, "tenantId") != tenant_id:
+        raise ValueError("resource belongs to a different tenant")
+
+    tags = row.get("tags") or {}
+    properties = row.get("properties") or {}
+    if not isinstance(tags, Mapping):
+        raise ValueError("tags must be an object")
+    if not isinstance(properties, Mapping):
+        raise ValueError("properties must be an object")
+
+    return InventoryResource(
+        snapshot_id=snapshot_id,
+        tenant_id=tenant_id,
+        subscription_id=subscription_id,
+        resource_id=resource_id,
+        resource_type=resource_type,
+        name=name,
+        location=str(row.get("location") or ""),
+        resource_group=str(row.get("resourceGroup") or ""),
+        tags=dict(tags),
+        properties=dict(properties),
+    )
+
+
+def _required_string(row: Mapping[str, Any], field: str) -> str:
+    value = row.get(field)
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{field} must be a non-empty string")
+    return value.strip()
+
+
+def _response_errors(response: Any) -> list[str]:
+    """Extract partial-scope diagnostics without coupling to one SDK model version."""
+    raw_errors = getattr(response, "errors", None) or getattr(response, "partial_query_failure", None) or []
+    if not isinstance(raw_errors, list):
+        raw_errors = [raw_errors]
+    return [str(getattr(item, "message", item)) for item in raw_errors if item]
+
+
+def _retry_delay(exc: HttpResponseError, attempt: int) -> float:
+    response = getattr(exc, "response", None)
+    headers = getattr(response, "headers", {}) or {}
+    retry_after = headers.get("Retry-After") or headers.get("retry-after")
+    try:
+        return max(0.0, min(float(retry_after), 30.0))
+    except (TypeError, ValueError):
+        return min(2**attempt, 30)
+
+
+def _safe_http_error(exc: HttpResponseError) -> str:
+    status_code = getattr(exc, "status_code", None)
+    return f"ARG query failed with HTTP {status_code}" if status_code else "ARG query failed"

--- a/scanner/arg_inventory.py
+++ b/scanner/arg_inventory.py
@@ -141,7 +141,6 @@ class ArgInventoryClient:
                     top=self.page_size,
                     skip_token=skip_token,
                     result_format="objectArray",
-                    allow_partial_scopes=True,
                 ),
             )
             try:
@@ -174,11 +173,10 @@ class ArgInventoryClient:
                 seen_resources.add(key)
                 resources.append(resource)
 
-            for partial_error in _response_errors(response):
-                errors.append(f"page {pages}: {partial_error}")
-
             next_token = str(getattr(response, "skip_token", "") or "")
             if not next_token:
+                if _response_is_truncated(response):
+                    errors.append("ARG reported truncated results without a pagination token")
                 break
             if next_token in seen_tokens:
                 errors.append("ARG returned a repeated pagination token")
@@ -284,12 +282,12 @@ def _required_string(row: Mapping[str, Any], field: str) -> str:
     return value.strip()
 
 
-def _response_errors(response: Any) -> list[str]:
-    """Extract partial-scope diagnostics without coupling to one SDK model version."""
-    raw_errors = getattr(response, "errors", None) or getattr(response, "partial_query_failure", None) or []
-    if not isinstance(raw_errors, list):
-        raw_errors = [raw_errors]
-    return [str(getattr(item, "message", item)) for item in raw_errors if item]
+def _response_is_truncated(response: Any) -> bool:
+    """Return whether ARG says the result set is incomplete."""
+    value = getattr(response, "result_truncated", False)
+    if isinstance(value, str):
+        return value.strip().lower() == "true"
+    return value is True
 
 
 def _retry_delay(exc: HttpResponseError, attempt: int) -> float:

--- a/scanner/arg_inventory.py
+++ b/scanner/arg_inventory.py
@@ -250,8 +250,8 @@ def _normalise_resource(
     if subscription_id not in authorised_subscriptions:
         raise ValueError("resource belongs to an unauthorised subscription")
 
-    returned_tenant = str(row.get("tenantId") or "").strip()
-    if returned_tenant and _normalise_uuid(returned_tenant, "tenantId") != tenant_id:
+    returned_tenant = _normalise_uuid(_required_string(row, "tenantId"), "tenantId")
+    if returned_tenant != tenant_id:
         raise ValueError("resource belongs to a different tenant")
 
     tags = row.get("tags") or {}

--- a/tests/test_arg_inventory.py
+++ b/tests/test_arg_inventory.py
@@ -155,6 +155,28 @@ def test_rejects_cross_tenant_and_unauthorised_subscription_rows():
     assert any("unauthorised subscription" in error for error in snapshot.errors)
 
 
+def test_rejects_missing_blank_and_invalid_tenant_ids():
+    client = MagicMock()
+    missing_tenant = _row("/subscriptions/a/resourceGroups/rg/providers/type/missing-tenant")
+    missing_tenant.pop("tenantId")
+    blank_tenant = _row("/subscriptions/a/resourceGroups/rg/providers/type/blank-tenant")
+    blank_tenant["tenantId"] = ""
+    invalid_tenant = _row("/subscriptions/a/resourceGroups/rg/providers/type/invalid-tenant")
+    invalid_tenant["tenantId"] = "not-a-uuid"
+    client.resources.return_value = _response([missing_tenant, blank_tenant, invalid_tenant])
+
+    snapshot = ArgInventoryClient(client=client).collect(
+        tenant_id=TENANT_ID,
+        subscription_ids=[SUBSCRIPTION_A],
+    )
+
+    assert snapshot.status is InventoryStatus.PARTIAL
+    assert snapshot.resources == ()
+    assert len(snapshot.errors) == 3
+    assert sum("tenantId must be a non-empty string" in error for error in snapshot.errors) == 2
+    assert sum("tenantId must be a valid UUID" in error for error in snapshot.errors) == 1
+
+
 def test_repeated_pagination_token_stops_with_partial_status():
     client = MagicMock()
     client.resources.side_effect = [_response([], "same"), _response([], "same")]

--- a/tests/test_arg_inventory.py
+++ b/tests/test_arg_inventory.py
@@ -32,8 +32,8 @@ def _row(
     }
 
 
-def _response(rows: list[dict], skip_token: str | None = None, errors: list | None = None):
-    return SimpleNamespace(data=rows, skip_token=skip_token, errors=errors or [])
+def _response(rows: list[dict], skip_token: str | None = None, result_truncated: bool | str = False):
+    return SimpleNamespace(data=rows, skip_token=skip_token, result_truncated=result_truncated)
 
 
 def _http_error(status_code: int, retry_after: str | None = None) -> HttpResponseError:
@@ -167,6 +167,23 @@ def test_repeated_pagination_token_stops_with_partial_status():
     assert snapshot.status is InventoryStatus.PARTIAL
     assert snapshot.pages == 2
     assert snapshot.errors == ("ARG returned a repeated pagination token",)
+
+
+def test_truncated_response_without_pagination_token_is_partial():
+    client = MagicMock()
+    client.resources.return_value = _response(
+        [_row("/subscriptions/a/resourceGroups/rg/providers/Microsoft.Storage/storageAccounts/one")],
+        result_truncated="true",
+    )
+
+    snapshot = ArgInventoryClient(client=client).collect(
+        tenant_id=TENANT_ID,
+        subscription_ids=[SUBSCRIPTION_A],
+    )
+
+    assert snapshot.status is InventoryStatus.PARTIAL
+    assert len(snapshot.resources) == 1
+    assert snapshot.errors == ("ARG reported truncated results without a pagination token",)
 
 
 def test_scope_requires_valid_non_empty_identifiers():

--- a/tests/test_arg_inventory.py
+++ b/tests/test_arg_inventory.py
@@ -1,0 +1,190 @@
+"""Regression tests for the Azure Resource Graph inventory foundation."""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from azure.core.exceptions import HttpResponseError
+
+from scanner.arg_inventory import ArgInventoryClient, InventoryStatus
+
+
+TENANT_ID = "11111111-1111-1111-1111-111111111111"
+SUBSCRIPTION_A = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+SUBSCRIPTION_B = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
+
+
+def _row(
+    resource_id: str,
+    *,
+    subscription_id: str = SUBSCRIPTION_A,
+    tenant_id: str = TENANT_ID,
+) -> dict:
+    return {
+        "id": resource_id,
+        "name": resource_id.rsplit("/", 1)[-1],
+        "type": "Microsoft.Storage/storageAccounts",
+        "location": "uksouth",
+        "subscriptionId": subscription_id,
+        "resourceGroup": "rg-security",
+        "tenantId": tenant_id,
+        "tags": {"environment": "test"},
+        "properties": {"supportsHttpsTrafficOnly": True},
+    }
+
+
+def _response(rows: list[dict], skip_token: str | None = None, errors: list | None = None):
+    return SimpleNamespace(data=rows, skip_token=skip_token, errors=errors or [])
+
+
+def _http_error(status_code: int, retry_after: str | None = None) -> HttpResponseError:
+    headers = {"Retry-After": retry_after} if retry_after is not None else {}
+    response = SimpleNamespace(status_code=status_code, headers=headers, reason="test")
+    return HttpResponseError(message="request failed", response=response)
+
+
+def test_collects_paginated_multi_subscription_snapshot():
+    client = MagicMock()
+    client.resources.side_effect = [
+        _response([_row("/subscriptions/a/resourceGroups/rg/providers/Microsoft.Storage/storageAccounts/one")], "next"),
+        _response(
+            [
+                _row(
+                    "/subscriptions/b/resourceGroups/rg/providers/Microsoft.Compute/virtualMachines/two",
+                    subscription_id=SUBSCRIPTION_B,
+                )
+            ]
+        ),
+    ]
+    clock = iter([10.0, 10.125])
+
+    snapshot = ArgInventoryClient(client=client, monotonic=lambda: next(clock)).collect(
+        tenant_id=TENANT_ID,
+        subscription_ids=[SUBSCRIPTION_A, SUBSCRIPTION_B],
+    )
+
+    assert snapshot.status is InventoryStatus.COMPLETE
+    assert snapshot.pages == 2
+    assert snapshot.duration_ms == 125
+    assert len(snapshot.resources) == 2
+    assert {item.subscription_id for item in snapshot.resources} == {SUBSCRIPTION_A, SUBSCRIPTION_B}
+    assert all(item.snapshot_id == snapshot.snapshot_id for item in snapshot.resources)
+    assert client.resources.call_args_list[0].args[0].options.skip_token is None
+    assert client.resources.call_args_list[1].args[0].options.skip_token == "next"
+
+
+def test_empty_inventory_is_a_complete_snapshot():
+    client = MagicMock()
+    client.resources.return_value = _response([])
+
+    snapshot = ArgInventoryClient(client=client).collect(
+        tenant_id=TENANT_ID,
+        subscription_ids=[SUBSCRIPTION_A],
+    )
+
+    assert snapshot.status is InventoryStatus.COMPLETE
+    assert snapshot.resources == ()
+    assert snapshot.errors == ()
+    assert snapshot.to_dict()["resource_count"] == 0
+
+
+def test_retries_throttling_using_retry_after_header():
+    client = MagicMock()
+    client.resources.side_effect = [_http_error(429, "2"), _response([])]
+    delays: list[float] = []
+
+    snapshot = ArgInventoryClient(client=client, sleep=delays.append).collect(
+        tenant_id=TENANT_ID,
+        subscription_ids=[SUBSCRIPTION_A],
+    )
+
+    assert snapshot.status is InventoryStatus.COMPLETE
+    assert delays == [2.0]
+    assert client.resources.call_count == 2
+
+
+def test_first_page_failure_is_not_a_clean_snapshot():
+    client = MagicMock()
+    client.resources.side_effect = _http_error(403)
+
+    snapshot = ArgInventoryClient(client=client).collect(
+        tenant_id=TENANT_ID,
+        subscription_ids=[SUBSCRIPTION_A],
+    )
+
+    assert snapshot.status is InventoryStatus.FAILED
+    assert snapshot.pages == 0
+    assert snapshot.resources == ()
+    assert snapshot.errors == ("ARG query failed with HTTP 403",)
+
+
+def test_later_page_failure_preserves_resources_as_partial():
+    client = MagicMock()
+    client.resources.side_effect = [
+        _response([_row("/subscriptions/a/resourceGroups/rg/providers/Microsoft.Storage/storageAccounts/one")], "next"),
+        _http_error(503),
+    ]
+
+    snapshot = ArgInventoryClient(client=client, max_retries=0).collect(
+        tenant_id=TENANT_ID,
+        subscription_ids=[SUBSCRIPTION_A],
+    )
+
+    assert snapshot.status is InventoryStatus.PARTIAL
+    assert snapshot.pages == 1
+    assert len(snapshot.resources) == 1
+    assert snapshot.errors == ("ARG query failed with HTTP 503",)
+
+
+def test_rejects_cross_tenant_and_unauthorised_subscription_rows():
+    client = MagicMock()
+    client.resources.return_value = _response(
+        [
+            _row("/subscriptions/a/resourceGroups/rg/providers/type/cross-tenant", tenant_id=SUBSCRIPTION_B),
+            _row("/subscriptions/c/resourceGroups/rg/providers/type/cross-sub", subscription_id=SUBSCRIPTION_B),
+        ]
+    )
+
+    snapshot = ArgInventoryClient(client=client).collect(
+        tenant_id=TENANT_ID,
+        subscription_ids=[SUBSCRIPTION_A],
+    )
+
+    assert snapshot.status is InventoryStatus.PARTIAL
+    assert snapshot.resources == ()
+    assert any("different tenant" in error for error in snapshot.errors)
+    assert any("unauthorised subscription" in error for error in snapshot.errors)
+
+
+def test_repeated_pagination_token_stops_with_partial_status():
+    client = MagicMock()
+    client.resources.side_effect = [_response([], "same"), _response([], "same")]
+
+    snapshot = ArgInventoryClient(client=client).collect(
+        tenant_id=TENANT_ID,
+        subscription_ids=[SUBSCRIPTION_A],
+    )
+
+    assert snapshot.status is InventoryStatus.PARTIAL
+    assert snapshot.pages == 2
+    assert snapshot.errors == ("ARG returned a repeated pagination token",)
+
+
+def test_scope_requires_valid_non_empty_identifiers():
+    collector = ArgInventoryClient(client=MagicMock())
+
+    for tenant_id, subscriptions in [("invalid", [SUBSCRIPTION_A]), (TENANT_ID, []), (TENANT_ID, ["invalid"])]:
+        try:
+            collector.collect(tenant_id=tenant_id, subscription_ids=subscriptions)
+        except ValueError:
+            pass
+        else:
+            raise AssertionError("invalid scope was accepted")
+
+
+def test_context_manager_closes_sdk_client():
+    client = MagicMock()
+
+    with ArgInventoryClient(client=client):
+        pass
+
+    client.close.assert_called_once_with()


### PR DESCRIPTION
## Summary

Introduces Azure Resource Graph inventory as Phase 1 of the proposed OpenShield Evidence Graph.

- Adds paginated multi-subscription ARG collection.
- Produces normalised, tenant-scoped resource snapshots.
- Preserves complete, partial, and failed collection states.
- Handles throttling with bounded retries and detects repeated pagination tokens.
- Records snapshot identity, collection duration, page count, resources, and safe errors.
- Adds the Evidence Graph and Customer Trust Layer architecture document.
- Keeps existing SDK rule execution unchanged while ARG completeness is evaluated.

## Security boundaries

- ARG collection is read-only.
- Every resource is bound to a tenant, authorised subscription, and snapshot.
- Cross-tenant and unauthorised-subscription rows are rejected.
- Phase 1 does not persist snapshots or send them to an LLM or external service.
- No remediation or production write access is introduced.

## Verification

- ARG regression suite: 10 passed, 92% module coverage.
- Broader scanner/API suite: 536 passed, 3 skipped.
- Ruff check and format pass.
- Python compilation passes.
- Bandit reports no medium or high findings.
- Installed-environment dependency audit reports no known vulnerabilities.
- Detects `resultTruncated` responses without a continuation token and marks the snapshot partial.
- GitHub CI: all 20 checks pass on the final fix revision.

The unrelated ChromaDB dependency test was excluded from the local Windows run because that dependency could not be installed cleanly in the isolated environment. GitHub CI ran the repository's complete Linux suite successfully.

## Live Azure validation

Validated on 11 August 2026 in Azure Resource Graph Explorer using an active Azure for Students subscription containing five resources. The scope was restricted to that student subscription; two unrelated university production subscriptions were not selected.

The OpenShield inventory projection was executed as a read-only query:

```kusto
Resources
Resources
| project id, name, type, location, subscriptionId, resourceGroup, tenantId, tags, properties
| summarize resourceCount = count()
| extend validation = "OpenShield PR #250 ARG inventory"
```

Results:

- Aggregate resource count: 5 resources in 0.442 seconds.
- Full OpenShield inventory projection: 5 of 5 resources in 0.575 seconds.
- No Azure resources, configuration, or permissions were changed.
- A privacy-safe proof query labelled the result `OpenShield PR #250 ARG inventory` without exposing resource identifiers in shared evidence.

This proves the KQL projection and real Azure ARG execution path. It does not yet prove the local Python client against live university credentials because the local Azure CLI remains authenticated to a different tenant.

## Remaining benchmark gates

- Run `ArgInventoryClient` directly with authorised live Azure CLI credentials.
- Exercise pagination with more than one result page.
- Compare ARG completeness with the current SDK scanner.
- Record properties that require targeted SDK enrichment.
- Validate throttling, partial-scope, and restricted-permission behaviour.

No sub-30-second performance guarantee is claimed until these larger-scale gates are complete.

Closes #249



