### PR TITLE
Add Azure Network Layer assurance and routing checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,6 +101,14 @@ jobs:
           seen_ids = defaultdict(list)
 
           for filename in sorted(os.listdir(rules_dir)):
+              is_helper = filename == "__init__.py" or (
+                  filename.startswith("_") and filename.endswith("_common.py")
+              )
+              if filename.endswith(".py") and not (filename.startswith("az_") or is_helper):
+                  failures.append(
+                      f"{filename}: rule-directory Python files must match az_*.py or _*_common.py"
+                  )
+                  continue
               if not filename.startswith("az_") or not filename.endswith(".py"):
                   continue
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ OpenShield uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
-- Azure Network Layer Assurance API with 20-domain coverage and evidence-based OSI classification of network rules
+- Azure Network Layer Assurance API with 20-domain coverage, network-rule classification, and authoritative IP forwarding and direct Internet route checks
 - Azure Data Link Layer Assurance API with LLC and MAC coverage plus ExpressRoute Direct MACsec checks
 - Azure public-cloud Physical Layer Assurance API with complete OSI and IEEE PHY domain, sublayer, and provider-evidence coverage
 - Semgrep SAST integrated into GitHub Actions CI as an open-source, account-free complement to CodeQL

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ OpenShield uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- Azure Network Layer Assurance API with 20-domain coverage and evidence-based OSI classification of network rules
 - Azure Data Link Layer Assurance API with LLC and MAC coverage plus ExpressRoute Direct MACsec checks
 - Azure public-cloud Physical Layer Assurance API with complete OSI and IEEE PHY domain, sublayer, and provider-evidence coverage
 - Semgrep SAST integrated into GitHub Actions CI as an open-source, account-free complement to CodeQL

--- a/api/routes/assurance.py
+++ b/api/routes/assurance.py
@@ -6,6 +6,7 @@ from flask import Blueprint, jsonify
 
 from api.services.physical_assurance import CatalogValidationError, get_physical_assurance_report
 from api.services.data_link_assurance import get_data_link_assurance_report
+from api.services.network_layer_assurance import get_network_layer_assurance_report
 
 
 assurance_bp = Blueprint("assurance", __name__)
@@ -36,3 +37,16 @@ def get_data_link_layer_assurance():
     except Exception as exc:
         logger.error("Failed to build Data Link assurance report: %s", exc)
         return jsonify({"error": "Data Link assurance report generation failed"}), 500
+
+
+@assurance_bp.get("/api/assurance/network-layer")
+def get_network_layer_assurance():
+    """Return Azure public-cloud OSI Layer 3 responsibility and evidence coverage."""
+    try:
+        return jsonify(get_network_layer_assurance_report())
+    except CatalogValidationError as exc:
+        logger.error("Network Layer assurance catalog validation failed: %s", exc)
+        return jsonify({"error": "Network Layer assurance catalog is unavailable"}), 500
+    except Exception as exc:
+        logger.error("Failed to build Network Layer assurance report: %s", exc)
+        return jsonify({"error": "Network Layer assurance report generation failed"}), 500

--- a/api/services/network_layer_assurance.py
+++ b/api/services/network_layer_assurance.py
@@ -20,7 +20,7 @@ CATALOG_PATH = Path(__file__).resolve().parents[2] / "compliance" / "assurance" 
 EXPECTED_DOMAIN_IDS = {f"NL-{number:02d}" for number in range(1, 21)}
 EXPECTED_SUBDOMAIN_IDS = {"ADDRESSING", "ROUTING", "TRANSIT", "PROTECTION", "OBSERVABILITY"}
 EXPECTED_CONTROL_IDS = {f"NL-C{number:02d}" for number in range(1, 21)}
-EXPECTED_RULE_IDS = {f"AZ-NET-{number:03d}" for number in range(1, 16)} | {"AZ-DL-001", "AZ-DL-002"}
+EXPECTED_RULE_IDS = {f"AZ-NET-{number:03d}" for number in range(1, 18)} | {"AZ-DL-001", "AZ-DL-002"}
 ALLOWED_RESPONSIBILITIES = {"Microsoft", "Customer", "Shared"}
 ALLOWED_APPLICABILITY = {"APPLICABLE", "NOT_APPLICABLE", "UNSUPPORTED"}
 ALLOWED_VERIFICATION = {
@@ -66,7 +66,7 @@ def validate_catalog(catalog: dict[str, Any]) -> None:
         raise CatalogValidationError("controls must contain the complete NL-C01 through NL-C20 set")
     if set(rules) != EXPECTED_RULE_IDS:
         raise CatalogValidationError(
-            "rule_classifications must contain AZ-NET-001 through AZ-NET-015 and both MACsec rules"
+            "rule_classifications must contain AZ-NET-001 through AZ-NET-017 and both MACsec rules"
         )
 
     for evidence_id, source in evidence.items():

--- a/api/services/network_layer_assurance.py
+++ b/api/services/network_layer_assurance.py
@@ -94,16 +94,10 @@ def validate_catalog(catalog: dict[str, Any]) -> None:
         if status not in ALLOWED_CONTROL_STATUSES:
             raise CatalogValidationError(f"{control_id}: invalid status")
         covered_domains.update(require_reference_list(control, "domain_ids", set(domains), control_id))
-        covered_subdomains.update(
-            require_reference_list(control, "subdomain_ids", set(subdomains), control_id)
-        )
-        referenced_evidence.update(
-            require_reference_list(control, "evidence_source_ids", set(evidence), control_id)
-        )
+        covered_subdomains.update(require_reference_list(control, "subdomain_ids", set(subdomains), control_id))
+        referenced_evidence.update(require_reference_list(control, "evidence_source_ids", set(evidence), control_id))
         scanner_rule_ids = control.get("scanner_rule_ids")
-        if not isinstance(scanner_rule_ids, list) or any(
-            not isinstance(rule_id, str) for rule_id in scanner_rule_ids
-        ):
+        if not isinstance(scanner_rule_ids, list) or any(not isinstance(rule_id, str) for rule_id in scanner_rule_ids):
             raise CatalogValidationError(f"{control_id}: scanner_rule_ids must be a list of strings")
         if len(scanner_rule_ids) != len(set(scanner_rule_ids)) or set(scanner_rule_ids) - set(rules):
             raise CatalogValidationError(f"{control_id}: scanner_rule_ids contains invalid references")
@@ -192,9 +186,7 @@ def build_report(catalog: dict[str, Any], as_of: date | None = None) -> dict[str
         )
     for subdomain in report["subdomains"]:
         subdomain["control_ids"] = [
-            control["id"]
-            for control in report["controls"]
-            if subdomain["id"] in control["subdomain_ids"]
+            control["id"] for control in report["controls"] if subdomain["id"] in control["subdomain_ids"]
         ]
         subdomain["domain_ids"] = sorted(
             {

--- a/api/services/network_layer_assurance.py
+++ b/api/services/network_layer_assurance.py
@@ -1,0 +1,241 @@
+"""Load, validate, and report Azure Network Layer assurance coverage."""
+
+from __future__ import annotations
+
+import copy
+import json
+from datetime import date
+from pathlib import Path
+from typing import Any
+
+from api.services.assurance_catalog import (
+    CatalogValidationError,
+    require_reference_list,
+    require_string,
+    require_unique,
+    validate_evidence_source,
+)
+
+CATALOG_PATH = Path(__file__).resolve().parents[2] / "compliance" / "assurance" / "network_layer.json"
+EXPECTED_DOMAIN_IDS = {f"NL-{number:02d}" for number in range(1, 21)}
+EXPECTED_SUBDOMAIN_IDS = {"ADDRESSING", "ROUTING", "TRANSIT", "PROTECTION", "OBSERVABILITY"}
+EXPECTED_CONTROL_IDS = {f"NL-C{number:02d}" for number in range(1, 21)}
+EXPECTED_RULE_IDS = {f"AZ-NET-{number:03d}" for number in range(1, 16)} | {"AZ-DL-001", "AZ-DL-002"}
+ALLOWED_RESPONSIBILITIES = {"Microsoft", "Customer", "Shared"}
+ALLOWED_APPLICABILITY = {"APPLICABLE", "NOT_APPLICABLE", "UNSUPPORTED"}
+ALLOWED_VERIFICATION = {
+    "PROVIDER_ATTESTED",
+    "PLATFORM_ENFORCED",
+    "AUTOMATICALLY_CHECKED",
+    "MANUALLY_VERIFIABLE",
+    "UNSUPPORTED",
+    "NOT_APPLICABLE",
+}
+ALLOWED_CLASSIFICATIONS = {"Layer 2", "Layer 3", "Layer 4", "Layer 7", "Cross-layer"}
+ALLOWED_CONTROL_STATUSES = {"DOCUMENTED", "REVIEW_DUE"}
+
+
+def validate_catalog(catalog: dict[str, Any]) -> None:
+    """Fail closed when any Layer 3 domain, rule audit, decision, or reference is missing."""
+    if not isinstance(catalog, dict):
+        raise CatalogValidationError("Catalog root must be an object")
+    layer = catalog.get("layer")
+    if not isinstance(layer, dict) or layer.get("number") != 3 or layer.get("name") != "Network":
+        raise CatalogValidationError("Catalog must describe OSI Layer 3 Network")
+    require_string(catalog, "catalog_version", "catalog")
+    if catalog.get("schema_version") != 1:
+        raise CatalogValidationError("schema_version must be 1")
+    scope = catalog.get("scope")
+    if not isinstance(scope, dict):
+        raise CatalogValidationError("scope must be an object")
+    require_string(scope, "statement", "scope")
+    require_string(scope, "responsibility_boundary", "scope")
+    if scope.get("environment") != "azure_public_cloud":
+        raise CatalogValidationError("scope.environment must be azure_public_cloud")
+
+    domains = require_unique(catalog.get("domains"), "domains")
+    subdomains = require_unique(catalog.get("subdomains"), "subdomains")
+    controls = require_unique(catalog.get("controls"), "controls")
+    evidence = require_unique(catalog.get("evidence_sources"), "evidence_sources")
+    rules = require_unique(catalog.get("rule_classifications"), "rule_classifications")
+    if set(domains) != EXPECTED_DOMAIN_IDS:
+        raise CatalogValidationError("domains must contain the complete NL-01 through NL-20 set")
+    if set(subdomains) != EXPECTED_SUBDOMAIN_IDS:
+        raise CatalogValidationError("subdomains must contain the complete Layer 3 functional set")
+    if set(controls) != EXPECTED_CONTROL_IDS:
+        raise CatalogValidationError("controls must contain the complete NL-C01 through NL-C20 set")
+    if set(rules) != EXPECTED_RULE_IDS:
+        raise CatalogValidationError(
+            "rule_classifications must contain AZ-NET-001 through AZ-NET-015 and both MACsec rules"
+        )
+
+    for evidence_id, source in evidence.items():
+        validate_evidence_source(source, evidence_id, {"learn.microsoft.com"})
+    for subdomain_id, subdomain in subdomains.items():
+        require_string(subdomain, "name", subdomain_id)
+        require_string(subdomain, "description", subdomain_id)
+
+    referenced_evidence: set[str] = set()
+    referenced_rules: set[str] = set()
+    covered_domains: set[str] = set()
+    covered_subdomains: set[str] = set()
+    for control_id, control in controls.items():
+        require_string(control, "title", control_id)
+        responsibility = require_string(control, "responsibility", control_id)
+        applicability = require_string(control, "applicability", control_id)
+        verification = require_string(control, "verification", control_id)
+        status = require_string(control, "status", control_id)
+        if responsibility not in ALLOWED_RESPONSIBILITIES:
+            raise CatalogValidationError(f"{control_id}: invalid responsibility")
+        if applicability not in ALLOWED_APPLICABILITY:
+            raise CatalogValidationError(f"{control_id}: invalid applicability")
+        if verification not in ALLOWED_VERIFICATION:
+            raise CatalogValidationError(f"{control_id}: invalid verification")
+        if status not in ALLOWED_CONTROL_STATUSES:
+            raise CatalogValidationError(f"{control_id}: invalid status")
+        covered_domains.update(require_reference_list(control, "domain_ids", set(domains), control_id))
+        covered_subdomains.update(
+            require_reference_list(control, "subdomain_ids", set(subdomains), control_id)
+        )
+        referenced_evidence.update(
+            require_reference_list(control, "evidence_source_ids", set(evidence), control_id)
+        )
+        scanner_rule_ids = control.get("scanner_rule_ids")
+        if not isinstance(scanner_rule_ids, list) or any(
+            not isinstance(rule_id, str) for rule_id in scanner_rule_ids
+        ):
+            raise CatalogValidationError(f"{control_id}: scanner_rule_ids must be a list of strings")
+        if len(scanner_rule_ids) != len(set(scanner_rule_ids)) or set(scanner_rule_ids) - set(rules):
+            raise CatalogValidationError(f"{control_id}: scanner_rule_ids contains invalid references")
+        referenced_rules.update(scanner_rule_ids)
+
+    if covered_domains != set(domains):
+        raise CatalogValidationError(f"Uncovered Network Layer domains: {sorted(set(domains) - covered_domains)}")
+    if covered_subdomains != set(subdomains):
+        raise CatalogValidationError(
+            f"Uncovered Network Layer subdomains: {sorted(set(subdomains) - covered_subdomains)}"
+        )
+
+    for domain_id, domain in domains.items():
+        require_string(domain, "name", domain_id)
+        require_string(domain, "observability_method", domain_id)
+        require_string(domain, "automation_decision", domain_id)
+        responsibility = require_string(domain, "responsibility_owner", domain_id)
+        applicability = require_string(domain, "azure_applicability", domain_id)
+        verification = require_string(domain, "verification", domain_id)
+        if responsibility not in ALLOWED_RESPONSIBILITIES:
+            raise CatalogValidationError(f"{domain_id}: invalid responsibility_owner")
+        if applicability not in ALLOWED_APPLICABILITY:
+            raise CatalogValidationError(f"{domain_id}: invalid azure_applicability")
+        if verification not in ALLOWED_VERIFICATION:
+            raise CatalogValidationError(f"{domain_id}: invalid verification")
+        domain_evidence = require_reference_list(domain, "evidence_source_ids", set(evidence), domain_id)
+        referenced_evidence.update(domain_evidence)
+        rule_ids = domain.get("rule_ids")
+        if not isinstance(rule_ids, list) or any(not isinstance(rule_id, str) for rule_id in rule_ids):
+            raise CatalogValidationError(f"{domain_id}: rule_ids must be a list of strings")
+        if len(rule_ids) != len(set(rule_ids)) or set(rule_ids) - set(rules):
+            raise CatalogValidationError(f"{domain_id}: rule_ids contains invalid references")
+
+    if referenced_evidence != set(evidence):
+        raise CatalogValidationError("every evidence source must be referenced")
+
+    for rule_id, rule in rules.items():
+        require_string(rule, "name", rule_id)
+        classification = require_string(rule, "osi_classification", rule_id)
+        require_string(rule, "classification_basis", rule_id)
+        if classification not in ALLOWED_CLASSIFICATIONS:
+            raise CatalogValidationError(f"{rule_id}: invalid osi_classification")
+        domain_ids = rule.get("layer_3_domain_ids")
+        if not isinstance(domain_ids, list) or any(not isinstance(item, str) for item in domain_ids):
+            raise CatalogValidationError(f"{rule_id}: layer_3_domain_ids must be a list of strings")
+        if len(domain_ids) != len(set(domain_ids)) or set(domain_ids) - set(domains):
+            raise CatalogValidationError(f"{rule_id}: invalid Layer 3 domain reference")
+        if classification == "Layer 3" and not domain_ids:
+            raise CatalogValidationError(f"{rule_id}: Layer 3 rules must cross-reference a domain")
+        if classification not in {"Layer 3", "Cross-layer"} and domain_ids:
+            raise CatalogValidationError(f"{rule_id}: non-Layer 3 rules cannot claim Layer 3 coverage")
+        if domain_ids and rule_id not in referenced_rules:
+            raise CatalogValidationError(f"{rule_id}: domain cross-reference is not reciprocal")
+
+
+def load_catalog(path: Path = CATALOG_PATH) -> dict[str, Any]:
+    """Load and validate the bundled catalog."""
+    try:
+        with path.open(encoding="utf-8") as catalog_file:
+            catalog = json.load(catalog_file)
+    except (OSError, json.JSONDecodeError) as exc:
+        raise CatalogValidationError(f"Unable to load Network Layer assurance catalog: {exc}") from exc
+    validate_catalog(catalog)
+    return catalog
+
+
+def build_report(catalog: dict[str, Any], as_of: date | None = None) -> dict[str, Any]:
+    """Build static responsibility coverage with independent evidence freshness."""
+    validate_catalog(catalog)
+    report = copy.deepcopy(catalog)
+    as_of = as_of or date.today()
+    evidence = {item["id"]: item for item in report["evidence_sources"]}
+    current = sum(date.fromisoformat(item["review_due_at"]) >= as_of for item in evidence.values())
+    for domain in report["domains"]:
+        domain["evidence"] = [evidence[source_id] for source_id in domain["evidence_source_ids"]]
+        domain["control_ids"] = [
+            control["id"] for control in report["controls"] if domain["id"] in control["domain_ids"]
+        ]
+        domain["subdomain_ids"] = sorted(
+            {
+                subdomain_id
+                for control in report["controls"]
+                if domain["id"] in control["domain_ids"]
+                for subdomain_id in control["subdomain_ids"]
+            }
+        )
+    for subdomain in report["subdomains"]:
+        subdomain["control_ids"] = [
+            control["id"]
+            for control in report["controls"]
+            if subdomain["id"] in control["subdomain_ids"]
+        ]
+        subdomain["domain_ids"] = sorted(
+            {
+                domain_id
+                for control in report["controls"]
+                if subdomain["id"] in control["subdomain_ids"]
+                for domain_id in control["domain_ids"]
+            }
+        )
+    report["catalog_coverage"] = {
+        "controls_covered": 20,
+        "controls_total": 20,
+        "domains_covered": 20,
+        "domains_total": 20,
+        "subdomains_covered": 5,
+        "subdomains_total": 5,
+        "percent": 100,
+    }
+    report["evidence_freshness"] = {
+        "current_sources": current,
+        "total_sources": len(evidence),
+        "percent": round(current / len(evidence) * 100) if evidence else 0,
+        "assessed_as_of": as_of.isoformat(),
+    }
+    report["provider_assurance_state"] = "DOCUMENTED"
+    report["platform_enforcement_state"] = "DOCUMENTED_NOT_LIVE_INSPECTED"
+    report["automated_control_applicability"] = {
+        "state": "REQUIRES_RELEVANT_SUBSCRIPTION_INVENTORY",
+        "empty_inventory": "NOT_APPLICABLE",
+        "api_or_permission_failure": "INDETERMINATE",
+    }
+    report["limitations"] = [
+        "This report does not inspect Microsoft forwarding tables, tenant-isolated fabric internals, "
+        "packets, MTU paths, or anti-spoofing implementation.",
+        "Provider-owned and platform-enforced domains do not create findings or alter the tenant security score.",
+        "Rule cross-references describe actual OSI behavior; Network-category rules at Layers 2, 4, "
+        "and 7 are not counted as Layer 3 controls.",
+    ]
+    return report
+
+
+def get_network_layer_assurance_report(as_of: date | None = None) -> dict[str, Any]:
+    """Return the bundled Network Layer assurance report."""
+    return build_report(load_catalog(), as_of=as_of)

--- a/compliance/assurance/data_link_layer.json
+++ b/compliance/assurance/data_link_layer.json
@@ -18,8 +18,8 @@
     {"id": "AZ-ERD-API", "title": "Express Route Ports REST API", "url": "https://learn.microsoft.com/en-us/rest/api/expressroute/express-route-ports", "reviewed_at": "2026-08-10", "review_due_at": "2027-08-10"}
   ],
   "automated_controls": [
-    {"id": "AZ-DL-001", "name": "ExpressRoute Direct link uses MACsec", "domain_ids": ["DL-15"], "frameworks": {"CIS": "TBD-DL-001", "NIST": "PR.DS-2", "ISO27001": "A.13.1.1", "SOC2": "CC6.7"}, "playbook": "playbooks/cli/fix_az_dl_001.sh"},
-    {"id": "AZ-DL-002", "name": "High-speed ExpressRoute Direct link uses XPN MACsec", "domain_ids": ["DL-07", "DL-15"], "frameworks": {"CIS": "TBD-DL-002", "NIST": "PR.DS-2", "ISO27001": "A.13.1.1", "SOC2": "CC6.7"}, "playbook": "playbooks/cli/fix_az_dl_002.sh"}
+    {"id": "AZ-DL-001", "name": "ExpressRoute Direct link uses MACsec", "domain_ids": ["DL-15"], "frameworks": {"CIS": "N/A-DL-001", "NIST": "PR.DS-2", "ISO27001": "A.13.1.1", "SOC2": "CC6.7"}, "playbook": "playbooks/cli/fix_az_dl_001.sh"},
+    {"id": "AZ-DL-002", "name": "High-speed ExpressRoute Direct link uses XPN MACsec", "domain_ids": ["DL-07", "DL-15"], "frameworks": {"CIS": "N/A-DL-002", "NIST": "PR.DS-2", "ISO27001": "A.13.1.1", "SOC2": "CC6.7"}, "playbook": "playbooks/cli/fix_az_dl_002.sh"}
   ],
   "domains": [
     {"id":"DL-01","name":"Frame construction and delimiting","sublayer_ids":["MAC"],"azure_applicability":"APPLICABLE","responsibility_owner":"Microsoft","observability_method":"provider documentation","evidence_source_ids":["AZ-L2-BOUNDARY"],"verification":"PROVIDER_ATTESTED"},

--- a/compliance/assurance/network_layer.json
+++ b/compliance/assurance/network_layer.json
@@ -111,10 +111,12 @@
         "NL-04"
       ],
       "evidence_source_ids": [
-        "E-NEXT-HOP"
+        "E-NEXT-HOP",
+        "E-NETWORK-POLICY"
       ],
       "scanner_rule_ids": [
-        "AZ-NET-011"
+        "AZ-NET-011",
+        "AZ-NET-016"
       ]
     },
     {
@@ -131,9 +133,12 @@
         "NL-05"
       ],
       "evidence_source_ids": [
-        "E-ROUTING"
+        "E-ROUTING",
+        "E-ROUTE-API"
       ],
-      "scanner_rule_ids": []
+      "scanner_rule_ids": [
+        "AZ-NET-017"
+      ]
     },
     {
       "id": "NL-C06",
@@ -239,7 +244,8 @@
       "scanner_rule_ids": [
         "AZ-NET-006",
         "AZ-NET-010",
-        "AZ-NET-013"
+        "AZ-NET-013",
+        "AZ-NET-017"
       ]
     },
     {
@@ -421,7 +427,9 @@
         "AZ-NET-004",
         "AZ-NET-010",
         "AZ-NET-013",
-        "AZ-NET-014"
+        "AZ-NET-014",
+        "AZ-NET-016",
+        "AZ-NET-017"
       ]
     },
     {
@@ -497,13 +505,15 @@
       "responsibility_owner": "Shared",
       "observability_method": "Use Network Watcher next-hop diagnostics for a selected VM NIC and destination.",
       "evidence_source_ids": [
-        "E-NEXT-HOP"
+        "E-NEXT-HOP",
+        "E-NETWORK-POLICY"
       ],
-      "verification": "MANUALLY_VERIFIABLE",
+      "verification": "AUTOMATICALLY_CHECKED",
       "rule_ids": [
-        "AZ-NET-011"
+        "AZ-NET-011",
+        "AZ-NET-016"
       ],
-      "automation_decision": "Next hop is contextual and cannot be judged securely without an intended-flow policy."
+      "automation_decision": "NIC IP forwarding is checked from authoritative configuration; path-specific next-hop intent remains manual."
     },
     {
       "id": "NL-05",
@@ -512,11 +522,14 @@
       "responsibility_owner": "Shared",
       "observability_method": "Inspect route tables and documented Azure system routes.",
       "evidence_source_ids": [
-        "E-ROUTING"
+        "E-ROUTING",
+        "E-ROUTE-API"
       ],
-      "verification": "MANUALLY_VERIFIABLE",
-      "rule_ids": [],
-      "automation_decision": "A default or Internet route can be intentional; no safe universal finding is emitted."
+      "verification": "AUTOMATICALLY_CHECKED",
+      "rule_ids": [
+        "AZ-NET-017"
+      ],
+      "automation_decision": "Explicit user-defined default Internet routes are checked; system routes and intended private routing remain contextual."
     },
     {
       "id": "NL-06",
@@ -593,7 +606,8 @@
       "rule_ids": [
         "AZ-NET-006",
         "AZ-NET-010",
-        "AZ-NET-013"
+        "AZ-NET-013",
+        "AZ-NET-017"
       ],
       "automation_decision": "Existing rules check unused public IPs and selected segmentation boundaries; they do not prove end-to-end exposure."
     },
@@ -726,7 +740,9 @@
         "AZ-NET-004",
         "AZ-NET-010",
         "AZ-NET-013",
-        "AZ-NET-014"
+        "AZ-NET-014",
+        "AZ-NET-016",
+        "AZ-NET-017"
       ],
       "automation_decision": "Existing cross-layer rules provide limited configuration checks; platform tenant isolation is provider-owned."
     },
@@ -899,6 +915,27 @@
       "osi_classification": "Layer 7",
       "classification_basis": "DNS is an application-layer naming protocol even when records contain IP addresses.",
       "layer_3_domain_ids": []
+    },
+    {
+      "id": "AZ-NET-016",
+      "name": "Network interface with IP forwarding enabled",
+      "osi_classification": "Layer 3",
+      "classification_basis": "IP forwarding changes Layer 3 source, destination, and transit behavior on the network interface.",
+      "layer_3_domain_ids": [
+        "NL-04",
+        "NL-19"
+      ]
+    },
+    {
+      "id": "AZ-NET-017",
+      "name": "User-defined default route using direct Internet next hop",
+      "osi_classification": "Layer 3",
+      "classification_basis": "The route explicitly selects the Layer 3 next hop for all IPv4 or IPv6 destinations.",
+      "layer_3_domain_ids": [
+        "NL-05",
+        "NL-10",
+        "NL-19"
+      ]
     }
   ],
   "evidence_sources": [
@@ -920,6 +957,20 @@
       "id": "E-ROUTING",
       "title": "Azure virtual network traffic routing",
       "url": "https://learn.microsoft.com/azure/virtual-network/virtual-networks-udr-overview",
+      "reviewed_at": "2026-08-12",
+      "review_due_at": "2027-02-12"
+    },
+    {
+      "id": "E-NETWORK-POLICY",
+      "title": "Built-in policy definitions for Azure networking services",
+      "url": "https://learn.microsoft.com/azure/networking/policy-reference",
+      "reviewed_at": "2026-08-12",
+      "review_due_at": "2027-02-12"
+    },
+    {
+      "id": "E-ROUTE-API",
+      "title": "Microsoft.Network route tables resource reference",
+      "url": "https://learn.microsoft.com/azure/templates/microsoft.network/routetables",
       "reviewed_at": "2026-08-12",
       "review_due_at": "2027-02-12"
     },

--- a/compliance/assurance/network_layer.json
+++ b/compliance/assurance/network_layer.json
@@ -1,0 +1,1018 @@
+{
+  "schema_version": 1,
+  "catalog_version": "2026.08",
+  "layer": {
+    "number": 3,
+    "name": "Network",
+    "model": "OSI",
+    "assessment_type": "mixed_assurance"
+  },
+  "scope": {
+    "environment": "azure_public_cloud",
+    "statement": "Azure public-cloud IPv4 and IPv6 addressing, routing, transit, isolation, IP-boundary protection, and Layer 3 diagnostics exposed through documented management-plane state.",
+    "responsibility_boundary": "Customers configure address spaces, routes, peerings, gateways, public IP boundaries, and supported diagnostics. Microsoft owns and operates the physical fabric, tenant isolation, system-route implementation, packet forwarding, and other internals not exposed as tenant-verifiable state."
+  },
+  "subdomains": [
+    {
+      "id": "ADDRESSING",
+      "name": "Addressing and packet behavior",
+      "description": "IP addressing, prefix allocation, subnetting, NAT, public/private boundaries, fragmentation, MTU, ICMP, and source validation."
+    },
+    {
+      "id": "ROUTING",
+      "name": "Routing and forwarding",
+      "description": "Packet forwarding, next-hop selection, system and user-defined routes, propagation, effective routes, BGP, redundancy, and failover."
+    },
+    {
+      "id": "TRANSIT",
+      "name": "Network transit",
+      "description": "Virtual network peering, hub-and-spoke topology, VPN Gateway, and ExpressRoute routing and advertisement."
+    },
+    {
+      "id": "PROTECTION",
+      "name": "Protection and isolation",
+      "description": "DDoS protection, tenant boundaries, segmentation, and network isolation."
+    },
+    {
+      "id": "OBSERVABILITY",
+      "name": "Layer 3 observability",
+      "description": "Route diagnostics, flow visibility, reachability diagnostics, and monitoring coverage."
+    }
+  ],
+  "controls": [
+    {
+      "id": "NL-C01",
+      "title": "IPv4 addressing and prefix management assurance",
+      "responsibility": "Customer",
+      "applicability": "APPLICABLE",
+      "verification": "MANUALLY_VERIFIABLE",
+      "status": "DOCUMENTED",
+      "subdomain_ids": [
+        "ADDRESSING"
+      ],
+      "domain_ids": [
+        "NL-01"
+      ],
+      "evidence_source_ids": [
+        "E-NETWORKING"
+      ],
+      "scanner_rule_ids": [
+        "AZ-NET-006"
+      ]
+    },
+    {
+      "id": "NL-C02",
+      "title": "IPv6 addressing and dual-stack assurance",
+      "responsibility": "Shared",
+      "applicability": "APPLICABLE",
+      "verification": "MANUALLY_VERIFIABLE",
+      "status": "DOCUMENTED",
+      "subdomain_ids": [
+        "ADDRESSING"
+      ],
+      "domain_ids": [
+        "NL-02"
+      ],
+      "evidence_source_ids": [
+        "E-IPV6"
+      ],
+      "scanner_rule_ids": []
+    },
+    {
+      "id": "NL-C03",
+      "title": "Subnet and overlap assurance",
+      "responsibility": "Customer",
+      "applicability": "APPLICABLE",
+      "verification": "MANUALLY_VERIFIABLE",
+      "status": "DOCUMENTED",
+      "subdomain_ids": [
+        "ADDRESSING"
+      ],
+      "domain_ids": [
+        "NL-03"
+      ],
+      "evidence_source_ids": [
+        "E-NETWORKING",
+        "E-PEERING"
+      ],
+      "scanner_rule_ids": []
+    },
+    {
+      "id": "NL-C04",
+      "title": "Packet forwarding and next-hop assurance",
+      "responsibility": "Shared",
+      "applicability": "APPLICABLE",
+      "verification": "MANUALLY_VERIFIABLE",
+      "status": "DOCUMENTED",
+      "subdomain_ids": [
+        "ROUTING"
+      ],
+      "domain_ids": [
+        "NL-04"
+      ],
+      "evidence_source_ids": [
+        "E-NEXT-HOP"
+      ],
+      "scanner_rule_ids": [
+        "AZ-NET-011"
+      ]
+    },
+    {
+      "id": "NL-C05",
+      "title": "System and user-defined route assurance",
+      "responsibility": "Shared",
+      "applicability": "APPLICABLE",
+      "verification": "MANUALLY_VERIFIABLE",
+      "status": "DOCUMENTED",
+      "subdomain_ids": [
+        "ROUTING"
+      ],
+      "domain_ids": [
+        "NL-05"
+      ],
+      "evidence_source_ids": [
+        "E-ROUTING"
+      ],
+      "scanner_rule_ids": []
+    },
+    {
+      "id": "NL-C06",
+      "title": "Route propagation and effective-route assurance",
+      "responsibility": "Shared",
+      "applicability": "APPLICABLE",
+      "verification": "MANUALLY_VERIFIABLE",
+      "status": "DOCUMENTED",
+      "subdomain_ids": [
+        "ROUTING",
+        "OBSERVABILITY"
+      ],
+      "domain_ids": [
+        "NL-06"
+      ],
+      "evidence_source_ids": [
+        "E-ROUTING",
+        "E-EFFECTIVE"
+      ],
+      "scanner_rule_ids": [
+        "AZ-NET-011"
+      ]
+    },
+    {
+      "id": "NL-C07",
+      "title": "Virtual network peering and transit assurance",
+      "responsibility": "Customer",
+      "applicability": "APPLICABLE",
+      "verification": "AUTOMATICALLY_CHECKED",
+      "status": "DOCUMENTED",
+      "subdomain_ids": [
+        "TRANSIT"
+      ],
+      "domain_ids": [
+        "NL-07"
+      ],
+      "evidence_source_ids": [
+        "E-PEERING"
+      ],
+      "scanner_rule_ids": [
+        "AZ-NET-014"
+      ]
+    },
+    {
+      "id": "NL-C08",
+      "title": "Hub-and-spoke routing assurance",
+      "responsibility": "Customer",
+      "applicability": "APPLICABLE",
+      "verification": "MANUALLY_VERIFIABLE",
+      "status": "DOCUMENTED",
+      "subdomain_ids": [
+        "ROUTING",
+        "TRANSIT"
+      ],
+      "domain_ids": [
+        "NL-08"
+      ],
+      "evidence_source_ids": [
+        "E-HUB-SPOKE"
+      ],
+      "scanner_rule_ids": [
+        "AZ-NET-013",
+        "AZ-NET-014"
+      ]
+    },
+    {
+      "id": "NL-C09",
+      "title": "Network address translation assurance",
+      "responsibility": "Shared",
+      "applicability": "APPLICABLE",
+      "verification": "MANUALLY_VERIFIABLE",
+      "status": "DOCUMENTED",
+      "subdomain_ids": [
+        "ADDRESSING"
+      ],
+      "domain_ids": [
+        "NL-09"
+      ],
+      "evidence_source_ids": [
+        "E-NAT"
+      ],
+      "scanner_rule_ids": [
+        "AZ-NET-006"
+      ]
+    },
+    {
+      "id": "NL-C10",
+      "title": "Public and private IP boundary assurance",
+      "responsibility": "Customer",
+      "applicability": "APPLICABLE",
+      "verification": "AUTOMATICALLY_CHECKED",
+      "status": "DOCUMENTED",
+      "subdomain_ids": [
+        "ADDRESSING",
+        "PROTECTION"
+      ],
+      "domain_ids": [
+        "NL-10"
+      ],
+      "evidence_source_ids": [
+        "E-NETWORKING"
+      ],
+      "scanner_rule_ids": [
+        "AZ-NET-006",
+        "AZ-NET-010",
+        "AZ-NET-013"
+      ]
+    },
+    {
+      "id": "NL-C11",
+      "title": "IP fragmentation, MTU, and path MTU assurance",
+      "responsibility": "Shared",
+      "applicability": "APPLICABLE",
+      "verification": "MANUALLY_VERIFIABLE",
+      "status": "DOCUMENTED",
+      "subdomain_ids": [
+        "ADDRESSING"
+      ],
+      "domain_ids": [
+        "NL-11"
+      ],
+      "evidence_source_ids": [
+        "E-MTU"
+      ],
+      "scanner_rule_ids": []
+    },
+    {
+      "id": "NL-C12",
+      "title": "ICMP and diagnostic reachability assurance",
+      "responsibility": "Shared",
+      "applicability": "APPLICABLE",
+      "verification": "MANUALLY_VERIFIABLE",
+      "status": "DOCUMENTED",
+      "subdomain_ids": [
+        "ADDRESSING",
+        "OBSERVABILITY"
+      ],
+      "domain_ids": [
+        "NL-12"
+      ],
+      "evidence_source_ids": [
+        "E-DIAGNOSTICS"
+      ],
+      "scanner_rule_ids": [
+        "AZ-NET-011"
+      ]
+    },
+    {
+      "id": "NL-C13",
+      "title": "Source-address validation and anti-spoofing assurance",
+      "responsibility": "Microsoft",
+      "applicability": "APPLICABLE",
+      "verification": "PROVIDER_ATTESTED",
+      "status": "DOCUMENTED",
+      "subdomain_ids": [
+        "ADDRESSING",
+        "PROTECTION"
+      ],
+      "domain_ids": [
+        "NL-13"
+      ],
+      "evidence_source_ids": [
+        "E-SECURITY"
+      ],
+      "scanner_rule_ids": []
+    },
+    {
+      "id": "NL-C14",
+      "title": "BGP routing assurance",
+      "responsibility": "Shared",
+      "applicability": "APPLICABLE",
+      "verification": "MANUALLY_VERIFIABLE",
+      "status": "DOCUMENTED",
+      "subdomain_ids": [
+        "ROUTING"
+      ],
+      "domain_ids": [
+        "NL-14"
+      ],
+      "evidence_source_ids": [
+        "E-BGP"
+      ],
+      "scanner_rule_ids": [
+        "AZ-NET-009"
+      ]
+    },
+    {
+      "id": "NL-C15",
+      "title": "VPN Gateway routing assurance",
+      "responsibility": "Shared",
+      "applicability": "APPLICABLE",
+      "verification": "AUTOMATICALLY_CHECKED",
+      "status": "DOCUMENTED",
+      "subdomain_ids": [
+        "ROUTING",
+        "TRANSIT"
+      ],
+      "domain_ids": [
+        "NL-15"
+      ],
+      "evidence_source_ids": [
+        "E-VPN"
+      ],
+      "scanner_rule_ids": [
+        "AZ-NET-009"
+      ]
+    },
+    {
+      "id": "NL-C16",
+      "title": "ExpressRoute routing and advertisement assurance",
+      "responsibility": "Shared",
+      "applicability": "APPLICABLE",
+      "verification": "MANUALLY_VERIFIABLE",
+      "status": "DOCUMENTED",
+      "subdomain_ids": [
+        "ROUTING",
+        "TRANSIT"
+      ],
+      "domain_ids": [
+        "NL-16"
+      ],
+      "evidence_source_ids": [
+        "E-EXPRESSROUTE"
+      ],
+      "scanner_rule_ids": []
+    },
+    {
+      "id": "NL-C17",
+      "title": "Route redundancy and failover assurance",
+      "responsibility": "Shared",
+      "applicability": "APPLICABLE",
+      "verification": "MANUALLY_VERIFIABLE",
+      "status": "DOCUMENTED",
+      "subdomain_ids": [
+        "ROUTING"
+      ],
+      "domain_ids": [
+        "NL-17"
+      ],
+      "evidence_source_ids": [
+        "E-RELIABILITY"
+      ],
+      "scanner_rule_ids": [
+        "AZ-NET-008",
+        "AZ-NET-009"
+      ]
+    },
+    {
+      "id": "NL-C18",
+      "title": "DDoS protection at the IP boundary assurance",
+      "responsibility": "Shared",
+      "applicability": "APPLICABLE",
+      "verification": "AUTOMATICALLY_CHECKED",
+      "status": "DOCUMENTED",
+      "subdomain_ids": [
+        "PROTECTION"
+      ],
+      "domain_ids": [
+        "NL-18"
+      ],
+      "evidence_source_ids": [
+        "E-DDOS"
+      ],
+      "scanner_rule_ids": [
+        "AZ-NET-005"
+      ]
+    },
+    {
+      "id": "NL-C19",
+      "title": "Network isolation and segmentation assurance",
+      "responsibility": "Shared",
+      "applicability": "APPLICABLE",
+      "verification": "AUTOMATICALLY_CHECKED",
+      "status": "DOCUMENTED",
+      "subdomain_ids": [
+        "PROTECTION"
+      ],
+      "domain_ids": [
+        "NL-19"
+      ],
+      "evidence_source_ids": [
+        "E-SECURITY"
+      ],
+      "scanner_rule_ids": [
+        "AZ-NET-004",
+        "AZ-NET-010",
+        "AZ-NET-013",
+        "AZ-NET-014"
+      ]
+    },
+    {
+      "id": "NL-C20",
+      "title": "Layer 3 monitoring and route diagnostics assurance",
+      "responsibility": "Shared",
+      "applicability": "APPLICABLE",
+      "verification": "AUTOMATICALLY_CHECKED",
+      "status": "DOCUMENTED",
+      "subdomain_ids": [
+        "OBSERVABILITY"
+      ],
+      "domain_ids": [
+        "NL-20"
+      ],
+      "evidence_source_ids": [
+        "E-DIAGNOSTICS",
+        "E-EFFECTIVE"
+      ],
+      "scanner_rule_ids": [
+        "AZ-NET-011",
+        "AZ-NET-012"
+      ]
+    }
+  ],
+  "domains": [
+    {
+      "id": "NL-01",
+      "name": "IPv4 addressing and prefix management",
+      "azure_applicability": "APPLICABLE",
+      "responsibility_owner": "Customer",
+      "observability_method": "Inspect VNet, subnet, NIC, and public IP management-plane configuration.",
+      "evidence_source_ids": [
+        "E-NETWORKING"
+      ],
+      "verification": "MANUALLY_VERIFIABLE",
+      "rule_ids": [
+        "AZ-NET-006"
+      ],
+      "automation_decision": "Existing public-IP association check covers one boundary condition; broad prefix policy is deployment-specific."
+    },
+    {
+      "id": "NL-02",
+      "name": "IPv6 addressing and dual-stack behavior",
+      "azure_applicability": "APPLICABLE",
+      "responsibility_owner": "Shared",
+      "observability_method": "Inspect IPv6 VNet prefixes, subnet prefixes, NIC configurations, and public IP SKUs.",
+      "evidence_source_ids": [
+        "E-IPV6"
+      ],
+      "verification": "MANUALLY_VERIFIABLE",
+      "rule_ids": [],
+      "automation_decision": "No universal requirement to enable dual stack; absence is not a safe finding."
+    },
+    {
+      "id": "NL-03",
+      "name": "Subnetting and address-space overlap",
+      "azure_applicability": "APPLICABLE",
+      "responsibility_owner": "Customer",
+      "observability_method": "Compare authoritative VNet, subnet, peering, and connected-network prefixes.",
+      "evidence_source_ids": [
+        "E-NETWORKING",
+        "E-PEERING"
+      ],
+      "verification": "MANUALLY_VERIFIABLE",
+      "rule_ids": [],
+      "automation_decision": "Azure prevents invalid local subnet overlap, while intended cross-network overlap requires topology context not currently inventoried."
+    },
+    {
+      "id": "NL-04",
+      "name": "Packet forwarding and next-hop selection",
+      "azure_applicability": "APPLICABLE",
+      "responsibility_owner": "Shared",
+      "observability_method": "Use Network Watcher next-hop diagnostics for a selected VM NIC and destination.",
+      "evidence_source_ids": [
+        "E-NEXT-HOP"
+      ],
+      "verification": "MANUALLY_VERIFIABLE",
+      "rule_ids": [
+        "AZ-NET-011"
+      ],
+      "automation_decision": "Next hop is contextual and cannot be judged securely without an intended-flow policy."
+    },
+    {
+      "id": "NL-05",
+      "name": "System routes and user-defined routes",
+      "azure_applicability": "APPLICABLE",
+      "responsibility_owner": "Shared",
+      "observability_method": "Inspect route tables and documented Azure system routes.",
+      "evidence_source_ids": [
+        "E-ROUTING"
+      ],
+      "verification": "MANUALLY_VERIFIABLE",
+      "rule_ids": [],
+      "automation_decision": "A default or Internet route can be intentional; no safe universal finding is emitted."
+    },
+    {
+      "id": "NL-06",
+      "name": "Route propagation and effective routes",
+      "azure_applicability": "APPLICABLE",
+      "responsibility_owner": "Shared",
+      "observability_method": "Inspect route-table propagation settings and Network Watcher effective routes for selected NICs.",
+      "evidence_source_ids": [
+        "E-ROUTING",
+        "E-EFFECTIVE"
+      ],
+      "verification": "MANUALLY_VERIFIABLE",
+      "rule_ids": [
+        "AZ-NET-011"
+      ],
+      "automation_decision": "Effective-route evaluation requires workload intent and NIC scope."
+    },
+    {
+      "id": "NL-07",
+      "name": "Virtual network peering and transit",
+      "azure_applicability": "APPLICABLE",
+      "responsibility_owner": "Customer",
+      "observability_method": "Inspect both peering directions, forwarded-traffic, remote-gateway, and gateway-transit flags.",
+      "evidence_source_ids": [
+        "E-PEERING"
+      ],
+      "verification": "AUTOMATICALLY_CHECKED",
+      "rule_ids": [
+        "AZ-NET-014"
+      ],
+      "automation_decision": "Existing peering transit rule supplies a limited management-plane check; full topology validity remains manual."
+    },
+    {
+      "id": "NL-08",
+      "name": "Hub-and-spoke routing",
+      "azure_applicability": "APPLICABLE",
+      "responsibility_owner": "Customer",
+      "observability_method": "Correlate peerings, route tables, gateways, and network virtual appliances against the intended topology.",
+      "evidence_source_ids": [
+        "E-HUB-SPOKE"
+      ],
+      "verification": "MANUALLY_VERIFIABLE",
+      "rule_ids": [
+        "AZ-NET-013",
+        "AZ-NET-014"
+      ],
+      "automation_decision": "Inventory does not identify intended hubs, spokes, or routing functions, so topology assumptions cannot create findings."
+    },
+    {
+      "id": "NL-09",
+      "name": "Network address translation",
+      "azure_applicability": "APPLICABLE",
+      "responsibility_owner": "Shared",
+      "observability_method": "Inspect NAT Gateway attachment, outbound rules, and Azure-managed translation behavior.",
+      "evidence_source_ids": [
+        "E-NAT"
+      ],
+      "verification": "MANUALLY_VERIFIABLE",
+      "rule_ids": [
+        "AZ-NET-006"
+      ],
+      "automation_decision": "NAT design is workload-specific; public IP association is the only existing related check."
+    },
+    {
+      "id": "NL-10",
+      "name": "Public and private IP boundaries",
+      "azure_applicability": "APPLICABLE",
+      "responsibility_owner": "Customer",
+      "observability_method": "Inspect public IP resources and associations plus private subnet and NIC addressing.",
+      "evidence_source_ids": [
+        "E-NETWORKING"
+      ],
+      "verification": "AUTOMATICALLY_CHECKED",
+      "rule_ids": [
+        "AZ-NET-006",
+        "AZ-NET-010",
+        "AZ-NET-013"
+      ],
+      "automation_decision": "Existing rules check unused public IPs and selected segmentation boundaries; they do not prove end-to-end exposure."
+    },
+    {
+      "id": "NL-11",
+      "name": "IP fragmentation, MTU, and path MTU behavior",
+      "azure_applicability": "APPLICABLE",
+      "responsibility_owner": "Shared",
+      "observability_method": "Validate workload paths with documented Azure MTU guidance and controlled diagnostics.",
+      "evidence_source_ids": [
+        "E-MTU"
+      ],
+      "verification": "MANUALLY_VERIFIABLE",
+      "rule_ids": [],
+      "automation_decision": "Management-plane inventory cannot prove packet fragmentation or path MTU behavior."
+    },
+    {
+      "id": "NL-12",
+      "name": "ICMP and diagnostic reachability",
+      "azure_applicability": "APPLICABLE",
+      "responsibility_owner": "Shared",
+      "observability_method": "Use Network Watcher connection troubleshoot and IP flow verification for an explicitly selected path.",
+      "evidence_source_ids": [
+        "E-DIAGNOSTICS"
+      ],
+      "verification": "MANUALLY_VERIFIABLE",
+      "rule_ids": [
+        "AZ-NET-011"
+      ],
+      "automation_decision": "Reachability is path- and policy-specific; scanner inventory alone is insufficient."
+    },
+    {
+      "id": "NL-13",
+      "name": "Source-address validation and anti-spoofing",
+      "azure_applicability": "APPLICABLE",
+      "responsibility_owner": "Microsoft",
+      "observability_method": "Rely on Microsoft platform documentation; tenant inventory cannot inspect fabric enforcement.",
+      "evidence_source_ids": [
+        "E-SECURITY"
+      ],
+      "verification": "PROVIDER_ATTESTED",
+      "rule_ids": [],
+      "automation_decision": "No customer-actionable authoritative state exists; no finding is safe."
+    },
+    {
+      "id": "NL-14",
+      "name": "BGP routing",
+      "azure_applicability": "APPLICABLE",
+      "responsibility_owner": "Shared",
+      "observability_method": "Inspect gateway BGP configuration and learned or advertised routes for an applicable gateway.",
+      "evidence_source_ids": [
+        "E-BGP"
+      ],
+      "verification": "MANUALLY_VERIFIABLE",
+      "rule_ids": [
+        "AZ-NET-009"
+      ],
+      "automation_decision": "BGP correctness depends on intended on-premises prefixes and policy."
+    },
+    {
+      "id": "NL-15",
+      "name": "VPN gateway routing",
+      "azure_applicability": "APPLICABLE",
+      "responsibility_owner": "Shared",
+      "observability_method": "Inspect VPN gateway, connection, local network gateway, routing, and effective route state.",
+      "evidence_source_ids": [
+        "E-VPN"
+      ],
+      "verification": "AUTOMATICALLY_CHECKED",
+      "rule_ids": [
+        "AZ-NET-009"
+      ],
+      "automation_decision": "Existing VPN rule checks IKE configuration; route correctness remains contextual."
+    },
+    {
+      "id": "NL-16",
+      "name": "ExpressRoute routing and route advertisement",
+      "azure_applicability": "APPLICABLE",
+      "responsibility_owner": "Shared",
+      "observability_method": "Inspect circuit, gateway, peering, BGP, and advertised-route management-plane state when ExpressRoute is deployed.",
+      "evidence_source_ids": [
+        "E-EXPRESSROUTE"
+      ],
+      "verification": "MANUALLY_VERIFIABLE",
+      "rule_ids": [],
+      "automation_decision": "The MACsec rules are Layer 2 and deliberately excluded; Layer 3 advertisement correctness requires customer route intent."
+    },
+    {
+      "id": "NL-17",
+      "name": "Route redundancy and failover",
+      "azure_applicability": "APPLICABLE",
+      "responsibility_owner": "Shared",
+      "observability_method": "Inspect gateway redundancy mode and validate planned failover using service-specific diagnostics.",
+      "evidence_source_ids": [
+        "E-RELIABILITY"
+      ],
+      "verification": "MANUALLY_VERIFIABLE",
+      "rule_ids": [
+        "AZ-NET-008",
+        "AZ-NET-009"
+      ],
+      "automation_decision": "Backend presence and VPN configuration are related cross-layer signals, not proof of route failover."
+    },
+    {
+      "id": "NL-18",
+      "name": "DDoS protection at the IP boundary",
+      "azure_applicability": "APPLICABLE",
+      "responsibility_owner": "Shared",
+      "observability_method": "Inspect VNet DDoS plan association and Microsoft platform protection documentation.",
+      "evidence_source_ids": [
+        "E-DDOS"
+      ],
+      "verification": "AUTOMATICALLY_CHECKED",
+      "rule_ids": [
+        "AZ-NET-005"
+      ],
+      "automation_decision": "Existing VNet DDoS rule checks authoritative plan association."
+    },
+    {
+      "id": "NL-19",
+      "name": "Network isolation and segmentation",
+      "azure_applicability": "APPLICABLE",
+      "responsibility_owner": "Shared",
+      "observability_method": "Inspect prefixes, subnets, peerings, route boundaries, NSGs, and firewall placement against architecture intent.",
+      "evidence_source_ids": [
+        "E-SECURITY"
+      ],
+      "verification": "AUTOMATICALLY_CHECKED",
+      "rule_ids": [
+        "AZ-NET-004",
+        "AZ-NET-010",
+        "AZ-NET-013",
+        "AZ-NET-014"
+      ],
+      "automation_decision": "Existing cross-layer rules provide limited configuration checks; platform tenant isolation is provider-owned."
+    },
+    {
+      "id": "NL-20",
+      "name": "Layer 3 monitoring, flow visibility, and route diagnostics",
+      "azure_applicability": "APPLICABLE",
+      "responsibility_owner": "Shared",
+      "observability_method": "Inspect Network Watcher availability and supported flow and route diagnostic configuration.",
+      "evidence_source_ids": [
+        "E-DIAGNOSTICS",
+        "E-EFFECTIVE"
+      ],
+      "verification": "AUTOMATICALLY_CHECKED",
+      "rule_ids": [
+        "AZ-NET-011",
+        "AZ-NET-012"
+      ],
+      "automation_decision": "Existing rules check selected diagnostic services; they do not constitute live traffic or fabric inspection."
+    }
+  ],
+  "rule_classifications": [
+    {
+      "id": "AZ-DL-001",
+      "name": "ExpressRoute Direct link without MACsec",
+      "osi_classification": "Layer 2",
+      "classification_basis": "MACsec protects Ethernet frames on the direct link and remains a Data Link control.",
+      "layer_3_domain_ids": []
+    },
+    {
+      "id": "AZ-DL-002",
+      "name": "ExpressRoute Direct non-XPN MACsec cipher",
+      "osi_classification": "Layer 2",
+      "classification_basis": "The MACsec cipher suite protects Ethernet frames and remains a Data Link control.",
+      "layer_3_domain_ids": []
+    },
+    {
+      "id": "AZ-NET-001",
+      "name": "Unrestricted inbound SSH",
+      "osi_classification": "Layer 4",
+      "classification_basis": "The finding is selected by TCP destination port 22.",
+      "layer_3_domain_ids": []
+    },
+    {
+      "id": "AZ-NET-002",
+      "name": "Unrestricted inbound RDP",
+      "osi_classification": "Layer 4",
+      "classification_basis": "The finding is selected by TCP destination port 3389.",
+      "layer_3_domain_ids": []
+    },
+    {
+      "id": "AZ-NET-003",
+      "name": "Unrestricted inbound HTTPS",
+      "osi_classification": "Layer 4",
+      "classification_basis": "The finding is selected by TCP destination port 443.",
+      "layer_3_domain_ids": []
+    },
+    {
+      "id": "AZ-NET-004",
+      "name": "NSG with no rules",
+      "osi_classification": "Cross-layer",
+      "classification_basis": "NSGs evaluate Layer 3 prefixes and Layer 4 protocol and port tuples.",
+      "layer_3_domain_ids": [
+        "NL-19"
+      ]
+    },
+    {
+      "id": "AZ-NET-005",
+      "name": "VNet without DDoS plan",
+      "osi_classification": "Layer 3",
+      "classification_basis": "The control protects the VNet IP boundary against network-layer denial of service.",
+      "layer_3_domain_ids": [
+        "NL-18"
+      ]
+    },
+    {
+      "id": "AZ-NET-006",
+      "name": "Unassociated public IP",
+      "osi_classification": "Layer 3",
+      "classification_basis": "The resource represents an IP address and public/private boundary.",
+      "layer_3_domain_ids": [
+        "NL-01",
+        "NL-09",
+        "NL-10"
+      ]
+    },
+    {
+      "id": "AZ-NET-007",
+      "name": "Application Gateway without WAF",
+      "osi_classification": "Layer 7",
+      "classification_basis": "Application Gateway WAF inspects HTTP application traffic.",
+      "layer_3_domain_ids": []
+    },
+    {
+      "id": "AZ-NET-008",
+      "name": "Load balancer without backend pool",
+      "osi_classification": "Cross-layer",
+      "classification_basis": "Azure Load Balancer spans IP frontend selection and transport-layer load balancing.",
+      "layer_3_domain_ids": [
+        "NL-17"
+      ]
+    },
+    {
+      "id": "AZ-NET-009",
+      "name": "VPN gateway using IKEv1",
+      "osi_classification": "Cross-layer",
+      "classification_basis": "IKE establishes the VPN security association while the gateway carries routed IP traffic.",
+      "layer_3_domain_ids": [
+        "NL-14",
+        "NL-15",
+        "NL-17"
+      ]
+    },
+    {
+      "id": "AZ-NET-010",
+      "name": "Subnet without NSG",
+      "osi_classification": "Cross-layer",
+      "classification_basis": "The subnet is Layer 3 while NSG policy can match Layer 3 and Layer 4 fields.",
+      "layer_3_domain_ids": [
+        "NL-10",
+        "NL-19"
+      ]
+    },
+    {
+      "id": "AZ-NET-011",
+      "name": "Network Watcher regional coverage",
+      "osi_classification": "Cross-layer",
+      "classification_basis": "Network Watcher exposes Layer 3 route and reachability diagnostics plus broader network tooling.",
+      "layer_3_domain_ids": [
+        "NL-04",
+        "NL-06",
+        "NL-12",
+        "NL-20"
+      ]
+    },
+    {
+      "id": "AZ-NET-012",
+      "name": "NSG flow logs disabled",
+      "osi_classification": "Cross-layer",
+      "classification_basis": "Flow records contain Layer 3 addresses and Layer 4 protocol and port information.",
+      "layer_3_domain_ids": [
+        "NL-20"
+      ]
+    },
+    {
+      "id": "AZ-NET-013",
+      "name": "VNet without Azure Firewall",
+      "osi_classification": "Cross-layer",
+      "classification_basis": "Firewall placement creates a Layer 3 boundary while policy can enforce through Layer 7.",
+      "layer_3_domain_ids": [
+        "NL-08",
+        "NL-10",
+        "NL-19"
+      ]
+    },
+    {
+      "id": "AZ-NET-014",
+      "name": "Peering gateway transit restrictions",
+      "osi_classification": "Layer 3",
+      "classification_basis": "VNet peering and gateway transit determine routed IP reachability.",
+      "layer_3_domain_ids": [
+        "NL-07",
+        "NL-08",
+        "NL-19"
+      ]
+    },
+    {
+      "id": "AZ-NET-015",
+      "name": "Public DNS exposing private infrastructure",
+      "osi_classification": "Layer 7",
+      "classification_basis": "DNS is an application-layer naming protocol even when records contain IP addresses.",
+      "layer_3_domain_ids": []
+    }
+  ],
+  "evidence_sources": [
+    {
+      "id": "E-NETWORKING",
+      "title": "Azure Virtual Network overview",
+      "url": "https://learn.microsoft.com/azure/virtual-network/virtual-networks-overview",
+      "reviewed_at": "2026-08-12",
+      "review_due_at": "2027-02-12"
+    },
+    {
+      "id": "E-IPV6",
+      "title": "IPv6 for Azure Virtual Network",
+      "url": "https://learn.microsoft.com/azure/virtual-network/ip-services/ipv6-overview",
+      "reviewed_at": "2026-08-12",
+      "review_due_at": "2027-02-12"
+    },
+    {
+      "id": "E-ROUTING",
+      "title": "Azure virtual network traffic routing",
+      "url": "https://learn.microsoft.com/azure/virtual-network/virtual-networks-udr-overview",
+      "reviewed_at": "2026-08-12",
+      "review_due_at": "2027-02-12"
+    },
+    {
+      "id": "E-EFFECTIVE",
+      "title": "Diagnose a virtual machine routing problem",
+      "url": "https://learn.microsoft.com/azure/virtual-network/diagnose-network-routing-problem",
+      "reviewed_at": "2026-08-12",
+      "review_due_at": "2027-02-12"
+    },
+    {
+      "id": "E-NEXT-HOP",
+      "title": "Network Watcher next hop overview",
+      "url": "https://learn.microsoft.com/azure/network-watcher/next-hop-overview",
+      "reviewed_at": "2026-08-12",
+      "review_due_at": "2027-02-12"
+    },
+    {
+      "id": "E-PEERING",
+      "title": "Azure virtual network peering",
+      "url": "https://learn.microsoft.com/azure/virtual-network/virtual-network-peering-overview",
+      "reviewed_at": "2026-08-12",
+      "review_due_at": "2027-02-12"
+    },
+    {
+      "id": "E-HUB-SPOKE",
+      "title": "Hub-spoke network topology in Azure",
+      "url": "https://learn.microsoft.com/azure/architecture/networking/architecture/hub-spoke",
+      "reviewed_at": "2026-08-12",
+      "review_due_at": "2027-02-12"
+    },
+    {
+      "id": "E-NAT",
+      "title": "Azure NAT Gateway overview",
+      "url": "https://learn.microsoft.com/azure/nat-gateway/nat-overview",
+      "reviewed_at": "2026-08-12",
+      "review_due_at": "2027-02-12"
+    },
+    {
+      "id": "E-MTU",
+      "title": "Azure VPN Gateway packet capture and MTU guidance",
+      "url": "https://learn.microsoft.com/azure/vpn-gateway/packet-capture",
+      "reviewed_at": "2026-08-12",
+      "review_due_at": "2027-02-12"
+    },
+    {
+      "id": "E-DIAGNOSTICS",
+      "title": "Azure Network Watcher overview",
+      "url": "https://learn.microsoft.com/azure/network-watcher/network-watcher-monitoring-overview",
+      "reviewed_at": "2026-08-12",
+      "review_due_at": "2027-02-12"
+    },
+    {
+      "id": "E-SECURITY",
+      "title": "Azure network security overview",
+      "url": "https://learn.microsoft.com/azure/security/fundamentals/network-overview",
+      "reviewed_at": "2026-08-12",
+      "review_due_at": "2027-02-12"
+    },
+    {
+      "id": "E-BGP",
+      "title": "BGP with Azure VPN Gateway",
+      "url": "https://learn.microsoft.com/azure/vpn-gateway/vpn-gateway-bgp-overview",
+      "reviewed_at": "2026-08-12",
+      "review_due_at": "2027-02-12"
+    },
+    {
+      "id": "E-VPN",
+      "title": "About Azure VPN Gateway",
+      "url": "https://learn.microsoft.com/azure/vpn-gateway/vpn-gateway-about-vpngateways",
+      "reviewed_at": "2026-08-12",
+      "review_due_at": "2027-02-12"
+    },
+    {
+      "id": "E-EXPRESSROUTE",
+      "title": "ExpressRoute routing requirements",
+      "url": "https://learn.microsoft.com/azure/expressroute/expressroute-routing",
+      "reviewed_at": "2026-08-12",
+      "review_due_at": "2027-02-12"
+    },
+    {
+      "id": "E-RELIABILITY",
+      "title": "Reliability in Azure Virtual Network Gateways",
+      "url": "https://learn.microsoft.com/azure/reliability/reliability-virtual-network-gateway",
+      "reviewed_at": "2026-08-12",
+      "review_due_at": "2027-02-12"
+    },
+    {
+      "id": "E-DDOS",
+      "title": "Azure DDoS Protection overview",
+      "url": "https://learn.microsoft.com/azure/ddos-protection/ddos-protection-overview",
+      "reviewed_at": "2026-08-12",
+      "review_due_at": "2027-02-12"
+    }
+  ]
+}

--- a/compliance/frameworks/cis_azure_benchmark.json
+++ b/compliance/frameworks/cis_azure_benchmark.json
@@ -342,6 +342,16 @@
       "control_id": "TBD-DL-002",
       "control_name": "ExpressRoute Direct XPN MACsec placeholder",
       "description": "Numbered placeholder pending maintainer approval of a direct CIS mapping."
+    },
+    "AZ-NET-016": {
+      "control_id": "TBD-NET-016",
+      "control_name": "Network interface IP forwarding placeholder",
+      "description": "Numbered placeholder pending maintainer approval of a direct CIS mapping."
+    },
+    "AZ-NET-017": {
+      "control_id": "TBD-NET-017",
+      "control_name": "Direct Internet default route placeholder",
+      "description": "Numbered placeholder pending maintainer approval of a direct CIS mapping."
     }
   }
 }

--- a/compliance/frameworks/cis_azure_benchmark.json
+++ b/compliance/frameworks/cis_azure_benchmark.json
@@ -344,14 +344,14 @@
       "description": "Numbered placeholder pending maintainer approval of a direct CIS mapping."
     },
     "AZ-NET-016": {
-      "control_id": "TBD-NET-016",
-      "control_name": "Network interface IP forwarding placeholder",
-      "description": "Numbered placeholder pending maintainer approval of a direct CIS mapping."
+      "control_id": "N/A-NET-016",
+      "control_name": "Network interface IP forwarding review (no direct CIS Azure Foundations 2.0.0 control)",
+      "description": "Azure recommends disabling NIC IP forwarding unless the interface belongs to a reviewed routing function, but CIS Azure Foundations 2.0.0 does not assign this check a direct recommendation number."
     },
     "AZ-NET-017": {
-      "control_id": "TBD-NET-017",
-      "control_name": "Direct Internet default route placeholder",
-      "description": "Numbered placeholder pending maintainer approval of a direct CIS mapping."
+      "control_id": "N/A-NET-017",
+      "control_name": "Direct Internet default route review (no direct CIS Azure Foundations 2.0.0 control)",
+      "description": "Azure exposes and documents user-defined Internet next hops, but CIS Azure Foundations 2.0.0 does not assign this route check a direct recommendation number."
     }
   }
 }

--- a/compliance/frameworks/cis_azure_benchmark.json
+++ b/compliance/frameworks/cis_azure_benchmark.json
@@ -134,9 +134,9 @@
       "description": "The virtual machine does not have automatic OS patching enabled. CIS 8.3 requires that OS patches are applied in a timely manner. Unpatched VMs are vulnerable to known exploits targeting unpatched OS vulnerabilities."
     },
     "AZ-KV-001": {
-      "control_id": "8.8",
-      "control_name": "Ensure the Key Vault is Recoverable",
-      "description": "Azure Key Vault soft delete should be enabled on all Key Vaults. The soft delete feature allows recovery of deleted vaults and vault objects (keys, secrets, certificates) for a configurable retention period (7–90 days), protecting against accidental or malicious deletion."
+      "control_id": "N/A-KV-001",
+      "control_name": "Key Vault soft-delete baseline (covered by the repository's CIS 8.5 purge-protection rule)",
+      "description": "Soft delete is part of CIS Azure Foundations 2.0.0 recommendation 8.5, which is assigned to AZ-KV-004 under the repository's one-CIS-ID-per-rule convention. This overlapping prerequisite check is explicitly not assigned a second numbered mapping."
     },
     "AZ-STOR-003": {
       "control_id": "3.7",
@@ -179,8 +179,8 @@
       "description": "SSL enforcement should be enabled on PostgreSQL Flexible Server to ensure data in transit is encrypted. Without SSL, database connections transmit data in plaintext, exposing it to interception."
     },
     "AZ-KV-004": {
-      "control_id": "8.6",
-      "control_name": "Ensure that Azure Key Vault Purge Protection is Enabled",
+      "control_id": "8.5",
+      "control_name": "Ensure the Key Vault is Recoverable",
       "description": "Azure Key Vaults without purge protection enabled allow permanent deletion of vaults and their secrets, keys, and certificates during the soft-delete retention period. Even with soft delete enabled, a malicious insider or privileged account can purge vault objects before the retention period expires. Enabling purge protection prevents this by blocking purge operations for the full retention period."
     },
     "AZ-DB-004": {
@@ -194,14 +194,14 @@
       "description": "Privileged Identity Management provides time-based and approval-based role activation to mitigate the risk of excessive, unnecessary, or misused access permissions on resources. Without PIM, admin roles are permanently assigned with no just-in-time controls or approval workflows."
     },
     "AZ-KV-005": {
-      "control_id": "8.5",
-      "control_name": "Ensure that the expiration date is set on all certificates",
-      "description": "A certificate stored in Azure Key Vault is expiring within 30 days and does not have auto-renewal configured. CIS 8.5 requires that expiration dates are monitored and certificates are renewed before expiry to prevent service outages and broken authentication flows."
+      "control_id": "N/A-KV-005",
+      "control_name": "Key Vault certificate renewal baseline (not directly mapped in CIS Azure Foundations 2.0.0)",
+      "description": "This rule detects certificates expiring within 30 days without automatic renewal. CIS Azure Foundations 2.0.0 contains certificate expiration-date recommendations, but does not directly prescribe this proactive 30-day renewal check, so no numbered mapping is claimed."
     },
     "AZ-KV-006": {
-      "control_id": "TBD-KV-006",
+      "control_id": "8.6",
       "control_name": "Ensure that Azure Key Vault Uses Azure RBAC for Data Plane Authorization",
-      "description": "Key Vaults authorizing access through legacy vault access policies instead of Azure RBAC lack scoped, auditable role assignments. Access policies grant broad permissions per permission type and are not tracked through Azure RBAC's centralized role-assignment audit trail, increasing the risk of over-privileged access to secrets, keys, and certificates. Note for maintainers: the official CIS Azure Foundations Benchmark control for this check is 8.6 (\"Enable Role Based Access Control for Azure Key Vault\"), but 8.6 is already assigned to AZ-KV-004 (purge protection) in this file — likely a pre-existing mapping error unrelated to this change. Left as TBD pending a maintainer decision on how to resolve the collision, following the same TBD-* convention used elsewhere in this file."
+      "description": "CIS Azure Foundations Benchmark 2.0.0 recommendation 8.6 requires Azure Key Vault to use the Azure RBAC permission model. Key Vaults using legacy access policies lack centrally auditable, scoped role assignments and increase the risk of over-privileged access to secrets, keys, and certificates."
     },
     "AZ-NET-013": {
       "control_id": "6.4",
@@ -264,84 +264,84 @@
       "description": "Microsoft recommends a managed node OS upgrade channel for timely security patches. This check has no direct control in the repository's CIS Azure Foundations 2.0.0 benchmark."
     },
     "AZ-IDN-010": {
-      "control_id": "TBD-IDN-010",
+      "control_id": "N/A-IDN-010",
       "control_name": "App Registration ownership (not mapped in CIS Azure Foundations 2.0.0)",
       "description": "Microsoft recommends accountable App Registration ownership. This check has no direct control in the repository's CIS Azure Foundations 2.0.0 benchmark."
     },
     "AZ-IDN-011": {
-      "control_id": "TBD-IDN-011",
+      "control_id": "N/A-IDN-011",
       "control_name": "App Registration redirect URI security (not mapped in CIS Azure Foundations 2.0.0)",
       "description": "Microsoft requires secure redirect URI handling. This check has no direct control in the repository's CIS Azure Foundations 2.0.0 benchmark."
     },
     "AZ-IDN-012": {
-      "control_id": "TBD-IDN-012",
+      "control_id": "N/A-IDN-012",
       "control_name": "OAuth implicit grant security (not mapped in CIS Azure Foundations 2.0.0)",
       "description": "Microsoft recommends authorization code flow instead of implicit grant. This check has no direct control in the repository's CIS Azure Foundations 2.0.0 benchmark."
     },
     "AZ-IDN-013": {
-      "control_id": "TBD-IDN-013",
+      "control_id": "N/A-IDN-013",
       "control_name": "App Registration password credentials (not mapped in CIS Azure Foundations 2.0.0)",
       "description": "Microsoft recommends managed identity, federation, or certificates instead of client secrets. This check has no direct control in the repository's CIS Azure Foundations 2.0.0 benchmark."
     },
     "AZ-IDN-014": {
-      "control_id": "TBD-IDN-014",
+      "control_id": "N/A-IDN-014",
       "control_name": "Application-instance property lock (not mapped in CIS Azure Foundations 2.0.0)",
       "description": "Microsoft recommends locking sensitive service-principal instance properties. This check has no direct control in the repository's CIS Azure Foundations 2.0.0 benchmark."
     },
     "AZ-IDN-015": {
-      "control_id": "TBD-IDN-015",
+      "control_id": "N/A-IDN-015",
       "control_name": "Managed Identity least privilege (not mapped in CIS Azure Foundations 2.0.0)",
       "description": "Microsoft recommends least-privilege roles and scopes for managed identities. This check has no direct control in the repository's CIS Azure Foundations 2.0.0 benchmark."
     },
     "AZ-SC-001": {
-      "control_id": "TBD-SC-001",
-      "control_name": "Container Registry Admin User Enabled placeholder",
-      "description": "Numbered placeholder pending maintainer approval of a direct CIS mapping."
+      "control_id": "N/A-SC-001",
+      "control_name": "Container Registry admin user baseline (not mapped in CIS Azure Foundations 2.0.0)",
+      "description": "Microsoft recommends disabling the Azure Container Registry admin account in favor of individual Microsoft Entra identities. This check has no direct recommendation in CIS Azure Foundations 2.0.0."
     },
     "AZ-SC-002": {
-      "control_id": "TBD-SC-002",
-      "control_name": "Container Registry Public Network Access Enabled placeholder",
-      "description": "Numbered placeholder pending maintainer approval of a direct CIS mapping."
+      "control_id": "N/A-SC-002",
+      "control_name": "Container Registry public network baseline (not mapped in CIS Azure Foundations 2.0.0)",
+      "description": "Microsoft recommends restricting Azure Container Registry network access with private endpoints or selected networks. This check has no direct recommendation in CIS Azure Foundations 2.0.0."
     },
     "AZ-SC-003": {
-      "control_id": "TBD-SC-003",
-      "control_name": "Container Registry Allows Anonymous Pull placeholder",
-      "description": "Numbered placeholder pending maintainer approval of a direct CIS mapping."
+      "control_id": "N/A-SC-003",
+      "control_name": "Container Registry anonymous pull baseline (not mapped in CIS Azure Foundations 2.0.0)",
+      "description": "Microsoft recommends disabling anonymous pull unless a registry intentionally distributes public images. This check has no direct recommendation in CIS Azure Foundations 2.0.0."
     },
     "AZ-SC-004": {
-      "control_id": "TBD-SC-004",
-      "control_name": "Container Registry Missing Retention or Quarantine Policy placeholder",
-      "description": "Numbered placeholder pending maintainer approval of a direct CIS mapping."
+      "control_id": "N/A-SC-004",
+      "control_name": "Container Registry retention and quarantine baseline (not mapped in CIS Azure Foundations 2.0.0)",
+      "description": "Microsoft documents retention and quarantine policies for managing untagged and potentially unsafe artifacts. This combined check has no direct recommendation in CIS Azure Foundations 2.0.0."
     },
     "AZ-SC-005": {
-      "control_id": "TBD-SC-005",
-      "control_name": "Terraform State Storage Container Publicly Readable placeholder",
-      "description": "Numbered placeholder pending maintainer approval of a direct CIS mapping."
+      "control_id": "N/A-SC-005",
+      "control_name": "Terraform state container access baseline (not directly mapped in CIS Azure Foundations 2.0.0)",
+      "description": "Terraform state can contain sensitive infrastructure data and must not be anonymously readable. The repository does not claim a direct CIS recommendation because this rule specifically identifies Terraform state rather than evaluating every blob container."
     },
     "AZ-SC-006": {
-      "control_id": "TBD-SC-006",
-      "control_name": "Terraform State Storage Account Missing Versioning or Soft Delete placeholder",
-      "description": "Numbered placeholder pending maintainer approval of a direct CIS mapping."
+      "control_id": "N/A-SC-006",
+      "control_name": "Terraform state recovery baseline (not mapped in CIS Azure Foundations 2.0.0)",
+      "description": "Microsoft recommends blob versioning and soft delete to recover Terraform state from accidental or malicious changes. This combined Terraform-specific check has no direct recommendation in CIS Azure Foundations 2.0.0."
     },
     "AZ-SC-007": {
-      "control_id": "TBD-SC-007",
-      "control_name": "Pipeline Service Connection Scoped to Subscription placeholder",
-      "description": "Numbered placeholder pending maintainer approval of a direct CIS mapping."
+      "control_id": "N/A-SC-007",
+      "control_name": "Pipeline service connection scope baseline (not mapped in CIS Azure Foundations 2.0.0)",
+      "description": "Microsoft recommends least-privilege scopes for Azure DevOps service connections. Azure DevOps pipeline connection scope is outside the direct recommendations in CIS Azure Foundations 2.0.0."
     },
     "AZ-SC-008": {
-      "control_id": "TBD-SC-008",
-      "control_name": "Pipeline Service Connection Uses Password Instead of Federated Credential placeholder",
-      "description": "Numbered placeholder pending maintainer approval of a direct CIS mapping."
+      "control_id": "N/A-SC-008",
+      "control_name": "Pipeline workload identity federation baseline (not mapped in CIS Azure Foundations 2.0.0)",
+      "description": "Microsoft recommends workload identity federation instead of stored service-principal secrets for Azure DevOps service connections. This check has no direct recommendation in CIS Azure Foundations 2.0.0."
     },
     "AZ-DL-001": {
-      "control_id": "TBD-DL-001",
-      "control_name": "ExpressRoute Direct MACsec placeholder",
-      "description": "Numbered placeholder pending maintainer approval of a direct CIS mapping."
+      "control_id": "N/A-DL-001",
+      "control_name": "ExpressRoute Direct MACsec baseline (not mapped in CIS Azure Foundations 2.0.0)",
+      "description": "Microsoft supports MACsec for encrypting ExpressRoute Direct physical links. CIS Azure Foundations 2.0.0 has no direct recommendation for ExpressRoute Direct MACsec."
     },
     "AZ-DL-002": {
-      "control_id": "TBD-DL-002",
-      "control_name": "ExpressRoute Direct XPN MACsec placeholder",
-      "description": "Numbered placeholder pending maintainer approval of a direct CIS mapping."
+      "control_id": "N/A-DL-002",
+      "control_name": "ExpressRoute Direct XPN MACsec baseline (not mapped in CIS Azure Foundations 2.0.0)",
+      "description": "Microsoft requires the XPN cipher for MACsec on 100-Gbps ExpressRoute Direct ports. CIS Azure Foundations 2.0.0 has no direct recommendation for this link-layer setting."
     },
     "AZ-NET-016": {
       "control_id": "N/A-NET-016",

--- a/compliance/frameworks/iso27001.json
+++ b/compliance/frameworks/iso27001.json
@@ -342,6 +342,16 @@
       "control_id": "A.13.1.1",
       "control_name": "Network controls",
       "description": "XPN MACsec provides appropriate packet-number capacity for high-speed ExpressRoute Direct links."
+    },
+    "AZ-NET-016": {
+      "control_id": "A.13.1.1",
+      "control_name": "Network controls",
+      "description": "NIC IP forwarding must be restricted to approved routing functions."
+    },
+    "AZ-NET-017": {
+      "control_id": "A.13.1.1",
+      "control_name": "Network controls",
+      "description": "Default routes must preserve the approved controlled egress boundary."
     }
   }
 }

--- a/compliance/frameworks/nist_csf.json
+++ b/compliance/frameworks/nist_csf.json
@@ -342,6 +342,16 @@
       "control_id": "PR.DS-2",
       "control_name": "Data in transit is protected",
       "description": "XPN MACsec avoids packet-number exhaustion risk on high-speed ExpressRoute Direct links."
+    },
+    "AZ-NET-016": {
+      "control_id": "PR.AC-5",
+      "control_name": "Network integrity is protected",
+      "description": "Unnecessary NIC IP forwarding weakens Azure source and destination validation and can create an unintended transit path."
+    },
+    "AZ-NET-017": {
+      "control_id": "PR.AC-5",
+      "control_name": "Network integrity is protected",
+      "description": "An explicit default Internet UDR can bypass the approved inspected egress path."
     }
   }
 }

--- a/compliance/frameworks/soc2.json
+++ b/compliance/frameworks/soc2.json
@@ -342,6 +342,16 @@
       "control_id": "CC6.7",
       "control_name": "Restricts Transmission and Movement of Information",
       "description": "XPN MACsec provides suitable packet-number capacity for high-speed protected links."
+    },
+    "AZ-NET-016": {
+      "control_id": "CC6.6",
+      "control_name": "Logical Access Security Measures",
+      "description": "NIC IP forwarding is restricted to reviewed network virtual appliances and routing functions."
+    },
+    "AZ-NET-017": {
+      "control_id": "CC6.6",
+      "control_name": "Logical Access Security Measures",
+      "description": "User-defined default routes preserve approved inspected egress paths."
     }
   }
 }

--- a/docs/network-layer-assurance.md
+++ b/docs/network-layer-assurance.md
@@ -10,6 +10,6 @@ The catalog classifies every `AZ-NET-001` through `AZ-NET-015` rule by actual be
 
 ## Automation limits
 
-The report cross-references existing authoritative management-plane checks. It does not add speculative findings for route intent, address overlap, next-hop correctness, MTU, ICMP reachability, BGP advertisement, or Microsoft anti-spoofing internals. Those conditions require architecture intent, selected endpoints, packet tests, or provider evidence that the scanner does not possess.
+The report cross-references authoritative management-plane checks. `AZ-NET-016` reports NICs with IP forwarding enabled for network-security review, and `AZ-NET-017` reports explicit IPv4 or IPv6 default user-defined routes that select the direct Internet next hop. It does not add speculative findings for address overlap, path-specific next-hop correctness, MTU, ICMP reachability, BGP advertisement, or Microsoft anti-spoofing internals. Those conditions require architecture intent, selected endpoints, packet tests, or provider evidence that the scanner does not possess.
 
 Empty relevant inventory is `NOT_APPLICABLE`; Azure API or permission failure is `INDETERMINATE`. Neither state creates a finding. The endpoint is documentation-backed assurance, not packet capture, live traffic inspection, or access to Microsoft forwarding tables.

--- a/docs/network-layer-assurance.md
+++ b/docs/network-layer-assurance.md
@@ -1,0 +1,15 @@
+# Azure Network Layer assurance
+
+OpenShield's authenticated `GET /api/assurance/network-layer` endpoint returns a closed OSI Layer 3 catalog for Azure public-cloud networking. It covers all 20 required addressing, routing, transit, isolation, IP-boundary protection, and diagnostic domains and reports catalog completeness separately from evidence freshness.
+
+## Responsibility boundary
+
+Customers control exposed address spaces, subnets, routes, peerings, gateways, public IP associations, and supported diagnostics. Microsoft owns the Azure fabric, underlying forwarding implementation, tenant isolation, physical packet handling, and system internals that subscriptions cannot inspect. Provider-owned domains are documented but never create findings or change the tenant score.
+
+The catalog classifies every `AZ-NET-001` through `AZ-NET-015` rule by actual behavior. Port-specific NSG rules remain Layer 4, the public DNS rule remains Layer 7, and ExpressRoute Direct MACsec rules remain Layer 2. Cross-layer rules only reference Layer 3 domains when part of their behavior genuinely covers IP addressing, routing, or segmentation.
+
+## Automation limits
+
+The report cross-references existing authoritative management-plane checks. It does not add speculative findings for route intent, address overlap, next-hop correctness, MTU, ICMP reachability, BGP advertisement, or Microsoft anti-spoofing internals. Those conditions require architecture intent, selected endpoints, packet tests, or provider evidence that the scanner does not possess.
+
+Empty relevant inventory is `NOT_APPLICABLE`; Azure API or permission failure is `INDETERMINATE`. Neither state creates a finding. The endpoint is documentation-backed assurance, not packet capture, live traffic inspection, or access to Microsoft forwarding tables.

--- a/docs/rules-reference.md
+++ b/docs/rules-reference.md
@@ -21,17 +21,17 @@ OpenShield currently ships 65 Azure scan rules. This table is generated from the
 | AZ-IDN-007 | Active User with No MFA Registered in Entra ID | HIGH | Identity | 1.1 | PR.AC-7 | A.9.4.2 |
 | AZ-IDN-008 | Custom RBAC Role with Wildcard Permissions at Subscription Scope | HIGH | Identity | 1.23 | PR.AC-4 | A.9.2.3 |
 | AZ-IDN-009 | No Activity Log Alert for Role Assignment Changes | MEDIUM | Identity | 5.2.1 | DE.CM-3 | A.12.4.1 |
-| AZ-IDN-010 | App Registration Has No Owner | MEDIUM | Identity | TBD-IDN-010 | PR.AC-4 | A.9.2.1 |
-| AZ-IDN-011 | App Registration Uses Insecure Redirect URI | HIGH | Identity | TBD-IDN-011 | PR.DS-2 | A.14.1.2 |
-| AZ-IDN-012 | App Registration Enables OAuth Implicit Grant | MEDIUM | Identity | TBD-IDN-012 | PR.AC-3 | A.9.4.2 |
-| AZ-IDN-013 | App Registration Uses Password Credentials | MEDIUM | Identity | TBD-IDN-013 | PR.AC-1 | A.9.4.3 |
-| AZ-IDN-014 | Multi-Tenant App Registration Lacks Property Lock | HIGH | Identity | TBD-IDN-014 | PR.IP-1 | A.12.1.2 |
-| AZ-IDN-015 | Managed Identity Has Privileged Subscription Role | HIGH | Identity | TBD-IDN-015 | PR.AC-4 | A.9.2.3 |
-| AZ-KV-001 | Key Vault with Soft Delete Disabled | MEDIUM | KeyVault | 8.8 | PR.IP-4 | A.17.2.1 |
+| AZ-IDN-010 | App Registration Has No Owner | MEDIUM | Identity | N/A-IDN-010 | PR.AC-4 | A.9.2.1 |
+| AZ-IDN-011 | App Registration Uses Insecure Redirect URI | HIGH | Identity | N/A-IDN-011 | PR.DS-2 | A.14.1.2 |
+| AZ-IDN-012 | App Registration Enables OAuth Implicit Grant | MEDIUM | Identity | N/A-IDN-012 | PR.AC-3 | A.9.4.2 |
+| AZ-IDN-013 | App Registration Uses Password Credentials | MEDIUM | Identity | N/A-IDN-013 | PR.AC-1 | A.9.4.3 |
+| AZ-IDN-014 | Multi-Tenant App Registration Lacks Property Lock | HIGH | Identity | N/A-IDN-014 | PR.IP-1 | A.12.1.2 |
+| AZ-IDN-015 | Managed Identity Has Privileged Subscription Role | HIGH | Identity | N/A-IDN-015 | PR.AC-4 | A.9.2.3 |
+| AZ-KV-001 | Key Vault with Soft Delete Disabled | MEDIUM | KeyVault | N/A-KV-001 | PR.IP-4 | A.17.2.1 |
 | AZ-KV-002 | Key Vault Allows Public Network Access Without Private Endpoint | HIGH | Key Vault | 8.7 | AC-17 | A.13.1.1 |
 | AZ-KV-003 | Key Vault Without Diagnostic Logging Enabled | MEDIUM | Key Vault | 8.4 | DE.CM-7 | A.12.4.1 |
-| AZ-KV-004 | Key Vault Purge Protection Disabled | MEDIUM | Key Vault | 8.6 | PR.IP-4 | A.17.2.1 |
-| AZ-KV-005 | Key Vault Certificate Expiring Within 30 Days | MEDIUM | Key Vault | 8.5 | PR.MA-1 | A.10.1.2 |
+| AZ-KV-004 | Key Vault Purge Protection Disabled | MEDIUM | Key Vault | 8.5 | PR.IP-4 | A.17.2.1 |
+| AZ-KV-005 | Key Vault Certificate Expiring Within 30 Days | MEDIUM | Key Vault | N/A-KV-005 | PR.MA-1 | A.10.1.2 |
 | AZ-NET-001 | NSG Allows Unrestricted Inbound SSH from Any Source | HIGH | Network | 6.2 | PR.AC-3 | A.13.1.1 |
 | AZ-NET-002 | NSG Allows Unrestricted Inbound RDP from Any Source | HIGH | Network | 6.3 | PR.AC-3 | A.13.1.1 |
 | AZ-NET-003 | NSG allows unrestricted inbound on port 443 | HIGH | Network | 9.3 | SC-7 | A.13.1.1 |
@@ -61,14 +61,14 @@ OpenShield currently ships 65 Azure scan rules. This table is generated from the
 | AZ-AKS-004 | AKS Workload Identity Not Fully Enabled | MEDIUM | Kubernetes | N/A-AKS-004 | PR.AC-4 | A.9.2.3 |
 | AZ-AKS-005 | AKS Azure Policy Add-on Not Enabled | MEDIUM | Kubernetes | N/A-AKS-005 | PR.IP-1 | A.12.1.2 |
 | AZ-AKS-006 | AKS Node OS Automatic Upgrades Disabled | HIGH | Kubernetes | N/A-AKS-006 | PR.IP-12 | A.12.6.1 |
-| AZ-SC-001 | Container Registry Admin User Enabled | HIGH | Supply Chain | TBD-SC-001 | PR.AC-1 | A.9.2.1 |
-| AZ-SC-002 | Container Registry Public Network Access Enabled | HIGH | Supply Chain | TBD-SC-002 | PR.AC-5 | A.13.1.1 |
-| AZ-SC-003 | Container Registry Allows Anonymous Pull | HIGH | Supply Chain | TBD-SC-003 | PR.AC-1 | A.9.2.1 |
-| AZ-SC-004 | Container Registry Missing Retention or Quarantine Policy | MEDIUM | Supply Chain | TBD-SC-004 | PR.IP-1 | A.12.1.2 |
-| AZ-SC-005 | Terraform State Storage Container Publicly Readable | CRITICAL | Supply Chain | TBD-SC-005 | PR.AC-5 | A.13.1.1 |
-| AZ-SC-006 | Terraform State Storage Account Missing Versioning or Soft Delete | HIGH | Supply Chain | TBD-SC-006 | PR.IP-4 | A.12.3.1 |
-| AZ-SC-007 | Pipeline Service Connection Scoped to Subscription | HIGH | Supply Chain | TBD-SC-007 | PR.AC-4 | A.9.2.3 |
-| AZ-SC-008 | Pipeline Service Connection Uses Password Instead of Federated Credential | MEDIUM | Supply Chain | TBD-SC-008 | PR.AC-1 | A.9.4.3 |
+| AZ-SC-001 | Container Registry Admin User Enabled | HIGH | Supply Chain | N/A-SC-001 | PR.AC-1 | A.9.2.1 |
+| AZ-SC-002 | Container Registry Public Network Access Enabled | HIGH | Supply Chain | N/A-SC-002 | PR.AC-5 | A.13.1.1 |
+| AZ-SC-003 | Container Registry Allows Anonymous Pull | HIGH | Supply Chain | N/A-SC-003 | PR.AC-1 | A.9.2.1 |
+| AZ-SC-004 | Container Registry Missing Retention or Quarantine Policy | MEDIUM | Supply Chain | N/A-SC-004 | PR.IP-1 | A.12.1.2 |
+| AZ-SC-005 | Terraform State Storage Container Publicly Readable | CRITICAL | Supply Chain | N/A-SC-005 | PR.AC-5 | A.13.1.1 |
+| AZ-SC-006 | Terraform State Storage Account Missing Versioning or Soft Delete | HIGH | Supply Chain | N/A-SC-006 | PR.IP-4 | A.12.3.1 |
+| AZ-SC-007 | Pipeline Service Connection Scoped to Subscription | HIGH | Supply Chain | N/A-SC-007 | PR.AC-4 | A.9.2.3 |
+| AZ-SC-008 | Pipeline Service Connection Uses Password Instead of Federated Credential | MEDIUM | Supply Chain | N/A-SC-008 | PR.AC-1 | A.9.4.3 |
 
 SOC 2 mappings are maintained in `compliance/frameworks/soc2.json`.
 

--- a/playbooks/cli/fix_az_net_016.sh
+++ b/playbooks/cli/fix_az_net_016.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Review and disable IP forwarding on an Azure network interface.
+set -euo pipefail
+
+RESOURCE_GROUP="${1:-}"
+NIC_NAME="${2:-}"
+
+if [[ -z "$RESOURCE_GROUP" || -z "$NIC_NAME" ]]; then
+  echo "Usage: $0 <resource-group> <network-interface-name>"
+  exit 1
+fi
+
+echo "Confirm that $NIC_NAME is not an approved network virtual appliance before continuing."
+read -r -p "Disable IP forwarding? [y/N] " CONFIRM
+if [[ "$CONFIRM" != "y" && "$CONFIRM" != "Y" ]]; then
+  echo "No change made."
+  exit 0
+fi
+
+az network nic update \
+  --resource-group "$RESOURCE_GROUP" \
+  --name "$NIC_NAME" \
+  --ip-forwarding false
+
+echo "IP forwarding disabled on $NIC_NAME."

--- a/playbooks/cli/fix_az_net_017.sh
+++ b/playbooks/cli/fix_az_net_017.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Remove an explicit default route that uses the Internet next hop.
+set -euo pipefail
+
+RESOURCE_GROUP="${1:-}"
+ROUTE_TABLE_NAME="${2:-}"
+ROUTE_NAME="${3:-}"
+
+if [[ -z "$RESOURCE_GROUP" || -z "$ROUTE_TABLE_NAME" || -z "$ROUTE_NAME" ]]; then
+  echo "Usage: $0 <resource-group> <route-table-name> <route-name>"
+  exit 1
+fi
+
+echo "Review dependent subnet egress before removing route $ROUTE_NAME."
+read -r -p "Remove the direct Internet route? [y/N] " CONFIRM
+if [[ "$CONFIRM" != "y" && "$CONFIRM" != "Y" ]]; then
+  echo "No change made."
+  exit 0
+fi
+
+az network route-table route delete \
+  --resource-group "$RESOURCE_GROUP" \
+  --route-table-name "$ROUTE_TABLE_NAME" \
+  --name "$ROUTE_NAME"
+
+echo "Route $ROUTE_NAME removed. Configure the approved inspected egress route before restoring traffic."

--- a/scanner/azure_client.py
+++ b/scanner/azure_client.py
@@ -266,6 +266,24 @@ class AzureClient:
             logger.error("get_network_interface(%s) failed: %s", nic_name, exc)
             return None
 
+    def get_network_interfaces(self) -> Optional[List[Any]]:
+        """List NICs while preserving API failure as indeterminate."""
+        try:
+            client = NetworkManagementClient(self.credential, self.subscription_id)
+            return list(client.network_interfaces.list_all())
+        except Exception as exc:
+            logger.error("get_network_interfaces failed: %s", exc)
+            return None
+
+    def get_route_tables(self) -> Optional[List[Any]]:
+        """List route tables while preserving API failure as indeterminate."""
+        try:
+            client = NetworkManagementClient(self.credential, self.subscription_id)
+            return list(client.route_tables.list_all())
+        except Exception as exc:
+            logger.error("get_route_tables failed: %s", exc)
+            return None
+
     def get_virtual_networks(self) -> List[Any]:
         """List all virtual networks in the subscription."""
         try:

--- a/scanner/engine.py
+++ b/scanner/engine.py
@@ -65,18 +65,20 @@ class ScanEngine:
 
     def load_rules(self) -> None:
         """Dynamically import every *.py file in scanner/rules/ as a rule module."""
-        for rule_path in sorted(RULES_DIR.glob("*.py")):
-            if rule_path.name.startswith("_"):
-                continue
+        # Keep runtime discovery identical to CI validation and documentation
+        # counts. A misnamed scratch module must never execute against a real
+        # subscription without first passing the rule checks.
+        for rule_path in sorted(RULES_DIR.glob("az_*.py")):
             try:
                 spec = importlib.util.spec_from_file_location(rule_path.stem, rule_path)
                 module = importlib.util.module_from_spec(spec)  # type: ignore[arg-type]
                 spec.loader.exec_module(module)  # type: ignore[union-attr]
-                if callable(getattr(module, "scan", None)):
+                rule_id = getattr(module, "RULE_ID", None)
+                if callable(getattr(module, "scan", None)) and isinstance(rule_id, str) and rule_id:
                     self.rules.append(module)
-                    logger.info("Loaded rule: %s", getattr(module, "RULE_ID", rule_path.stem))
+                    logger.info("Loaded rule: %s", rule_id)
                 else:
-                    logger.warning("Rule file %s has no scan() function — skipped", rule_path.name)
+                    logger.warning("Rule file %s has no scan() function or RULE_ID — skipped", rule_path.name)
             except Exception as exc:
                 logger.error("Failed to load rule %s: %s", rule_path.name, exc)
 

--- a/scanner/rules/az_dl_001.py
+++ b/scanner/rules/az_dl_001.py
@@ -17,7 +17,7 @@ RULE_ID = "AZ-DL-001"
 RULE_NAME = "ExpressRoute Direct Link Does Not Use MACsec"
 SEVERITY = "HIGH"
 CATEGORY = "Data Link"
-FRAMEWORKS = {"CIS": "TBD-DL-001", "NIST": "PR.DS-2", "ISO27001": "A.13.1.1", "SOC2": "CC6.7"}
+FRAMEWORKS = {"CIS": "N/A-DL-001", "NIST": "PR.DS-2", "ISO27001": "A.13.1.1", "SOC2": "CC6.7"}
 DESCRIPTION = "An enabled ExpressRoute Direct Ethernet link does not have a MACsec configuration."
 REMEDIATION = (
     "Plan a maintenance window, store CAK and CKN values in Azure Key Vault, then enable MACsec on both "

--- a/scanner/rules/az_dl_002.py
+++ b/scanner/rules/az_dl_002.py
@@ -19,7 +19,7 @@ RULE_ID = "AZ-DL-002"
 RULE_NAME = "High-Speed ExpressRoute Direct Link Uses Non-XPN MACsec"
 SEVERITY = "MEDIUM"
 CATEGORY = "Data Link"
-FRAMEWORKS = {"CIS": "TBD-DL-002", "NIST": "PR.DS-2", "ISO27001": "A.13.1.1", "SOC2": "CC6.7"}
+FRAMEWORKS = {"CIS": "N/A-DL-002", "NIST": "PR.DS-2", "ISO27001": "A.13.1.1", "SOC2": "CC6.7"}
 DESCRIPTION = "An enabled ExpressRoute Direct port of 40 Gbps or greater uses a MACsec cipher without XPN."
 REMEDIATION = (
     "Confirm both peer devices support an XPN cipher, schedule a maintenance window, update the MACsec "

--- a/scanner/rules/az_idn_010.py
+++ b/scanner/rules/az_idn_010.py
@@ -9,7 +9,7 @@ RULE_ID = "AZ-IDN-010"
 RULE_NAME = "App Registration Has No Owner"
 SEVERITY = "MEDIUM"
 CATEGORY = "Identity"
-FRAMEWORKS = {"CIS": "TBD-IDN-010", "NIST": "PR.AC-4", "ISO27001": "A.9.2.1", "SOC2": "CC6.2"}
+FRAMEWORKS = {"CIS": "N/A-IDN-010", "NIST": "PR.AC-4", "ISO27001": "A.9.2.1", "SOC2": "CC6.2"}
 DESCRIPTION = (
     "The App Registration has no assigned owner. Unowned applications can escape periodic review, "
     "credential rotation, permission cleanup, and accountable incident response."

--- a/scanner/rules/az_idn_011.py
+++ b/scanner/rules/az_idn_011.py
@@ -11,7 +11,7 @@ RULE_ID = "AZ-IDN-011"
 RULE_NAME = "App Registration Uses Insecure Redirect URI"
 SEVERITY = "HIGH"
 CATEGORY = "Identity"
-FRAMEWORKS = {"CIS": "TBD-IDN-011", "NIST": "PR.DS-2", "ISO27001": "A.14.1.2", "SOC2": "CC6.7"}
+FRAMEWORKS = {"CIS": "N/A-IDN-011", "NIST": "PR.DS-2", "ISO27001": "A.14.1.2", "SOC2": "CC6.7"}
 DESCRIPTION = (
     "The App Registration contains an HTTP redirect URI for a non-loopback host. Authorization "
     "responses can be intercepted or modified before reaching the application."

--- a/scanner/rules/az_idn_012.py
+++ b/scanner/rules/az_idn_012.py
@@ -9,7 +9,7 @@ RULE_ID = "AZ-IDN-012"
 RULE_NAME = "App Registration Enables OAuth Implicit Grant"
 SEVERITY = "MEDIUM"
 CATEGORY = "Identity"
-FRAMEWORKS = {"CIS": "TBD-IDN-012", "NIST": "PR.AC-3", "ISO27001": "A.9.4.2", "SOC2": "CC6.1"}
+FRAMEWORKS = {"CIS": "N/A-IDN-012", "NIST": "PR.AC-3", "ISO27001": "A.9.4.2", "SOC2": "CC6.1"}
 DESCRIPTION = (
     "The App Registration enables access-token or ID-token issuance through the legacy implicit "
     "grant flow. Tokens can be exposed to browser history, extensions, or front-channel leakage."

--- a/scanner/rules/az_idn_013.py
+++ b/scanner/rules/az_idn_013.py
@@ -9,7 +9,7 @@ RULE_ID = "AZ-IDN-013"
 RULE_NAME = "App Registration Uses Password Credentials"
 SEVERITY = "MEDIUM"
 CATEGORY = "Identity"
-FRAMEWORKS = {"CIS": "TBD-IDN-013", "NIST": "PR.AC-1", "ISO27001": "A.9.4.3", "SOC2": "CC6.1"}
+FRAMEWORKS = {"CIS": "N/A-IDN-013", "NIST": "PR.AC-1", "ISO27001": "A.9.4.3", "SOC2": "CC6.1"}
 DESCRIPTION = (
     "The App Registration has one or more password credentials. Client secrets are commonly copied, "
     "logged, leaked, or left unrotated and are weaker than managed identity or certificate authentication."

--- a/scanner/rules/az_idn_014.py
+++ b/scanner/rules/az_idn_014.py
@@ -9,7 +9,7 @@ RULE_ID = "AZ-IDN-014"
 RULE_NAME = "Multi-Tenant App Registration Lacks Property Lock"
 SEVERITY = "HIGH"
 CATEGORY = "Identity"
-FRAMEWORKS = {"CIS": "TBD-IDN-014", "NIST": "PR.IP-1", "ISO27001": "A.12.1.2", "SOC2": "CC6.6"}
+FRAMEWORKS = {"CIS": "N/A-IDN-014", "NIST": "PR.IP-1", "ISO27001": "A.12.1.2", "SOC2": "CC6.6"}
 DESCRIPTION = (
     "The multi-tenant App Registration does not lock all sensitive properties on its service-principal "
     "instances. Tenant administrators can modify credentials or token-encryption settings unexpectedly."

--- a/scanner/rules/az_idn_015.py
+++ b/scanner/rules/az_idn_015.py
@@ -7,7 +7,7 @@ RULE_ID = "AZ-IDN-015"
 RULE_NAME = "Managed Identity Has Privileged Subscription Role"
 SEVERITY = "HIGH"
 CATEGORY = "Identity"
-FRAMEWORKS = {"CIS": "TBD-IDN-015", "NIST": "PR.AC-4", "ISO27001": "A.9.2.3", "SOC2": "CC6.3"}
+FRAMEWORKS = {"CIS": "N/A-IDN-015", "NIST": "PR.AC-4", "ISO27001": "A.9.2.3", "SOC2": "CC6.3"}
 DESCRIPTION = (
     "A managed identity holds Owner or Contributor at subscription scope. Compromise of any resource "
     "that can use the identity would provide an unnecessarily large Azure control-plane blast radius."

--- a/scanner/rules/az_kv_001.py
+++ b/scanner/rules/az_kv_001.py
@@ -6,7 +6,7 @@ RULE_ID = "AZ-KV-001"
 RULE_NAME = "Key Vault with Soft Delete Disabled"
 SEVERITY = "MEDIUM"
 CATEGORY = "KeyVault"
-FRAMEWORKS = {"CIS": "8.8", "NIST": "PR.IP-4", "ISO27001": "A.17.2.1"}
+FRAMEWORKS = {"CIS": "N/A-KV-001", "NIST": "PR.IP-4", "ISO27001": "A.17.2.1"}
 DESCRIPTION = (
     "Azure Key Vault soft delete is disabled. Without soft delete, secrets, keys, "
     "and certificates can be permanently destroyed immediately upon deletion — "

--- a/scanner/rules/az_kv_004.py
+++ b/scanner/rules/az_kv_004.py
@@ -6,7 +6,7 @@ RULE_ID = "AZ-KV-004"
 RULE_NAME = "Key Vault Purge Protection Disabled"
 SEVERITY = "MEDIUM"
 CATEGORY = "KeyVault"
-FRAMEWORKS = {"CIS": "8.6", "NIST": "PR.IP-4", "ISO27001": "A.17.2.1", "SOC2": "CC9.1"}
+FRAMEWORKS = {"CIS": "8.5", "NIST": "PR.IP-4", "ISO27001": "A.17.2.1", "SOC2": "CC9.1"}
 DESCRIPTION = (
     "Azure Key Vaults without purge protection enabled allow permanent "
     "deletion of vaults and their secrets, keys, and certificates during "

--- a/scanner/rules/az_kv_005.py
+++ b/scanner/rules/az_kv_005.py
@@ -9,7 +9,7 @@ RULE_NAME = "Key Vault Certificate Expiring Within 30 Days"
 SEVERITY = "MEDIUM"
 CATEGORY = "KeyVault"
 FRAMEWORKS = {
-    "CIS": "8.5",
+    "CIS": "N/A-KV-005",
     "NIST": "PR.MA-1",
     "ISO27001": "A.10.1.2",
     "SOC2": "CC9.1",

--- a/scanner/rules/az_kv_006.py
+++ b/scanner/rules/az_kv_006.py
@@ -6,7 +6,7 @@ RULE_ID = "AZ-KV-006"
 RULE_NAME = "Key Vault Using Legacy Access Policies Instead of Azure RBAC"
 SEVERITY = "MEDIUM"
 CATEGORY = "KeyVault"
-FRAMEWORKS = {"CIS": "TBD-KV-006", "NIST": "PR.AC-4", "ISO27001": "A.9.2.3", "SOC2": "CC6.1"}
+FRAMEWORKS = {"CIS": "8.6", "NIST": "PR.AC-4", "ISO27001": "A.9.2.3", "SOC2": "CC6.1"}
 DESCRIPTION = (
     "The Azure Key Vault is authorizing access through legacy vault access policies "
     "instead of Azure RBAC. Access policies are all-or-nothing per permission type, "

--- a/scanner/rules/az_net_016.py
+++ b/scanner/rules/az_net_016.py
@@ -1,0 +1,61 @@
+"""AZ-NET-016: Network interface has IP forwarding enabled."""
+
+import logging
+from typing import Any, Dict, List
+
+RULE_ID = "AZ-NET-016"
+RULE_NAME = "Network Interface Has IP Forwarding Enabled"
+SEVERITY = "MEDIUM"
+CATEGORY = "Network"
+FRAMEWORKS = {"CIS": "TBD-NET-016", "NIST": "SC-7", "ISO27001": "A.13.1.1", "SOC2": "CC6.6"}
+DESCRIPTION = (
+    "The network interface has IP forwarding enabled, which disables Azure source and destination checks and "
+    "allows the attached workload to forward traffic not addressed to it. This is normally required only for a "
+    "documented network virtual appliance or routing function."
+)
+REMEDIATION = (
+    "Confirm that the interface belongs to an approved network virtual appliance. Otherwise disable IP forwarding. "
+    "If forwarding is required, document the routing function and restrict its paths with route tables and NSGs."
+)
+PLAYBOOK = "playbooks/cli/fix_az_net_016.sh"
+
+logger = logging.getLogger(__name__)
+
+
+def scan(azure_client: Any, subscription_id: str) -> List[Dict[str, Any]]:
+    """Report authoritative NIC IP-forwarding state without guessing on API failure."""
+    interfaces = azure_client.get_network_interfaces()
+    if interfaces is None:
+        logger.warning("%s: NIC inventory unavailable; result is indeterminate", RULE_ID)
+        return []
+    if not interfaces:
+        logger.info("%s: no network interfaces; rule is not applicable", RULE_ID)
+        return []
+
+    findings: List[Dict[str, Any]] = []
+    for interface in interfaces:
+        if getattr(interface, "enable_ip_forwarding", None) is not True:
+            continue
+        resource_id = getattr(interface, "id", "") or ""
+        parsed = azure_client.parse_resource_id(resource_id)
+        findings.append(
+            {
+                "rule_id": RULE_ID,
+                "rule_name": RULE_NAME,
+                "severity": SEVERITY,
+                "category": CATEGORY,
+                "resource_id": resource_id,
+                "resource_name": getattr(interface, "name", ""),
+                "resource_type": "Microsoft.Network/networkInterfaces",
+                "description": DESCRIPTION,
+                "remediation": REMEDIATION,
+                "playbook": PLAYBOOK,
+                "frameworks": FRAMEWORKS,
+                "metadata": {
+                    "resource_group": parsed.get("resource_group", ""),
+                    "ip_forwarding_enabled": True,
+                    "requires_routing_function_review": True,
+                },
+            }
+        )
+    return findings

--- a/scanner/rules/az_net_016.py
+++ b/scanner/rules/az_net_016.py
@@ -7,7 +7,7 @@ RULE_ID = "AZ-NET-016"
 RULE_NAME = "Network Interface Has IP Forwarding Enabled"
 SEVERITY = "MEDIUM"
 CATEGORY = "Network"
-FRAMEWORKS = {"CIS": "TBD-NET-016", "NIST": "SC-7", "ISO27001": "A.13.1.1", "SOC2": "CC6.6"}
+FRAMEWORKS = {"CIS": "N/A-NET-016", "NIST": "SC-7", "ISO27001": "A.13.1.1", "SOC2": "CC6.6"}
 DESCRIPTION = (
     "The network interface has IP forwarding enabled, which disables Azure source and destination checks and "
     "allows the attached workload to forward traffic not addressed to it. This is normally required only for a "

--- a/scanner/rules/az_net_017.py
+++ b/scanner/rules/az_net_017.py
@@ -1,0 +1,67 @@
+"""AZ-NET-017: User-defined default route sends traffic directly to the Internet."""
+
+import logging
+from typing import Any, Dict, List
+
+from scanner.azure_client import enum_str
+
+RULE_ID = "AZ-NET-017"
+RULE_NAME = "User-Defined Default Route Uses Direct Internet Next Hop"
+SEVERITY = "MEDIUM"
+CATEGORY = "Network"
+FRAMEWORKS = {"CIS": "TBD-NET-017", "NIST": "SC-7", "ISO27001": "A.13.1.1", "SOC2": "CC6.6"}
+DESCRIPTION = (
+    "A user-defined IPv4 or IPv6 default route explicitly sends traffic to the Internet next hop. This bypasses "
+    "a virtual appliance or virtual network gateway that would otherwise provide controlled egress inspection."
+)
+REMEDIATION = (
+    "Review the subnet egress design. Remove the direct Internet default route or change its next hop to the approved "
+    "Azure Firewall, network virtual appliance, or virtual network gateway."
+)
+PLAYBOOK = "playbooks/cli/fix_az_net_017.sh"
+
+logger = logging.getLogger(__name__)
+DEFAULT_PREFIXES = {"0.0.0.0/0", "::/0"}
+
+
+def scan(azure_client: Any, subscription_id: str) -> List[Dict[str, Any]]:
+    """Report explicit default Internet UDRs and preserve failed inventory as indeterminate."""
+    route_tables = azure_client.get_route_tables()
+    if route_tables is None:
+        logger.warning("%s: route-table inventory unavailable; result is indeterminate", RULE_ID)
+        return []
+    if not route_tables:
+        logger.info("%s: no route tables; rule is not applicable", RULE_ID)
+        return []
+
+    findings: List[Dict[str, Any]] = []
+    for route_table in route_tables:
+        for route in getattr(route_table, "routes", None) or []:
+            address_prefix = (getattr(route, "address_prefix", "") or "").strip()
+            next_hop_type = enum_str(getattr(route, "next_hop_type", ""))
+            if address_prefix not in DEFAULT_PREFIXES or next_hop_type.lower() != "internet":
+                continue
+            route_table_id = getattr(route_table, "id", "") or ""
+            route_id = getattr(route, "id", "") or route_table_id
+            findings.append(
+                {
+                    "rule_id": RULE_ID,
+                    "rule_name": RULE_NAME,
+                    "severity": SEVERITY,
+                    "category": CATEGORY,
+                    "resource_id": route_id,
+                    "resource_name": getattr(route, "name", "") or getattr(route_table, "name", ""),
+                    "resource_type": "Microsoft.Network/routeTables/routes",
+                    "description": DESCRIPTION,
+                    "remediation": REMEDIATION,
+                    "playbook": PLAYBOOK,
+                    "frameworks": FRAMEWORKS,
+                    "metadata": {
+                        "route_table_id": route_table_id,
+                        "route_table_name": getattr(route_table, "name", ""),
+                        "address_prefix": address_prefix,
+                        "next_hop_type": next_hop_type,
+                    },
+                }
+            )
+    return findings

--- a/scanner/rules/az_net_017.py
+++ b/scanner/rules/az_net_017.py
@@ -9,7 +9,7 @@ RULE_ID = "AZ-NET-017"
 RULE_NAME = "User-Defined Default Route Uses Direct Internet Next Hop"
 SEVERITY = "MEDIUM"
 CATEGORY = "Network"
-FRAMEWORKS = {"CIS": "TBD-NET-017", "NIST": "SC-7", "ISO27001": "A.13.1.1", "SOC2": "CC6.6"}
+FRAMEWORKS = {"CIS": "N/A-NET-017", "NIST": "SC-7", "ISO27001": "A.13.1.1", "SOC2": "CC6.6"}
 DESCRIPTION = (
     "A user-defined IPv4 or IPv6 default route explicitly sends traffic to the Internet next hop. This bypasses "
     "a virtual appliance or virtual network gateway that would otherwise provide controlled egress inspection."

--- a/scanner/rules/az_sc_001.py
+++ b/scanner/rules/az_sc_001.py
@@ -7,7 +7,7 @@ RULE_ID = "AZ-SC-001"
 RULE_NAME = "Container Registry Admin User Enabled"
 SEVERITY = "HIGH"
 CATEGORY = "Supply Chain"
-FRAMEWORKS = {"CIS": "TBD-SC-001", "NIST": "PR.AC-1", "ISO27001": "A.9.2.1", "SOC2": "CC6.1"}
+FRAMEWORKS = {"CIS": "N/A-SC-001", "NIST": "PR.AC-1", "ISO27001": "A.9.2.1", "SOC2": "CC6.1"}
 
 DESCRIPTION = (
     "The Azure Container Registry has the admin user enabled. The admin account is a single "

--- a/scanner/rules/az_sc_002.py
+++ b/scanner/rules/az_sc_002.py
@@ -9,7 +9,7 @@ RULE_ID = "AZ-SC-002"
 RULE_NAME = "Container Registry Public Network Access Enabled"
 SEVERITY = "HIGH"
 CATEGORY = "Supply Chain"
-FRAMEWORKS = {"CIS": "TBD-SC-002", "NIST": "PR.AC-5", "ISO27001": "A.13.1.1", "SOC2": "CC6.6"}
+FRAMEWORKS = {"CIS": "N/A-SC-002", "NIST": "PR.AC-5", "ISO27001": "A.13.1.1", "SOC2": "CC6.6"}
 
 DESCRIPTION = (
     "The Azure Container Registry is reachable from the public internet. A registry that holds "

--- a/scanner/rules/az_sc_003.py
+++ b/scanner/rules/az_sc_003.py
@@ -7,7 +7,7 @@ RULE_ID = "AZ-SC-003"
 RULE_NAME = "Container Registry Allows Anonymous Pull"
 SEVERITY = "HIGH"
 CATEGORY = "Supply Chain"
-FRAMEWORKS = {"CIS": "TBD-SC-003", "NIST": "PR.AC-1", "ISO27001": "A.9.2.1", "SOC2": "CC6.1"}
+FRAMEWORKS = {"CIS": "N/A-SC-003", "NIST": "PR.AC-1", "ISO27001": "A.9.2.1", "SOC2": "CC6.1"}
 
 DESCRIPTION = (
     "The Azure Container Registry allows anonymous pull, so any client on the network can pull "

--- a/scanner/rules/az_sc_004.py
+++ b/scanner/rules/az_sc_004.py
@@ -7,7 +7,7 @@ RULE_ID = "AZ-SC-004"
 RULE_NAME = "Container Registry Missing Retention or Quarantine Policy"
 SEVERITY = "MEDIUM"
 CATEGORY = "Supply Chain"
-FRAMEWORKS = {"CIS": "TBD-SC-004", "NIST": "PR.IP-1", "ISO27001": "A.12.1.2", "SOC2": "CC7.1"}
+FRAMEWORKS = {"CIS": "N/A-SC-004", "NIST": "PR.IP-1", "ISO27001": "A.12.1.2", "SOC2": "CC7.1"}
 
 DESCRIPTION = (
     "The Azure Container Registry has no retention policy for untagged manifests, so stale and "

--- a/scanner/rules/az_sc_005.py
+++ b/scanner/rules/az_sc_005.py
@@ -8,7 +8,7 @@ RULE_ID = "AZ-SC-005"
 RULE_NAME = "Terraform State Storage Container Publicly Readable"
 SEVERITY = "CRITICAL"
 CATEGORY = "Supply Chain"
-FRAMEWORKS = {"CIS": "TBD-SC-005", "NIST": "PR.AC-5", "ISO27001": "A.13.1.1", "SOC2": "CC6.6"}
+FRAMEWORKS = {"CIS": "N/A-SC-005", "NIST": "PR.AC-5", "ISO27001": "A.13.1.1", "SOC2": "CC6.6"}
 
 DESCRIPTION = (
     "A blob container that appears to hold Terraform remote state (matched by name) allows "

--- a/scanner/rules/az_sc_006.py
+++ b/scanner/rules/az_sc_006.py
@@ -8,7 +8,7 @@ RULE_ID = "AZ-SC-006"
 RULE_NAME = "Terraform State Storage Account Missing Versioning or Soft Delete"
 SEVERITY = "HIGH"
 CATEGORY = "Supply Chain"
-FRAMEWORKS = {"CIS": "TBD-SC-006", "NIST": "PR.IP-4", "ISO27001": "A.12.3.1", "SOC2": "A1.2"}
+FRAMEWORKS = {"CIS": "N/A-SC-006", "NIST": "PR.IP-4", "ISO27001": "A.12.3.1", "SOC2": "A1.2"}
 
 DESCRIPTION = (
     "A storage account holding a container that appears to be a Terraform remote state backend "

--- a/scanner/rules/az_sc_007.py
+++ b/scanner/rules/az_sc_007.py
@@ -7,7 +7,7 @@ RULE_ID = "AZ-SC-007"
 RULE_NAME = "Pipeline Service Connection Scoped to Subscription"
 SEVERITY = "HIGH"
 CATEGORY = "Supply Chain"
-FRAMEWORKS = {"CIS": "TBD-SC-007", "NIST": "PR.AC-4", "ISO27001": "A.9.2.3", "SOC2": "CC6.1"}
+FRAMEWORKS = {"CIS": "N/A-SC-007", "NIST": "PR.AC-4", "ISO27001": "A.9.2.3", "SOC2": "CC6.1"}
 
 DESCRIPTION = (
     "An Azure DevOps service connection is scoped to the entire subscription rather than a "

--- a/scanner/rules/az_sc_008.py
+++ b/scanner/rules/az_sc_008.py
@@ -7,7 +7,7 @@ RULE_ID = "AZ-SC-008"
 RULE_NAME = "Pipeline Service Connection Uses Password Instead of Federated Credential"
 SEVERITY = "MEDIUM"
 CATEGORY = "Supply Chain"
-FRAMEWORKS = {"CIS": "TBD-SC-008", "NIST": "PR.AC-1", "ISO27001": "A.9.4.3", "SOC2": "CC6.1"}
+FRAMEWORKS = {"CIS": "N/A-SC-008", "NIST": "PR.AC-1", "ISO27001": "A.9.4.3", "SOC2": "CC6.1"}
 
 DESCRIPTION = (
     "An Azure DevOps service connection authenticates with a stored service principal secret "

--- a/tests/helpers/mock_azure.py
+++ b/tests/helpers/mock_azure.py
@@ -56,6 +56,8 @@ class MockAzureClient:
         self._sql_firewall_rules: Dict[Tuple[str, str], List[Any]] = {}
         # --- Additional state added for full rule-coverage tests ---------- #
         self._network_interfaces: Dict[Tuple[str, str], Any] = {}
+        self._all_network_interfaces: Optional[List[Any]] = []
+        self._route_tables: Optional[List[Any]] = []
         self._vm_extensions: Dict[Tuple[str, str], Optional[List[Any]]] = {}
         self._disks: Dict[str, Optional[Any]] = {}
         self._storage_lifecycle: Dict[Tuple[str, str], Optional[bool]] = {}
@@ -107,6 +109,20 @@ class MockAzureClient:
 
     def get_express_route_ports(self) -> Optional[List[Any]]:
         return self._express_route_ports
+
+    def set_network_interfaces(self, interfaces: Optional[List[Any]]) -> "MockAzureClient":
+        self._all_network_interfaces = interfaces
+        return self
+
+    def get_network_interfaces(self) -> Optional[List[Any]]:
+        return self._all_network_interfaces
+
+    def set_route_tables(self, route_tables: Optional[List[Any]]) -> "MockAzureClient":
+        self._route_tables = route_tables
+        return self
+
+    def get_route_tables(self) -> Optional[List[Any]]:
+        return self._route_tables
 
     def set_managed_clusters(self, clusters: Optional[List[Any]]) -> "MockAzureClient":
         """Configure AKS inventory; ``None`` represents an API failure."""

--- a/tests/test_cis_benchmark_mapping.py
+++ b/tests/test_cis_benchmark_mapping.py
@@ -51,3 +51,18 @@ def test_all_rule_files_agree_with_the_cis_mapping_file():
             mismatches.append((rule_id, rule_cis, control["control_id"]))
 
     assert mismatches == [], f"rule_id, rule_FRAMEWORKS[CIS], json control_id: {mismatches}"
+
+
+def test_cis_mapping_has_no_legacy_tbd_control_ids():
+    """Unresolved TBD identifiers must never reach scoring or findings.
+
+    N/A-* is the explicit, reviewed representation for controls that have no
+    direct CIS recommendation; the old TBD-* prefix was only a placeholder.
+    """
+    controls = _load_controls()
+    legacy = {
+        rule_id: control["control_id"]
+        for rule_id, control in controls.items()
+        if control["control_id"].startswith("TBD-")
+    }
+    assert legacy == {}

--- a/tests/test_engine_integration.py
+++ b/tests/test_engine_integration.py
@@ -6,6 +6,8 @@ so there is no constructor injection point for a mock. These tests monkeypatch
 instantiating the engine, then exercise run_scan() end-to-end with no network.
 """
 
+from pathlib import Path
+
 import scanner.engine as engine_mod
 from scanner.engine import ScanEngine
 from tests.helpers.mock_azure import MockAzureClient, make_resource
@@ -52,6 +54,28 @@ def test_engine_loads_all_57_rules(monkeypatch):
     for rule in eng.rules:
         assert callable(getattr(rule, "scan", None))
         assert getattr(rule, "RULE_ID", None)
+
+
+def test_engine_discovery_matches_ci_and_ignores_misnamed_modules(monkeypatch, tmp_path):
+    """Only CI-validated az_*.py modules may execute at scan time."""
+    (tmp_path / "az_valid_001.py").write_text(
+        'RULE_ID = "AZ-VALID-001"\n\ndef scan(azure_client, subscription_id):\n    return []\n',
+        encoding="utf-8",
+    )
+    (tmp_path / "scratch_test.py").write_text(
+        'def scan(azure_client, subscription_id):\n    raise AssertionError("must not load")\n',
+        encoding="utf-8",
+    )
+    (tmp_path / "_network_common.py").write_text(
+        'def scan(azure_client, subscription_id):\n    raise AssertionError("must not load")\n',
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(engine_mod, "RULES_DIR", Path(tmp_path))
+    _patch_engine_client(monkeypatch, _offline_mock())
+
+    eng = ScanEngine(_SUB)
+
+    assert [rule.RULE_ID for rule in eng.rules] == ["AZ-VALID-001"]
 
 
 def test_engine_run_scan_result_is_self_consistent(monkeypatch):

--- a/tests/test_network_layer_assurance.py
+++ b/tests/test_network_layer_assurance.py
@@ -1,0 +1,137 @@
+"""Completeness and API regression tests for Network Layer assurance."""
+
+import copy
+from datetime import date
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from api.services.assurance_catalog import CatalogValidationError
+from api.services.network_layer_assurance import (
+    EXPECTED_CONTROL_IDS,
+    EXPECTED_DOMAIN_IDS,
+    EXPECTED_RULE_IDS,
+    EXPECTED_SUBDOMAIN_IDS,
+    build_report,
+    load_catalog,
+    validate_catalog,
+)
+
+
+def test_catalog_covers_all_domains_and_audits_all_network_rules():
+    catalog = load_catalog()
+    assert {item["id"] for item in catalog["domains"]} == EXPECTED_DOMAIN_IDS
+    assert {item["id"] for item in catalog["subdomains"]} == EXPECTED_SUBDOMAIN_IDS
+    assert {item["id"] for item in catalog["controls"]} == EXPECTED_CONTROL_IDS
+    assert {item["id"] for item in catalog["rule_classifications"]} == EXPECTED_RULE_IDS
+    assert all(domain["responsibility_owner"] for domain in catalog["domains"])
+    assert all(domain["azure_applicability"] for domain in catalog["domains"])
+    assert all(domain["observability_method"] for domain in catalog["domains"])
+    assert all(domain["evidence_source_ids"] for domain in catalog["domains"])
+    assert all(domain["automation_decision"] for domain in catalog["domains"])
+
+
+def test_rule_audit_matches_every_network_rule_file():
+    rules_dir = Path(__file__).resolve().parents[1] / "scanner" / "rules"
+    discovered_ids = {
+        f"AZ-NET-{path.stem.rsplit('_', 1)[1]}" for path in rules_dir.glob("az_net_[0-9][0-9][0-9].py")
+    }
+    classified_ids = {
+        item["id"] for item in load_catalog()["rule_classifications"] if item["id"].startswith("AZ-NET-")
+    }
+    assert classified_ids == discovered_ids
+
+
+def test_controls_cover_every_domain_and_subdomain():
+    catalog = load_catalog()
+    covered_domains = {domain_id for control in catalog["controls"] for domain_id in control["domain_ids"]}
+    covered_subdomains = {
+        subdomain_id for control in catalog["controls"] for subdomain_id in control["subdomain_ids"]
+    }
+    assert covered_domains == EXPECTED_DOMAIN_IDS
+    assert covered_subdomains == EXPECTED_SUBDOMAIN_IDS
+    assert all(control["evidence_source_ids"] for control in catalog["controls"])
+    assert all("scanner_rule_ids" in control for control in catalog["controls"])
+
+
+@pytest.mark.parametrize(
+    ("mutation", "error_match"),
+    [
+        (lambda catalog: catalog["domains"].pop(), "complete NL-01 through NL-20"),
+        (lambda catalog: catalog["subdomains"].pop(), "complete Layer 3 functional set"),
+        (lambda catalog: catalog["controls"].pop(), "complete NL-C01 through NL-C20"),
+        (lambda catalog: catalog["rule_classifications"].pop(), "both MACsec rules"),
+        (lambda catalog: catalog["domains"][0].pop("responsibility_owner"), "responsibility_owner"),
+        (lambda catalog: catalog["domains"][0].pop("azure_applicability"), "azure_applicability"),
+        (lambda catalog: catalog["domains"][0].pop("evidence_source_ids"), "evidence_source_ids"),
+        (lambda catalog: catalog["domains"][0].pop("automation_decision"), "automation_decision"),
+        (lambda catalog: catalog["rule_classifications"][2].pop("classification_basis"), "classification_basis"),
+    ],
+)
+def test_catalog_fails_closed_on_missing_required_content(mutation, error_match):
+    catalog = copy.deepcopy(load_catalog())
+    mutation(catalog)
+    with pytest.raises(CatalogValidationError, match=error_match):
+        validate_catalog(catalog)
+
+
+def test_port_dns_and_macsec_rules_are_not_relabelled_as_layer_3():
+    rules = {item["id"]: item for item in load_catalog()["rule_classifications"]}
+    port_rules = ("AZ-NET-001", "AZ-NET-002", "AZ-NET-003")
+    assert {rules[rule_id]["osi_classification"] for rule_id in port_rules} == {"Layer 4"}
+    assert rules["AZ-NET-015"]["osi_classification"] == "Layer 7"
+    assert rules["AZ-DL-001"]["osi_classification"] == "Layer 2"
+    assert rules["AZ-DL-002"]["osi_classification"] == "Layer 2"
+    excluded_rules = (*port_rules, "AZ-NET-015", "AZ-DL-001", "AZ-DL-002")
+    assert all(not rules[rule_id]["layer_3_domain_ids"] for rule_id in excluded_rules)
+
+
+def test_report_separates_catalog_coverage_from_evidence_freshness():
+    report = build_report(load_catalog(), as_of=date(2028, 1, 1))
+    assert report["catalog_coverage"] == {
+        "controls_covered": 20,
+        "controls_total": 20,
+        "domains_covered": 20,
+        "domains_total": 20,
+        "subdomains_covered": 5,
+        "subdomains_total": 5,
+        "percent": 100,
+    }
+    assert report["evidence_freshness"]["percent"] == 0
+    assert report["provider_assurance_state"] == "DOCUMENTED"
+    assert report["platform_enforcement_state"] == "DOCUMENTED_NOT_LIVE_INSPECTED"
+    assert report["automated_control_applicability"]["empty_inventory"] == "NOT_APPLICABLE"
+    assert report["automated_control_applicability"]["api_or_permission_failure"] == "INDETERMINATE"
+
+
+def test_network_layer_endpoint_requires_authentication(client):
+    assert client.get("/api/assurance/network-layer").status_code == 401
+
+
+def test_network_layer_endpoint_returns_complete_report(client, auth_headers):
+    response = client.get("/api/assurance/network-layer", headers=auth_headers)
+    assert response.status_code == 200
+    payload = response.get_json()
+    assert payload["layer"] == {
+        "number": 3,
+        "name": "Network",
+        "model": "OSI",
+        "assessment_type": "mixed_assurance",
+    }
+    assert payload["catalog_coverage"]["percent"] == 100
+    assert len(payload["domains"]) == 20
+    assert len(payload["subdomains"]) == 5
+    assert len(payload["controls"]) == 20
+    assert len(payload["rule_classifications"]) == 17
+
+
+def test_network_layer_endpoint_hides_catalog_errors(client, auth_headers):
+    with patch(
+        "api.routes.assurance.get_network_layer_assurance_report",
+        side_effect=CatalogValidationError("sensitive path"),
+    ):
+        response = client.get("/api/assurance/network-layer", headers=auth_headers)
+    assert response.status_code == 500
+    assert response.get_json() == {"error": "Network Layer assurance catalog is unavailable"}
+    assert "sensitive path" not in response.get_data(as_text=True)

--- a/tests/test_network_layer_assurance.py
+++ b/tests/test_network_layer_assurance.py
@@ -35,21 +35,15 @@ def test_catalog_covers_all_domains_and_audits_all_network_rules():
 
 def test_rule_audit_matches_every_network_rule_file():
     rules_dir = Path(__file__).resolve().parents[1] / "scanner" / "rules"
-    discovered_ids = {
-        f"AZ-NET-{path.stem.rsplit('_', 1)[1]}" for path in rules_dir.glob("az_net_[0-9][0-9][0-9].py")
-    }
-    classified_ids = {
-        item["id"] for item in load_catalog()["rule_classifications"] if item["id"].startswith("AZ-NET-")
-    }
+    discovered_ids = {f"AZ-NET-{path.stem.rsplit('_', 1)[1]}" for path in rules_dir.glob("az_net_[0-9][0-9][0-9].py")}
+    classified_ids = {item["id"] for item in load_catalog()["rule_classifications"] if item["id"].startswith("AZ-NET-")}
     assert classified_ids == discovered_ids
 
 
 def test_controls_cover_every_domain_and_subdomain():
     catalog = load_catalog()
     covered_domains = {domain_id for control in catalog["controls"] for domain_id in control["domain_ids"]}
-    covered_subdomains = {
-        subdomain_id for control in catalog["controls"] for subdomain_id in control["subdomain_ids"]
-    }
+    covered_subdomains = {subdomain_id for control in catalog["controls"] for subdomain_id in control["subdomain_ids"]}
     assert covered_domains == EXPECTED_DOMAIN_IDS
     assert covered_subdomains == EXPECTED_SUBDOMAIN_IDS
     assert all(control["evidence_source_ids"] for control in catalog["controls"])

--- a/tests/test_network_layer_assurance.py
+++ b/tests/test_network_layer_assurance.py
@@ -3,7 +3,8 @@
 import copy
 from datetime import date
 from pathlib import Path
-from unittest.mock import patch
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -123,7 +124,7 @@ def test_network_layer_endpoint_returns_complete_report(client, auth_headers):
     assert len(payload["domains"]) == 20
     assert len(payload["subdomains"]) == 5
     assert len(payload["controls"]) == 20
-    assert len(payload["rule_classifications"]) == 17
+    assert len(payload["rule_classifications"]) == 19
 
 
 def test_network_layer_endpoint_hides_catalog_errors(client, auth_headers):
@@ -135,3 +136,24 @@ def test_network_layer_endpoint_hides_catalog_errors(client, auth_headers):
     assert response.status_code == 500
     assert response.get_json() == {"error": "Network Layer assurance catalog is unavailable"}
     assert "sensitive path" not in response.get_data(as_text=True)
+
+
+def test_layer_3_inventory_uses_azure_client_abstraction():
+    from scanner.azure_client import AzureClient
+
+    sdk_client = MagicMock()
+    sdk_client.network_interfaces.list_all.return_value = [SimpleNamespace(name="nic1")]
+    sdk_client.route_tables.list_all.return_value = [SimpleNamespace(name="rt1")]
+    with patch("scanner.azure_client.NetworkManagementClient", return_value=sdk_client):
+        azure_client = AzureClient("sub-1", credential=MagicMock())
+        assert [nic.name for nic in azure_client.get_network_interfaces()] == ["nic1"]
+        assert [table.name for table in azure_client.get_route_tables()] == ["rt1"]
+
+
+def test_layer_3_inventory_preserves_api_failure():
+    from scanner.azure_client import AzureClient
+
+    with patch("scanner.azure_client.NetworkManagementClient", side_effect=PermissionError("denied")):
+        azure_client = AzureClient("sub-1", credential=MagicMock())
+        assert azure_client.get_network_interfaces() is None
+        assert azure_client.get_route_tables() is None

--- a/tests/test_rules_network.py
+++ b/tests/test_rules_network.py
@@ -1,4 +1,4 @@
-"""Rule regression tests for the network rules AZ-NET-001 .. AZ-NET-015.
+"""Rule regression tests for the network rules AZ-NET-001 .. AZ-NET-017.
 
 AZ-NET-007/009/010 construct a NetworkManagementClient inside scan(); those
 tests monkeypatch azure.mgmt.network.NetworkManagementClient. The rest read data
@@ -24,6 +24,8 @@ import scanner.rules.az_net_012 as az_net_012
 import scanner.rules.az_net_013 as az_net_013
 import scanner.rules.az_net_014 as az_net_014
 import scanner.rules.az_net_015 as az_net_015
+import scanner.rules.az_net_016 as az_net_016
+import scanner.rules.az_net_017 as az_net_017
 from tests.helpers.mock_azure import make_resource
 
 try:
@@ -673,3 +675,69 @@ def test_net_015_skips_private_zone(mock_azure, subscription_id):
         ],
     )
     assert az_net_015.scan(mock_azure, subscription_id) == []
+
+
+# ── AZ-NET-016: NIC IP forwarding ──────────────────────────────────────────
+
+
+def test_net_016_empty_and_failed_inventory_create_no_findings(mock_azure, subscription_id):
+    mock_azure.set_network_interfaces([])
+    assert az_net_016.scan(mock_azure, subscription_id) == []
+    mock_azure.set_network_interfaces(None)
+    assert az_net_016.scan(mock_azure, subscription_id) == []
+
+
+def test_net_016_disabled_ip_forwarding_is_compliant(mock_azure, subscription_id):
+    mock_azure.set_network_interfaces(
+        [
+            make_resource(
+                id="/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/networkInterfaces/nic1",
+                name="nic1",
+                enable_ip_forwarding=False,
+            )
+        ]
+    )
+    assert az_net_016.scan(mock_azure, subscription_id) == []
+
+
+def test_net_016_enabled_ip_forwarding_creates_finding(mock_azure, subscription_id):
+    nic_id = "/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/networkInterfaces/nic1"
+    mock_azure.set_network_interfaces([make_resource(id=nic_id, name="nic1", enable_ip_forwarding=True)])
+    findings = az_net_016.scan(mock_azure, subscription_id)
+    assert len(findings) == 1
+    assert findings[0]["rule_id"] == "AZ-NET-016"
+    assert findings[0]["metadata"]["requires_routing_function_review"] is True
+
+
+# ── AZ-NET-017: direct Internet default UDR ─────────────────────────────────
+
+
+def test_net_017_empty_and_failed_inventory_create_no_findings(mock_azure, subscription_id):
+    mock_azure.set_route_tables([])
+    assert az_net_017.scan(mock_azure, subscription_id) == []
+    mock_azure.set_route_tables(None)
+    assert az_net_017.scan(mock_azure, subscription_id) == []
+
+
+def test_net_017_private_route_and_inspected_default_are_compliant(mock_azure, subscription_id):
+    routes = [
+        make_resource(name="private", address_prefix="10.0.0.0/8", next_hop_type="Internet"),
+        make_resource(name="default", address_prefix="0.0.0.0/0", next_hop_type="VirtualAppliance"),
+    ]
+    mock_azure.set_route_tables([make_resource(id="/routeTables/rt1", name="rt1", routes=routes)])
+    assert az_net_017.scan(mock_azure, subscription_id) == []
+
+
+@pytest.mark.parametrize("prefix", ["0.0.0.0/0", "::/0"])
+def test_net_017_direct_internet_default_creates_finding(mock_azure, subscription_id, prefix):
+    route = make_resource(
+        id="/routeTables/rt1/routes/default",
+        name="default",
+        address_prefix=prefix,
+        next_hop_type="Internet",
+    )
+    mock_azure.set_route_tables([make_resource(id="/routeTables/rt1", name="rt1", routes=[route])])
+    findings = az_net_017.scan(mock_azure, subscription_id)
+    assert len(findings) == 1
+    assert findings[0]["rule_id"] == "AZ-NET-017"
+    assert findings[0]["metadata"]["address_prefix"] == prefix


### PR DESCRIPTION
## Summary

Adds Azure public-cloud Network Layer assurance with complete addressing, routing, transit, protection, and observability coverage plus customer-actionable Layer 3 routing checks.

## What changed

- Added a validated catalog covering all 20 Layer 3 domains and five functional subdomains.
- Added one explicit assurance control for every Layer 3 domain.
- Added authenticated `GET /api/assurance/network-layer` reporting with separate catalog coverage and evidence freshness.
- Audited every `AZ-NET-*` scanner rule by its actual OSI behavior.
- Preserved port-specific NSG checks as Layer 4, DNS and WAF controls as Layer 7, and ExpressRoute Direct MACsec checks as Layer 2.
- Added `AZ-NET-016` for network interfaces with IP forwarding enabled.
- Added `AZ-NET-017` for explicit IPv4 or IPv6 default user-defined routes using the direct Internet next hop.
- Added safe remediation playbooks, all four framework mappings, and offline compliant, non-compliant, empty-inventory, and API-failure tests for both rules.
- Preserved empty inventory as not applicable and Azure API or permission failures as indeterminate without false findings.
- Added closed validation for domains, subdomains, controls, responsibility, applicability, evidence, verification state, and rule classifications.
- Resolved #244 by aligning runtime rule discovery with CI validation and adding a regression guard against misnamed rule modules.
- Made no frontend changes and did not score provider-owned controls.

## CIS mapping decisions

All CIS mappings were audited against CIS Microsoft Azure Foundations Benchmark 2.0.0. `AZ-KV-006` now maps to the genuine RBAC recommendation 8.6, while `AZ-KV-004` maps to recoverability recommendation 8.5. Rules without a direct benchmark recommendation use rule-specific `N/A-*` identifiers instead of unresolved `TBD-*` placeholders.

`N/A` is an explicit reviewed decision: it prevents OpenShield from claiming that a rule implements an unrelated CIS recommendation and preserves the repository invariant that each numbered CIS control maps to one OpenShield rule. This includes the Layer 3 routing checks, Layer 2 MACsec checks, application identity checks, supply-chain checks, the overlapping Key Vault soft-delete prerequisite, and the proactive 30-day certificate-renewal check.

## Verification

- Backend suite: 556 passed, 2 skipped.
- Layer 3 assurance and network rule regression tests pass.
- Ruff check passes.
- Bandit reports no high-severity issues.
- DCO verification passes for all commits.
- Python compilation, compliance JSON validation, and playbook shell syntax pass.
- Microsoft evidence links resolve successfully.

## Type of change

- [x] New scan rules
- [x] Remediation playbooks
- [x] API endpoint
- [x] Assurance catalog
- [x] Rule classification audit
- [x] Scanner discovery fix
- [x] Documentation
- [x] Compliance mappings

## Testing

- [ ] Tested against a real Azure free trial subscription
- [x] Returns correct JSON output
- [x] Local CI-equivalent backend checks pass
- [x] No hardcoded credentials or secrets

## Checklist

- [x] Every commit includes a DCO `Signed-off-by` trailer
- [x] Every Layer 3 domain and subdomain is covered
- [x] Every existing and new `AZ-NET-*` rule is classified
- [x] Runtime and CI use the same rule-discovery convention
- [x] Non-Layer 3 rules retain their correct OSI classification
- [x] Empty inventory and API failures do not create findings
- [x] No speculative provider-fabric findings were introduced
- [x] No real Azure credentials are committed
- [x] Branch name follows the project convention

## Related issues

- Closes #248 — complete OSI Network Layer assurance and Azure Layer 3 checks.
- Resolves #244 — align scanner runtime discovery with CI validation and rule counts.

## Files to review

The main implementation can be reviewed in this order:

1. `compliance/assurance/network_layer.json` — complete Layer 3 catalog, controls, evidence, automation decisions, and OSI classifications.
2. `api/services/network_layer_assurance.py` — closed validation and report generation.
3. `scanner/rules/az_net_016.py` and `scanner/rules/az_net_017.py` — new actionable Layer 3 checks.
4. `scanner/azure_client.py` — authoritative NIC and route-table inventory accessors.
5. `tests/test_network_layer_assurance.py` and `tests/test_rules_network.py` — catalog, endpoint, rule, empty-inventory, and failure-path coverage.
6. `playbooks/cli/fix_az_net_016.sh` and `playbooks/cli/fix_az_net_017.sh` — confirmation-based remediation.
7. `compliance/frameworks/*.json` — CIS, NIST, ISO 27001, and SOC 2 mappings.
8. `scanner/engine.py`, `.github/workflows/ci.yml`, and `tests/test_engine_integration.py` — #244 rule-discovery fix and regression guard.
9. `docs/network-layer-assurance.md` and `CHANGELOG.md` — responsibility boundary, limitations, and release entry.
