### PR TITLE
feat(scanner): add enterprise security operations rules

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,10 @@ FROM python:3.11-slim-trixie
 
 WORKDIR /app
 
+RUN apt-get update \
+    && apt-get dist-upgrade -y \
+    && rm -rf /var/lib/apt/lists/*
+
 COPY requirements.txt .
 RUN pip install --no-cache-dir --upgrade \
         pip==26.1.2 \

--- a/compliance/frameworks/cis_azure_benchmark.json
+++ b/compliance/frameworks/cis_azure_benchmark.json
@@ -352,6 +352,56 @@
       "control_id": "N/A-NET-017",
       "control_name": "Direct Internet default route review (no direct CIS Azure Foundations 2.0.0 control)",
       "description": "Azure exposes and documents user-defined Internet next hops, but CIS Azure Foundations 2.0.0 does not assign this route check a direct recommendation number."
+    },
+    "AZ-SECOPS-001": {
+      "control_id": "5.1.1",
+      "control_name": "Ensure that a 'Diagnostic Setting' exists",
+      "description": "The subscription's Activity Log has no diagnostic setting exporting it to an organisation-approved central destination. CIS 5.1.1 requires a diagnostic setting exporting the Activity Log so administrative, security, and policy events are retained beyond the platform default and available for centralized analysis."
+    },
+    "AZ-SECOPS-002": {
+      "control_id": "5.1.2",
+      "control_name": "Ensure Diagnostic Setting captures appropriate categories",
+      "description": "An Activity Log diagnostic setting exists but does not enable every required category (Administrative, Security, Policy, ServiceHealth). CIS 5.1.2 requires the diagnostic setting to capture all appropriate categories, not just an arbitrary subset."
+    },
+    "AZ-SECOPS-003": {
+      "control_id": "5.4",
+      "control_name": "Ensure that Azure Monitor Resource Logging is Enabled for All Services that Support it",
+      "description": "A critical resource (as defined by the organisation's security-operations policy) has no diagnostic setting exporting to an approved destination. CIS 5.4 requires resource-level logging to be enabled for all services that support it so activity on individual resources is captured, not just subscription-level events."
+    },
+    "AZ-SECOPS-004": {
+      "control_id": "N/A-SECOPS-004",
+      "control_name": "Security log retention below organisation minimum",
+      "description": "A Storage Account log export's retention_policy is disabled or set below the organisation's minimum retention requirement. The CIS Azure Foundations Benchmark addresses diagnostic-setting existence (5.1.1) and category coverage (5.1.2) as distinct numbered controls but does not assign its own control ID to the specific retention-duration value, so no single CIS control maps 1:1 to this rule."
+    },
+    "AZ-SECOPS-005": {
+      "control_id": "N/A-SECOPS-005",
+      "control_name": "Security logs stored only in a workload-administrator-modifiable destination",
+      "description": "A critical resource's only log export destination sits in the same resource group as the workload, so an administrator of that workload can alter or delete the exported logs. The CIS Azure Foundations Benchmark does not have a numbered control for log-destination ownership or tamper-protection separation of duties."
+    },
+    "AZ-SECOPS-006": {
+      "control_id": "N/A-SECOPS-006",
+      "control_name": "Required Microsoft Defender for Cloud plan not enabled",
+      "description": "An organisation-required Microsoft Defender for Cloud plan is not set to the 'Standard' pricing tier. CIS assigns each Defender plan its own leaf control (e.g. 2.1.1 Servers, 2.1.7 Storage, 2.1.4 Azure SQL Databases); because this rule evaluates whichever plans the organisation configures as required, no single fixed CIS control ID applies at the rule level (the matching per-plan CIS control is recorded on each finding's metadata instead)."
+    },
+    "AZ-SECOPS-007": {
+      "control_id": "2.1.13",
+      "control_name": "Ensure that Microsoft Defender Recommendation for 'Apply system updates' status is 'Completed'",
+      "description": "A High-severity Microsoft Defender for Cloud recommendation remains Unhealthy beyond the organisation's remediation SLA. CIS 2.1.13 requires Defender recommendations to reach a 'Completed'/remediated status rather than being left open indefinitely; this rule generalizes that expectation to all High-severity recommendations against an organisation-defined SLA rather than only the update-management recommendation."
+    },
+    "AZ-SECOPS-008": {
+      "control_id": "N/A-SECOPS-008",
+      "control_name": "Required Microsoft Sentinel data connector disconnected or unhealthy",
+      "description": "A required Microsoft Sentinel data connector is missing or has no enabled data type on a Sentinel-onboarded workspace. The CIS Azure Foundations Benchmark is an infrastructure-configuration benchmark and does not include SIEM/XDR operational controls such as Sentinel connector health."
+    },
+    "AZ-SECOPS-009": {
+      "control_id": "N/A-SECOPS-009",
+      "control_name": "Sentinel missing required high-severity analytics coverage",
+      "description": "A Sentinel-onboarded workspace has no enabled High-severity analytics rule covering an organisation-required detection use case. The CIS Azure Foundations Benchmark does not evaluate SIEM detection content or analytics coverage."
+    },
+    "AZ-SECOPS-010": {
+      "control_id": "2.1.20",
+      "control_name": "Ensure That 'Notify about alerts with the following severity' is Set to 'High'",
+      "description": "No enabled Azure Monitor action group with a notification receiver exists, and no Sentinel automation rule routes incidents onward. CIS 2.1.20 requires Defender security alerts to notify a monitored destination; this rule generalizes that requirement to the concrete Azure notification primitive (action groups) and the Sentinel-native incident routing mechanism (automation rules)."
     }
   }
 }

--- a/compliance/frameworks/iso27001.json
+++ b/compliance/frameworks/iso27001.json
@@ -352,6 +352,56 @@
       "control_id": "A.13.1.1",
       "control_name": "Network controls",
       "description": "Default routes must preserve the approved controlled egress boundary."
+    },
+    "AZ-SECOPS-001": {
+      "control_id": "A.12.4.1",
+      "control_name": "Event logging",
+      "description": "The subscription's Activity Log is not exported to an approved central destination. A.12.4.1 requires event logs recording user activities, exceptions, faults, and information security events to be produced, kept, and regularly reviewed; a log that is never centrally exported cannot be reviewed or retained beyond the platform default."
+    },
+    "AZ-SECOPS-002": {
+      "control_id": "A.12.4.1",
+      "control_name": "Event logging",
+      "description": "The Activity Log export omits organisation-required categories (Administrative, Security, Policy, ServiceHealth). A.12.4.1 requires event logging to capture the events relevant to information security; a partial category export leaves gaps in the recorded evidence base."
+    },
+    "AZ-SECOPS-003": {
+      "control_id": "A.12.4.1",
+      "control_name": "Event logging",
+      "description": "A critical resource has no diagnostic setting exporting to an approved destination. A.12.4.1 requires event logs to be produced for systems, and resource-level activity that is never logged cannot support later review, investigation, or evidence of misuse."
+    },
+    "AZ-SECOPS-004": {
+      "control_id": "A.12.4.1",
+      "control_name": "Event logging",
+      "description": "A security-relevant log export's retention is below the organisation's minimum. A.12.4.1 requires logs to be kept for an agreed period; retention that expires before an incident is discovered defeats the control's purpose of supporting later investigation."
+    },
+    "AZ-SECOPS-005": {
+      "control_id": "A.12.4.2",
+      "control_name": "Protection of log information",
+      "description": "A critical resource's only log export sits in a destination the workload's own administrators can modify. A.12.4.2 requires logging facilities and log information to be protected against tampering and unauthorised access, including by administrators of the systems being logged, which this single-destination, same-resource-group export does not achieve."
+    },
+    "AZ-SECOPS-006": {
+      "control_id": "A.12.6.1",
+      "control_name": "Management of technical vulnerabilities",
+      "description": "A required Microsoft Defender for Cloud plan is not enabled for a critical workload type. A.12.6.1 requires timely information about technical vulnerabilities to be obtained and the organisation's exposure evaluated; Defender for Cloud is the Azure-native control providing that vulnerability and threat information, and an unlicensed workload type receives none of it."
+    },
+    "AZ-SECOPS-007": {
+      "control_id": "A.12.6.1",
+      "control_name": "Management of technical vulnerabilities",
+      "description": "A High-severity Defender recommendation remains unresolved beyond the organisation's SLA. A.12.6.1 requires timely action to address identified technical vulnerabilities according to the organisation's associated risk; an SLA breach on a High-severity item is direct evidence that this control's timeliness requirement was not met."
+    },
+    "AZ-SECOPS-008": {
+      "control_id": "A.12.4.1",
+      "control_name": "Event logging",
+      "description": "A required Sentinel data connector is missing or unhealthy on an onboarded workspace. A.12.4.1 requires the systems that generate security-relevant events to have their logs actually collected; a disconnected connector means the corresponding event source produces no logs for the SIEM to review."
+    },
+    "AZ-SECOPS-009": {
+      "control_id": "A.12.4.1",
+      "control_name": "Event logging",
+      "description": "Sentinel lacks enabled High-severity analytics coverage for a required detection use case. A.12.4.1's objective of recording and reviewing security-relevant events is not met when the events are ingested but no analytics rule evaluates them for the specific threat pattern the organisation has identified as high-risk."
+    },
+    "AZ-SECOPS-010": {
+      "control_id": "A.16.1.2",
+      "control_name": "Reporting information security events",
+      "description": "No monitored destination exists for security alerts or Sentinel incidents. A.16.1.2 requires information security events to be reported through appropriate management channels as quickly as possible; an alert with no notified recipient cannot be reported or acted on."
     }
   }
 }

--- a/compliance/frameworks/nist_csf.json
+++ b/compliance/frameworks/nist_csf.json
@@ -352,6 +352,56 @@
       "control_id": "PR.AC-5",
       "control_name": "Network integrity is protected",
       "description": "An explicit default Internet UDR can bypass the approved inspected egress path."
+    },
+    "AZ-SECOPS-001": {
+      "control_id": "PR.PT-1",
+      "control_name": "Audit/log records are determined, documented, implemented, and reviewed in accordance with policy",
+      "description": "The subscription's Activity Log is not exported to an approved central destination. PR.PT-1 requires audit/log records to be implemented in accordance with policy; an unexported Activity Log is not available to the review process the policy requires."
+    },
+    "AZ-SECOPS-002": {
+      "control_id": "PR.PT-1",
+      "control_name": "Audit/log records are determined, documented, implemented, and reviewed in accordance with policy",
+      "description": "Required Activity Log categories are missing from the central export. PR.PT-1 requires audit/log records to be determined and implemented per policy; an export missing organisation-required categories does not implement the full policy-defined log scope."
+    },
+    "AZ-SECOPS-003": {
+      "control_id": "DE.AE-3",
+      "control_name": "Event data are collected and correlated from multiple sources and sensors",
+      "description": "A critical resource lacks diagnostic settings exporting to an approved destination. DE.AE-3 requires event data to be collected and correlated from multiple sources; a critical resource with no export is a source contributing no data to that correlation."
+    },
+    "AZ-SECOPS-004": {
+      "control_id": "PR.PT-1",
+      "control_name": "Audit/log records are determined, documented, implemented, and reviewed in accordance with policy",
+      "description": "A security-relevant log export's retention is below the organisation's minimum. PR.PT-1 requires audit/log records to be reviewed in accordance with policy, which presumes the records still exist at review time; retention shorter than the policy's minimum breaks that assumption."
+    },
+    "AZ-SECOPS-005": {
+      "control_id": "PR.DS-6",
+      "control_name": "Integrity checking mechanisms are used to verify software, firmware, and information integrity",
+      "description": "A critical resource's only log export sits in a destination its own workload administrators can modify. PR.DS-6 requires integrity-checking mechanisms to verify information integrity; a single, workload-owned destination provides no independent verification that the exported logs have not been altered or deleted by the resource's own administrators."
+    },
+    "AZ-SECOPS-006": {
+      "control_id": "DE.CM-8",
+      "control_name": "Vulnerability scans are performed",
+      "description": "A required Microsoft Defender for Cloud plan is not enabled for a critical workload type. DE.CM-8 requires vulnerability scans to be performed; Defender for Cloud performs this scanning for the workload types it protects, and an unlicensed type receives no such scanning."
+    },
+    "AZ-SECOPS-007": {
+      "control_id": "RS.MI-3",
+      "control_name": "Newly identified vulnerabilities are mitigated or documented as accepted risks",
+      "description": "A High-severity Defender recommendation remains unresolved beyond the organisation's SLA. RS.MI-3 requires newly identified vulnerabilities to be mitigated or documented as accepted risk; an SLA breach with no recorded exception means neither has happened."
+    },
+    "AZ-SECOPS-008": {
+      "control_id": "DE.AE-3",
+      "control_name": "Event data are collected and correlated from multiple sources and sensors",
+      "description": "A required Sentinel data connector is missing or unhealthy. DE.AE-3 requires event data to be collected and correlated from multiple sources and sensors; a disconnected connector is a required sensor that is not contributing data."
+    },
+    "AZ-SECOPS-009": {
+      "control_id": "DE.CM-1",
+      "control_name": "The network is monitored to detect potential cybersecurity events",
+      "description": "Sentinel lacks enabled High-severity analytics coverage for a required detection use case. DE.CM-1 requires the network to be monitored to detect potential cybersecurity events; ingested logs with no analytics rule evaluating them for a known high-risk pattern do not achieve that monitoring outcome for that use case."
+    },
+    "AZ-SECOPS-010": {
+      "control_id": "RS.CO-2",
+      "control_name": "Incidents are reported consistent with established criteria",
+      "description": "No monitored destination exists for security alerts or Sentinel incidents. RS.CO-2 requires incidents to be reported consistent with established criteria; an alert with no notified recipient is never reported to anyone who can act on it."
     }
   }
 }

--- a/compliance/frameworks/soc2.json
+++ b/compliance/frameworks/soc2.json
@@ -352,6 +352,56 @@
       "control_id": "CC6.6",
       "control_name": "Logical Access Security Measures",
       "description": "User-defined default routes preserve approved inspected egress paths."
+    },
+    "AZ-SECOPS-001": {
+      "control_id": "CC7.2",
+      "control_name": "System Monitoring",
+      "description": "The subscription's Activity Log is not exported to an approved central destination. CC7.2 requires the entity to monitor system components for anomalies; an unexported Activity Log removes the raw evidence that monitoring depends on."
+    },
+    "AZ-SECOPS-002": {
+      "control_id": "CC7.2",
+      "control_name": "System Monitoring",
+      "description": "Required Activity Log categories are missing from the central export. CC7.2 requires monitoring to cover the events relevant to detecting security anomalies; a partial category export leaves gaps in what can be monitored."
+    },
+    "AZ-SECOPS-003": {
+      "control_id": "CC7.2",
+      "control_name": "System Monitoring",
+      "description": "A critical resource lacks diagnostic settings exporting to an approved destination. CC7.2 requires monitoring of infrastructure and software for anomalies; a critical resource with no export is not being monitored at all."
+    },
+    "AZ-SECOPS-004": {
+      "control_id": "CC7.2",
+      "control_name": "System Monitoring",
+      "description": "A security-relevant log export's retention is below the organisation's minimum. CC7.2's monitoring objective depends on evidence remaining available long enough to detect and investigate anomalies; retention below the organisation's minimum shortens that window."
+    },
+    "AZ-SECOPS-005": {
+      "control_id": "CC7.2",
+      "control_name": "System Monitoring",
+      "description": "A critical resource's only log export sits in a destination its own workload administrators can modify. CC7.2 requires monitoring information to be reliable; a destination the monitored workload's own administrators can alter undermines that reliability."
+    },
+    "AZ-SECOPS-006": {
+      "control_id": "CC7.1",
+      "control_name": "Detection and Monitoring of New Vulnerabilities",
+      "description": "A required Microsoft Defender for Cloud plan is not enabled for a critical workload type. CC7.1 requires the entity to use detection and monitoring procedures to identify changes and vulnerabilities; Defender for Cloud is the mechanism providing that detection for the affected workload type."
+    },
+    "AZ-SECOPS-007": {
+      "control_id": "CC7.1",
+      "control_name": "Detection and Monitoring of New Vulnerabilities",
+      "description": "A High-severity Defender recommendation remains unresolved beyond the organisation's SLA. CC7.1 requires identified vulnerabilities to be evaluated and addressed; an SLA breach indicates the vulnerability-management process required by CC7.1 is not operating effectively."
+    },
+    "AZ-SECOPS-008": {
+      "control_id": "CC7.2",
+      "control_name": "System Monitoring",
+      "description": "A required Sentinel data connector is missing or unhealthy. CC7.2 requires monitoring of system components for anomalies; a disconnected connector is a monitored source that has stopped contributing data without detection."
+    },
+    "AZ-SECOPS-009": {
+      "control_id": "CC7.2",
+      "control_name": "System Monitoring",
+      "description": "Sentinel lacks enabled High-severity analytics coverage for a required detection use case. CC7.2 requires monitoring to actually evaluate collected data for anomalies; ingested logs with no analytics rule evaluating a known high-risk pattern do not fulfil that requirement for that use case."
+    },
+    "AZ-SECOPS-010": {
+      "control_id": "CC7.4",
+      "control_name": "Incident Response",
+      "description": "No monitored destination exists for security alerts or Sentinel incidents. CC7.4 requires the entity to respond to identified security incidents; an alert nobody is notified of cannot trigger the incident-response process CC7.4 requires."
     }
   }
 }

--- a/config/security-operations-policy.example.json
+++ b/config/security-operations-policy.example.json
@@ -1,0 +1,32 @@
+{
+  "critical_resource_types": [
+    "Microsoft.KeyVault/vaults",
+    "Microsoft.Sql/servers",
+    "Microsoft.Storage/storageAccounts"
+  ],
+  "approved_destination_ids": [
+    "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/security/providers/Microsoft.OperationalInsights/workspaces/central-security"
+  ],
+  "required_activity_categories": [
+    "Administrative",
+    "Security",
+    "Policy",
+    "ServiceHealth"
+  ],
+  "minimum_retention_days": 90,
+  "required_defender_plans": [
+    "VirtualMachines",
+    "StorageAccounts",
+    "SqlServers"
+  ],
+  "defender_recommendation_sla_days": 30,
+  "required_sentinel_connectors": [
+    "AzureActiveDirectory",
+    "AzureSecurityCenter"
+  ],
+  "required_high_severity_analytics": [
+    "privileged-role-change",
+    "credential-abuse"
+  ],
+  "approved_exclusions": []
+}

--- a/docs/security-operations-rules.md
+++ b/docs/security-operations-rules.md
@@ -1,23 +1,192 @@
 # Enterprise Security Operations Rules
 
-Issue #262 adds logging, Defender for Cloud, and Microsoft Sentinel controls. The first implementation phase establishes policy and evidence collection without inventing organisation-specific security requirements.
+Issue #262 adds logging, Microsoft Defender for Cloud, and Microsoft Sentinel operational-health
+controls. The foundation phase established policy and evidence collection without inventing
+organisation-specific security requirements; this phase adds the ten evaluation rules built on
+top of that foundation.
+
+## Coverage
+
+| Rule | Control |
+|---|---|
+| `AZ-SECOPS-001` | Subscription activity log not exported to an approved central destination |
+| `AZ-SECOPS-002` | Required activity-log categories missing from the central export |
+| `AZ-SECOPS-003` | Critical resource missing required diagnostic settings |
+| `AZ-SECOPS-004` | Security logs have insufficient retention |
+| `AZ-SECOPS-005` | Security logs stored only in a destination modifiable by workload administrators |
+| `AZ-SECOPS-006` | Required Microsoft Defender for Cloud plan not enabled |
+| `AZ-SECOPS-007` | High-risk Defender recommendation unresolved beyond SLA |
+| `AZ-SECOPS-008` | Required Microsoft Sentinel data connector disconnected or unhealthy |
+| `AZ-SECOPS-009` | Sentinel missing required high-severity analytics coverage |
+| `AZ-SECOPS-010` | Security alerts have no monitored incident-response destination |
 
 ## Policy boundary
 
-`config/security-operations-policy.example.json` documents every value that an organisation must approve: critical resource types, central destinations, activity-log categories, retention, Defender plans and SLA, Sentinel connectors and analytics coverage, and exclusions. The example is not a production baseline and is never loaded automatically.
+`config/security-operations-policy.example.json` documents every value that an organisation must
+approve: critical resource types, central destinations, activity-log categories, retention,
+Defender plans and SLA, Sentinel connectors and analytics coverage, and exclusions. The example is
+not a production baseline and is never loaded automatically.
+
+Every AZ-SECOPS rule reads its policy from the file named by the
+`OPENSHIELD_SECURITY_OPERATIONS_POLICY` environment variable. If the variable is unset, the
+referenced file is missing, or the file fails `load_security_operations_policy`'s strict
+validation, the rule logs a warning and returns no findings — an unapproved policy can never
+produce a compliance claim in either direction. Operators must set this variable to their
+organisation's own policy file (never the example file) before running these ten rules.
+
+## Sentinel scope: auto-discovered, not configured
+
+Microsoft Sentinel workspace scope is **discovered at scan time**, not named in the policy file.
+Every Log Analytics workspace in the subscription is enumerated
+(`LogAnalyticsManagementClient.workspaces.list()`, genuinely subscription-wide), and each
+workspace's Sentinel onboarding state is checked individually
+(`SecurityInsights.sentinel_onboarding_states.list(resource_group, workspace_name)`, which is not
+subscription-wide — Sentinel's SDK requires a resource group and workspace name for every
+operation). Only workspaces confirmed onboarded are queried for data connectors, analytics rules,
+and automation rules. This means a newly onboarded Sentinel workspace is covered automatically on
+the next scan with no policy change required.
+
+## Outcome model
+
+Issue #262 requires a four-state PASS/FAIL/UNKNOWN/NOT_APPLICABLE outcome per control, but
+`scanner/engine.py` only consumes a findings list and treats *presence of a finding* as the sole
+non-compliance signal (it feeds the list directly into severity-weighted scoring). All ten rules
+therefore represent the outcomes as follows, matching the existing convention already used by
+`az_dl_001`/`az_dl_002` and `az_kv_003`:
+
+- **PASS** — an empty list. No finding is emitted for a compliant resource.
+- **NOT_APPLICABLE** — an empty list plus an `INFO`-level log line (e.g. no critical resources in
+  scope, no Sentinel-onboarded workspaces, no required plans/connectors/analytics configured).
+- **UNKNOWN** — an empty list plus a `WARNING`-level log line. Any collector failure — a missing
+  policy, a permission error, an inaccessible workspace, a failed Defender/Sentinel API call — is
+  UNKNOWN and is never promoted to FAIL or silently treated as PASS.
+- **FAIL** — the only outcome that produces a finding dict, and only with positive evidence of a
+  missing or unsafe control (e.g. an actual diagnostic setting missing an approved destination, an
+  actual disabled Defender plan, an actual disconnected connector).
+
+This is a real, structural limitation of the current engine contract: NOT_APPLICABLE and UNKNOWN
+are not individually addressable as distinct dict rows the way FAIL findings are. The richer
+per-finding metadata issue #262 also asks for — scope, category, destination, retention,
+ownership, evidence timestamp, remediation, permissions required, severity, confidence, and an
+`unknown_reason` field — is carried on every FAIL finding's `metadata` dict so downstream tooling
+can still see "why," even though that metadata cannot currently attach to an outcome that produces
+no finding at all. Changing `engine.py`'s contract to add first-class UNKNOWN/NOT_APPLICABLE rows
+was out of scope for this change and would affect every existing rule, not just these ten.
+
+## Rule details
+
+### AZ-SECOPS-001 — Subscription activity log not exported
+
+Checks the subscription's `subscription_diagnostic_settings` for at least one setting whose
+`workspace_id`, `storage_account_id`, or `event_hub_authorization_rule_id` matches
+`approved_destination_ids`. No approved-destination match is a HIGH finding.
+
+### AZ-SECOPS-002 — Required activity-log categories missing
+
+Given at least one approved-destination export exists (otherwise AZ-SECOPS-001 owns the finding),
+checks that every category in `required_activity_categories` appears as an *enabled* `LogSettings`
+entry on an approved-destination setting. A disabled category counts as missing.
+
+### AZ-SECOPS-003 — Critical resource missing required diagnostic settings
+
+For every resource ID returned by `critical_resource_ids(policy)` (minus `approved_exclusions`),
+checks `resource_diagnostic_settings` for at least one setting reaching an approved destination.
+
+### AZ-SECOPS-004 — Security logs have insufficient retention
+
+For each critical resource's diagnostic settings that target a Storage Account destination,
+checks that every enabled log's `retention_policy` is enabled with `days >= minimum_retention_days`.
+Log Analytics workspace retention is a workspace-level setting, not a `retention_policy` field on
+the diagnostic setting, and is intentionally out of scope for this rule.
+
+### AZ-SECOPS-005 — Security logs stored only in a workload-administrator-modifiable destination
+
+For each critical resource with a diagnostic export that is **not** on the approved-destination
+list, checks whether every configured destination's resource group matches the workload resource's
+own resource group. If so, an administrator with Contributor/Owner on that resource group can
+modify or delete the exported logs. This is a resource-group/ownership comparison — the Monitor
+diagnostic-settings API does not expose a destination's own access-control or immutability
+configuration, so this rule cannot verify an actual Storage immutability policy directly.
+
+### AZ-SECOPS-006 — Required Defender for Cloud plan not enabled
+
+Checks `Microsoft.Security/pricings` (subscription scope) for each plan named in
+`required_defender_plans`; a plan whose `pricing_tier` is not `Standard` is a HIGH finding. Each
+finding records the matching CIS Azure Foundations Benchmark leaf control for that specific plan
+(e.g. 2.1.7 for StorageAccounts) in `metadata.cis_control_reference`, since the rule itself is
+policy-driven across whichever plans the organisation names and has no single fixed CIS mapping.
+
+### AZ-SECOPS-007 — High-risk Defender recommendation unresolved beyond SLA
+
+Checks `Microsoft.Security/assessments` for entries with `metadata.severity == High` and
+`status.code == Unhealthy`. Age is computed from a first-observed timestamp read defensively from
+the assessment's `additional_data` map (the SDK's typed `AssessmentStatusResponse` model exposes
+no timestamp field at all). An assessment with no recognised timestamp key is excluded from this
+rule's findings — its age is genuinely unknown and is never assumed to be either compliant or
+overdue.
+
+### AZ-SECOPS-008 — Required Sentinel data connector disconnected or unhealthy
+
+For each Sentinel-onboarded workspace, checks `data_connectors.list` for every connector kind in
+`required_sentinel_connectors`. A connector is "connected" when present with at least one enabled
+`data_types` entry (or when its connector kind exposes no typed `data_types` field at all, in
+which case presence is the only available signal). Missing or fully-disabled connectors are HIGH
+findings, distinguished as `missing` vs. `disconnected` in `metadata.connector_state`.
+
+### AZ-SECOPS-009 — Sentinel missing required high-severity analytics coverage
+
+For each Sentinel-onboarded workspace, checks `alert_rules.list` for an **enabled** scheduled rule
+with `severity == High` whose `display_name` matches (case/separator-insensitive substring) each
+use case in `required_high_severity_analytics`. A disabled rule, a wrong-severity rule, or no
+matching rule at all is a HIGH finding.
+
+### AZ-SECOPS-010 — Security alerts have no monitored incident-response destination
+
+Checks Azure Monitor `action_groups.list_by_subscription_id()` for at least one **enabled** action
+group with at least one receiver (email, SMS, voice, webhook, ITSM, Logic App, Automation
+runbook, Azure Function, or Event Hub). If none exists, checks whether any Sentinel-onboarded
+workspace has at least one automation rule (Sentinel's native incident-routing mechanism,
+typically a `RunPlaybook` action) as an accepted alternative destination. Only when *neither*
+mechanism exists is this a HIGH finding.
 
 ## Collection behavior
 
-- Collection is read-only and retrieves configuration metadata only, never log or alert content.
+- Collection is read-only and retrieves configuration metadata only, never log, alert, or incident
+  content.
 - A successful empty response is `COMPLETE` with no items.
-- Permission, API, or transport failures are `FAILED`; they are never converted into an empty inventory or compliance claim.
+- Permission, API, or transport failures are `FAILED`; they are never converted into an empty
+  inventory or compliance claim.
+- Sentinel's per-workspace fan-out (onboarding checks, data connectors, alert rules, automation
+  rules) uses a third `PARTIAL` `CollectionStatus`: when some workspaces succeed and others fail,
+  the succeeded workspaces' evidence is still usable and the failed workspaces are listed in
+  `CollectionResult.failed_scopes` so rules can treat only the affected scope as UNKNOWN rather than
+  discarding evidence for every other workspace in the subscription.
 - Resource diagnostic settings are collected only for policy-scoped critical resource IDs.
-- Final `PASS`, `FAIL`, `ERROR`, and `NOT_APPLICABLE` evaluation will integrate with issue #263 rather than creating a second outcome model.
 
 ## Minimum Azure permissions
 
-- `Microsoft.Insights/diagnosticSettings/read`
-- `Microsoft.Insights/eventtypes/values/read` where activity-log metadata is required
-- Read access to the resource inventory used to select critical resources
+- `Microsoft.Insights/diagnosticSettings/read` — activity-log and resource diagnostic settings
+  (AZ-SECOPS-001 through 005).
+- `Microsoft.Insights/actionGroups/read` — action group inventory (AZ-SECOPS-010).
+- `Microsoft.Security/pricings/read` — Defender plan pricing tier (AZ-SECOPS-006).
+- `Microsoft.Security/assessments/read` — Defender recommendations (AZ-SECOPS-007).
+- `Microsoft.OperationalInsights/workspaces/read` — Log Analytics workspace enumeration used for
+  Sentinel auto-discovery.
+- `Microsoft.SecurityInsights/onboardingStates/read`, `.../dataConnectors/read`,
+  `.../alertRules/read`, `.../automationRules/read` — Sentinel workspace and content collection
+  (AZ-SECOPS-008, 009, 010).
+- Read access to the resource inventory used to select critical resources.
 
-Defender and Sentinel permissions will be added with their dedicated collectors. No remediation or write permission is introduced in this phase.
+No remediation or write permission is required by any of these ten rules; the accompanying
+`playbooks/cli/fix_az_secops_*.sh` scripts run separately under an operator identity.
+
+## References
+
+- [CIS Microsoft Azure Foundations Benchmark v2.0.0](https://www.cisecurity.org/benchmark/azure)
+- [Azure Monitor diagnostic settings](https://learn.microsoft.com/azure/azure-monitor/essentials/diagnostic-settings)
+- [Azure Activity Log](https://learn.microsoft.com/azure/azure-monitor/essentials/activity-log)
+- [Microsoft Defender for Cloud pricing](https://learn.microsoft.com/azure/defender-for-cloud/pricing)
+- [Microsoft Defender for Cloud recommendations](https://learn.microsoft.com/azure/defender-for-cloud/review-security-recommendations)
+- [Microsoft Sentinel data connectors](https://learn.microsoft.com/azure/sentinel/data-connectors-reference)
+- [Microsoft Sentinel automation rules](https://learn.microsoft.com/azure/sentinel/automate-incident-handling-with-automation-rules)
+- [Azure Monitor action groups](https://learn.microsoft.com/azure/azure-monitor/alerts/action-groups)

--- a/docs/security-operations-rules.md
+++ b/docs/security-operations-rules.md
@@ -1,0 +1,23 @@
+# Enterprise Security Operations Rules
+
+Issue #262 adds logging, Defender for Cloud, and Microsoft Sentinel controls. The first implementation phase establishes policy and evidence collection without inventing organisation-specific security requirements.
+
+## Policy boundary
+
+`config/security-operations-policy.example.json` documents every value that an organisation must approve: critical resource types, central destinations, activity-log categories, retention, Defender plans and SLA, Sentinel connectors and analytics coverage, and exclusions. The example is not a production baseline and is never loaded automatically.
+
+## Collection behavior
+
+- Collection is read-only and retrieves configuration metadata only, never log or alert content.
+- A successful empty response is `COMPLETE` with no items.
+- Permission, API, or transport failures are `FAILED`; they are never converted into an empty inventory or compliance claim.
+- Resource diagnostic settings are collected only for policy-scoped critical resource IDs.
+- Final `PASS`, `FAIL`, `ERROR`, and `NOT_APPLICABLE` evaluation will integrate with issue #263 rather than creating a second outcome model.
+
+## Minimum Azure permissions
+
+- `Microsoft.Insights/diagnosticSettings/read`
+- `Microsoft.Insights/eventtypes/values/read` where activity-log metadata is required
+- Read access to the resource inventory used to select critical resources
+
+Defender and Sentinel permissions will be added with their dedicated collectors. No remediation or write permission is introduced in this phase.

--- a/playbooks/cli/fix_az_secops_001.sh
+++ b/playbooks/cli/fix_az_secops_001.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -euo pipefail
+# AZ-SECOPS-001: Export subscription Activity Log to an approved central Log Analytics workspace
+# Usage: ./fix_az_secops_001.sh <setting-name> <location> <workspace-resource-id>
+SETTING_NAME="${1:-}"
+LOCATION="${2:-}"
+WORKSPACE_ID="${3:-}"
+if [ -z "$SETTING_NAME" ] || [ -z "$LOCATION" ] || [ -z "$WORKSPACE_ID" ]; then
+  echo "Usage: $0 <setting-name> <location> <workspace-resource-id>"
+  echo "  workspace-resource-id must be an organisation-approved central destination."
+  exit 1
+fi
+echo "Creating subscription Activity Log diagnostic setting: $SETTING_NAME..."
+az monitor diagnostic-settings subscription create \
+  --name "$SETTING_NAME" \
+  --location "$LOCATION" \
+  --workspace "$WORKSPACE_ID" \
+  --logs '[{"category":"Administrative","enabled":true},{"category":"Security","enabled":true},{"category":"Policy","enabled":true},{"category":"ServiceHealth","enabled":true},{"category":"Alert","enabled":true},{"category":"Recommendation","enabled":true}]'
+echo "Activity Log diagnostic setting created: $SETTING_NAME -> $WORKSPACE_ID"

--- a/playbooks/cli/fix_az_secops_002.sh
+++ b/playbooks/cli/fix_az_secops_002.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -euo pipefail
+# AZ-SECOPS-002: Enable every required category on the subscription Activity Log diagnostic setting
+# Usage: ./fix_az_secops_002.sh <setting-name>
+SETTING_NAME="${1:-}"
+if [ -z "$SETTING_NAME" ]; then
+  echo "Usage: $0 <setting-name>"
+  echo "  setting-name is the existing Activity Log diagnostic setting to update."
+  exit 1
+fi
+echo "Enabling all required categories on Activity Log diagnostic setting: $SETTING_NAME..."
+az monitor diagnostic-settings subscription update \
+  --name "$SETTING_NAME" \
+  --logs '[{"category":"Administrative","enabled":true},{"category":"Security","enabled":true},{"category":"Policy","enabled":true},{"category":"ServiceHealth","enabled":true},{"category":"Alert","enabled":true},{"category":"Recommendation","enabled":true}]'
+echo "Required categories enabled on: $SETTING_NAME"

--- a/playbooks/cli/fix_az_secops_003.sh
+++ b/playbooks/cli/fix_az_secops_003.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -euo pipefail
+# AZ-SECOPS-003: Create a diagnostic setting on a critical resource exporting to an approved destination
+# Usage: ./fix_az_secops_003.sh <resource-id> <workspace-resource-id> [setting-name]
+RESOURCE_ID="${1:-}"
+WORKSPACE_ID="${2:-}"
+SETTING_NAME="${3:-central-security-export}"
+if [ -z "$RESOURCE_ID" ] || [ -z "$WORKSPACE_ID" ]; then
+  echo "Usage: $0 <resource-id> <workspace-resource-id> [setting-name]"
+  echo "  workspace-resource-id must be an organisation-approved central destination."
+  exit 1
+fi
+echo "Creating diagnostic setting '$SETTING_NAME' on resource: $RESOURCE_ID..."
+az monitor diagnostic-settings create \
+  --name "$SETTING_NAME" \
+  --resource "$RESOURCE_ID" \
+  --workspace "$WORKSPACE_ID" \
+  --logs '[{"categoryGroup":"allLogs","enabled":true}]'
+echo "Diagnostic setting created on: $RESOURCE_ID"

--- a/playbooks/cli/fix_az_secops_004.sh
+++ b/playbooks/cli/fix_az_secops_004.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+set -euo pipefail
+# AZ-SECOPS-004: Increase Storage Account log-export retention to the organisation minimum
+# Usage: ./fix_az_secops_004.sh <resource-id> <setting-name> <minimum-retention-days>
+RESOURCE_ID="${1:-}"
+SETTING_NAME="${2:-}"
+RETENTION_DAYS="${3:-}"
+if [ -z "$RESOURCE_ID" ] || [ -z "$SETTING_NAME" ] || [ -z "$RETENTION_DAYS" ]; then
+  echo "Usage: $0 <resource-id> <setting-name> <minimum-retention-days>"
+  exit 1
+fi
+echo "Setting Storage Account log retention to ${RETENTION_DAYS} days on: $SETTING_NAME..."
+az monitor diagnostic-settings update \
+  --name "$SETTING_NAME" \
+  --resource "$RESOURCE_ID" \
+  --logs "[{\"categoryGroup\":\"allLogs\",\"enabled\":true,\"retentionPolicy\":{\"enabled\":true,\"days\":${RETENTION_DAYS}}}]"
+echo "Retention updated to ${RETENTION_DAYS} days on: $SETTING_NAME"

--- a/playbooks/cli/fix_az_secops_005.sh
+++ b/playbooks/cli/fix_az_secops_005.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -euo pipefail
+# AZ-SECOPS-005: Add a second log export to an organisation-approved, centrally-owned destination
+# Usage: ./fix_az_secops_005.sh <resource-id> <setting-name> <approved-workspace-resource-id>
+RESOURCE_ID="${1:-}"
+SETTING_NAME="${2:-}"
+APPROVED_WORKSPACE_ID="${3:-}"
+if [ -z "$RESOURCE_ID" ] || [ -z "$SETTING_NAME" ] || [ -z "$APPROVED_WORKSPACE_ID" ]; then
+  echo "Usage: $0 <resource-id> <setting-name> <approved-workspace-resource-id>"
+  echo "  approved-workspace-resource-id must NOT be owned by the workload's own resource group."
+  exit 1
+fi
+echo "Adding an approved, centrally-owned destination to diagnostic setting: $SETTING_NAME..."
+az monitor diagnostic-settings update \
+  --name "$SETTING_NAME" \
+  --resource "$RESOURCE_ID" \
+  --workspace "$APPROVED_WORKSPACE_ID"
+echo "Diagnostic setting $SETTING_NAME now also exports to: $APPROVED_WORKSPACE_ID"
+echo "Consider also enabling a Storage Account immutability policy as defence in depth."

--- a/playbooks/cli/fix_az_secops_006.sh
+++ b/playbooks/cli/fix_az_secops_006.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -euo pipefail
+# AZ-SECOPS-006: Enable a required Microsoft Defender for Cloud plan at subscription scope
+# Usage: ./fix_az_secops_006.sh <plan-name>
+# plan-name examples: VirtualMachines, StorageAccounts, SqlServers, KeyVaults, AppServices
+PLAN_NAME="${1:-}"
+if [ -z "$PLAN_NAME" ]; then
+  echo "Usage: $0 <plan-name>"
+  echo "  plan-name examples: VirtualMachines, StorageAccounts, SqlServers, KeyVaults, AppServices"
+  exit 1
+fi
+echo "WARNING: Enabling Microsoft Defender for Cloud plan '$PLAN_NAME' incurs additional cost."
+echo "Enabling Defender plan: $PLAN_NAME..."
+az security pricing create --name "$PLAN_NAME" --tier Standard
+echo "Defender plan enabled: $PLAN_NAME"

--- a/playbooks/cli/fix_az_secops_007.sh
+++ b/playbooks/cli/fix_az_secops_007.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -euo pipefail
+# AZ-SECOPS-007: Show a Defender recommendation so it can be triaged and remediated before its SLA expires
+# Usage: ./fix_az_secops_007.sh <assessment-name>
+ASSESSMENT_NAME="${1:-}"
+if [ -z "$ASSESSMENT_NAME" ]; then
+  echo "Usage: $0 <assessment-name>"
+  exit 1
+fi
+echo "Fetching Defender assessment details: $ASSESSMENT_NAME..."
+az security assessment show --name "$ASSESSMENT_NAME"
+echo ""
+echo "Review the recommendation above and remediate the underlying resource misconfiguration."
+echo "If remediation is not currently possible, record an approved risk-acceptance exception"
+echo "with the security team rather than leaving the recommendation silently unresolved."

--- a/playbooks/cli/fix_az_secops_008.sh
+++ b/playbooks/cli/fix_az_secops_008.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -euo pipefail
+# AZ-SECOPS-008: List Sentinel data connectors for a workspace to identify and repair an unhealthy connector
+# Usage: ./fix_az_secops_008.sh <resource-group> <workspace-name>
+RESOURCE_GROUP="${1:-}"
+WORKSPACE_NAME="${2:-}"
+if [ -z "$RESOURCE_GROUP" ] || [ -z "$WORKSPACE_NAME" ]; then
+  echo "Usage: $0 <resource-group> <workspace-name>"
+  exit 1
+fi
+echo "Listing Sentinel data connectors for workspace: $WORKSPACE_NAME..."
+az sentinel data-connector list --resource-group "$RESOURCE_GROUP" --workspace-name "$WORKSPACE_NAME" -o table
+echo ""
+echo "Open Microsoft Sentinel > Data connectors in the Azure portal for the connector shown above"
+echo "as missing or disconnected, and complete its connection so at least one data type is Enabled."

--- a/playbooks/cli/fix_az_secops_009.sh
+++ b/playbooks/cli/fix_az_secops_009.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+set -euo pipefail
+# AZ-SECOPS-009: Create an enabled, High-severity Sentinel scheduled analytics rule for a detection use case
+# Usage: ./fix_az_secops_009.sh <resource-group> <workspace-name> <use-case-name> <kql-query>
+RESOURCE_GROUP="${1:-}"
+WORKSPACE_NAME="${2:-}"
+USE_CASE_NAME="${3:-}"
+KQL_QUERY="${4:-}"
+if [ -z "$RESOURCE_GROUP" ] || [ -z "$WORKSPACE_NAME" ] || [ -z "$USE_CASE_NAME" ] || [ -z "$KQL_QUERY" ]; then
+  echo "Usage: $0 <resource-group> <workspace-name> <use-case-name> <kql-query>"
+  exit 1
+fi
+echo "Creating High-severity Sentinel analytics rule for use case: $USE_CASE_NAME..."
+az sentinel alert-rule create \
+  --resource-group "$RESOURCE_GROUP" \
+  --workspace-name "$WORKSPACE_NAME" \
+  --kind Scheduled \
+  --severity High \
+  --display-name "$USE_CASE_NAME" \
+  --enabled true \
+  --query "$KQL_QUERY" \
+  --query-frequency PT1H \
+  --query-period PT1H \
+  --trigger-operator GreaterThan \
+  --trigger-threshold 0
+echo "Analytics rule created for use case: $USE_CASE_NAME"

--- a/playbooks/cli/fix_az_secops_010.sh
+++ b/playbooks/cli/fix_az_secops_010.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+set -euo pipefail
+# AZ-SECOPS-010: Create a monitored Azure Monitor action group so security alerts reach a responder
+# Usage: ./fix_az_secops_010.sh <resource-group> <action-group-name> <short-name> <receiver-name> <email>
+RESOURCE_GROUP="${1:-}"
+ACTION_GROUP_NAME="${2:-}"
+SHORT_NAME="${3:-}"
+RECEIVER_NAME="${4:-}"
+EMAIL="${5:-}"
+if [ -z "$RESOURCE_GROUP" ] || [ -z "$ACTION_GROUP_NAME" ] || [ -z "$SHORT_NAME" ] || [ -z "$RECEIVER_NAME" ] || [ -z "$EMAIL" ]; then
+  echo "Usage: $0 <resource-group> <action-group-name> <short-name> <receiver-name> <email>"
+  exit 1
+fi
+echo "Creating monitored action group: $ACTION_GROUP_NAME..."
+az monitor action-group create \
+  --resource-group "$RESOURCE_GROUP" \
+  --name "$ACTION_GROUP_NAME" \
+  --short-name "$SHORT_NAME" \
+  --action email "$RECEIVER_NAME" "$EMAIL"
+echo "Action group created: $ACTION_GROUP_NAME"
+echo "Attach this action group to Defender for Cloud email notifications and/or a Sentinel"
+echo "automation rule so both alert sources reach a monitored incident-response destination."

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,9 @@ azure-mgmt-authorization==4.0.0
 azure-mgmt-web==7.3.1
 azure-monitor-ingestion==1.0.3
 azure-mgmt-monitor==6.0.0
+azure-mgmt-security==7.0.0
+azure-mgmt-securityinsight==1.0.0
+azure-mgmt-loganalytics==14.0.0
 azure-mgmt-dns==8.0.0
 azure-mgmt-containerservice==41.3.0
 psycopg2-binary==2.9.9

--- a/scanner/rules/_security_operations_common.py
+++ b/scanner/rules/_security_operations_common.py
@@ -1,0 +1,197 @@
+"""Shared, secret-safe helpers for the issue #262 security-operations rules (AZ-SECOPS-001..010).
+
+Reconciling the 4-state PASS/FAIL/UNKNOWN/NOT_APPLICABLE model required by
+issue #262 with the existing findings-list-only ``scan()`` contract:
+
+``scanner/engine.py`` treats *presence of a finding in the returned list* as
+the only signal of non-compliance (it feeds the list straight into a
+severity-weighted score). It has no field or side channel for a rule to say
+"this resource is compliant", "this is out of scope", or "I could not tell".
+Two existing rule families in this repo already answer this exact question:
+``scanner/rules/az_dl_001.py``/``az_dl_002.py`` (via
+``scanner/rules/_data_link_common.py``) and ``az_kv_003.py``. Both follow the
+same pattern and this module continues it rather than inventing a third,
+incompatible convention:
+
+  * PASS is an empty list. No finding is emitted for a compliant resource.
+  * NOT_APPLICABLE is an empty list plus an ``INFO``-level log line. Nothing
+    in scope means nothing to report.
+  * UNKNOWN is an empty list plus a ``WARNING``-level log line. A collector
+    failure, an inaccessible permission, or a policy that cannot be loaded
+    must never be silently promoted to a compliance claim, so it is treated
+    the same as "no evidence of a violation" for scoring purposes and is
+    never converted into a FAIL.
+  * FAIL is the only outcome that produces a finding dict, and only when
+    there is positive evidence of a missing or unsafe control.
+
+This satisfies "Return NOT_APPLICABLE / UNKNOWN" and "Return FAIL only with
+positive evidence" without changing what ``engine.py`` does with the return
+value of ``scan()``. The richer per-finding metadata the issue also asks for
+(scope, category, destination, retention, ownership, evidence/timestamp,
+remediation, permissions, severity, confidence, and an UNKNOWN reason) is
+carried on every FAIL finding's ``metadata`` dict so a UI or export can still
+show "why" even though UNKNOWN/NOT_APPLICABLE outcomes themselves are not
+individually addressable dict rows. This is a real, structural limitation of
+the current engine contract for these two states — flagged here rather than
+worked around by inventing a second, parallel result channel that
+``engine.py`` (out of scope for this change) does not consume.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from datetime import datetime, timezone
+from typing import Any, Callable, Optional, Sequence
+
+from scanner.security_operations import (
+    CollectionResult,
+    CollectionStatus,
+    SecurityOperationsCollector,
+    SecurityOperationsPolicy,
+    load_security_operations_policy,
+)
+
+logger = logging.getLogger(__name__)
+
+# The policy file is organisation-owned and is never loaded by default (see
+# docs/security-operations-rules.md). A rule that cannot resolve a policy
+# path has no approved scope, destinations, retention, or SLA to evaluate
+# against, so its only safe outcome is UNKNOWN — never PASS and never FAIL.
+POLICY_PATH_ENV_VAR = "OPENSHIELD_SECURITY_OPERATIONS_POLICY"
+
+
+def value(item: Any, field: str, default: Any = None) -> Any:
+    """Read an SDK model or test dictionary field without raising."""
+    if item is None:
+        return default
+    if isinstance(item, dict):
+        return item.get(field, default)
+    return getattr(item, field, default)
+
+
+def enum_value(item: Any) -> str:
+    """Normalise an Azure SDK enum-like value (or plain string) to a lowercase string."""
+    if item is None:
+        return ""
+    return str(getattr(item, "value", item)).strip().lower()
+
+
+def load_policy_from_env(rule_id: str) -> Optional[SecurityOperationsPolicy]:
+    """Load the organisation's security-operations policy from the configured path.
+
+    Returns ``None`` (never raises) when the environment variable is unset,
+    the file is missing, or the file fails strict validation — every caller
+    must treat ``None`` as UNKNOWN, not as "no policy required".
+    """
+    path = os.environ.get(POLICY_PATH_ENV_VAR)
+    if not path:
+        logger.warning(
+            "%s: %s is not set; security-operations policy is unavailable, result is UNKNOWN",
+            rule_id,
+            POLICY_PATH_ENV_VAR,
+        )
+        return None
+    try:
+        return load_security_operations_policy(path)
+    except Exception as exc:
+        logger.warning("%s: failed to load security-operations policy from %s: %s", rule_id, path, exc)
+        return None
+
+
+def default_resource_inventory(credential: Any, subscription_id: str) -> Callable[[], Sequence[Any]]:
+    """Build a resource_inventory callable backed by the generic ARM resource list.
+
+    ``SecurityOperationsCollector.critical_resource_ids`` needs a callable
+    returning every resource in the subscription (id + type only). No
+    existing AzureClient method returns a generic, subscription-wide
+    inventory, so this uses azure-mgmt-resource directly — the standard SDK
+    for enumerating resources across all providers/types.
+    """
+
+    def _list() -> Sequence[Any]:
+        from azure.mgmt.resource import ResourceManagementClient
+
+        client = ResourceManagementClient(credential, subscription_id)
+        return list(client.resources.list())
+
+    return _list
+
+
+def build_collector(azure_client: Any, subscription_id: str) -> SecurityOperationsCollector:
+    """Build a SecurityOperationsCollector from the AzureClient supplied to scan()."""
+    credential = getattr(azure_client, "credential", None)
+    return SecurityOperationsCollector(
+        credential,
+        subscription_id,
+        resource_inventory=default_resource_inventory(credential, subscription_id),
+    )
+
+
+def is_usable(result: CollectionResult[Any]) -> bool:
+    """Return True when a CollectionResult has at least partial evidence to evaluate."""
+    return result.status in (CollectionStatus.COMPLETE, CollectionStatus.PARTIAL)
+
+
+def evidence_timestamp() -> str:
+    """Return the evidence-collection timestamp used on every finding (UTC, ISO 8601)."""
+    return datetime.now(timezone.utc).isoformat()
+
+
+def is_excluded(resource_id: str, policy: SecurityOperationsPolicy) -> bool:
+    """Return True when a resource ID matches an organisation-approved exclusion.
+
+    Exclusions are matched case-insensitively against the full resource ID so
+    an approved exception never produces a false FAIL finding.
+    """
+    normalised = str(resource_id or "").strip().lower()
+    return normalised in policy.approved_exclusions
+
+
+def build_finding(
+    *,
+    rule_id: str,
+    rule_name: str,
+    severity: str,
+    category: str,
+    resource_id: str,
+    resource_name: str,
+    resource_type: str,
+    description: str,
+    remediation: str,
+    playbook: str,
+    frameworks: dict,
+    scope: str,
+    confidence: str = "HIGH",
+    metadata: Optional[dict] = None,
+) -> dict:
+    """Build a finding dict carrying the issue #262 required metadata fields.
+
+    ``scope``, ``category``, ``destination``, ``retention``, ``ownership``,
+    ``evidence_collected_at``, ``remediation``, ``permissions_required``,
+    ``severity``, and ``confidence`` all live under ``metadata`` alongside
+    the rule-specific fields the caller supplies, so nothing in the required
+    field list is dropped even though the top-level finding shape must match
+    every other rule in this repo (see _REQUIRED_FIELDS in
+    tests/test_rules_keyvault.py).
+    """
+    merged_metadata = {
+        "scope": scope,
+        "evidence_collected_at": evidence_timestamp(),
+        "confidence": confidence,
+    }
+    merged_metadata.update(metadata or {})
+    return {
+        "rule_id": rule_id,
+        "rule_name": rule_name,
+        "severity": severity,
+        "category": category,
+        "resource_id": resource_id,
+        "resource_name": resource_name,
+        "resource_type": resource_type,
+        "description": description,
+        "remediation": remediation,
+        "playbook": playbook,
+        "frameworks": frameworks,
+        "metadata": merged_metadata,
+    }

--- a/scanner/rules/az_secops_001.py
+++ b/scanner/rules/az_secops_001.py
@@ -1,0 +1,93 @@
+"""AZ-SECOPS-001: Subscription activity logs are not exported to an approved central destination."""
+
+import logging
+from typing import Any, Dict, List
+
+from scanner.rules._security_operations_common import (
+    build_collector,
+    build_finding,
+    is_usable,
+    load_policy_from_env,
+    value,
+)
+
+logger = logging.getLogger(__name__)
+
+RULE_ID = "AZ-SECOPS-001"
+RULE_NAME = "Subscription Activity Log Not Exported to an Approved Central Destination"
+SEVERITY = "HIGH"
+CATEGORY = "Security Operations"
+FRAMEWORKS = {"CIS": "5.1.1", "NIST": "PR.PT-1", "ISO27001": "A.12.4.1", "SOC2": "CC7.2"}
+DESCRIPTION = (
+    "The subscription's Azure Activity Log has no diagnostic setting exporting it to an "
+    "organisation-approved central destination (Log Analytics workspace, Storage Account, or "
+    "Event Hub). Without a central export, subscription-level administrative, security, and "
+    "policy events are only retained for the Activity Log's fixed default window and are not "
+    "available to the SIEM/central security tooling used for detection and investigation."
+)
+REMEDIATION = (
+    "Create a diagnostic setting on the subscription's Activity Log that sends all required log "
+    "categories to an approved central destination, e.g.:\n"
+    "  az monitor diagnostic-settings subscription create \\\n"
+    "    --name central-security-export \\\n"
+    "    --location <region> \\\n"
+    "    --workspace <approved-log-analytics-workspace-resource-id>"
+)
+PLAYBOOK = "playbooks/cli/fix_az_secops_001.sh"
+
+
+def _destinations(setting: Any) -> set:
+    destinations = set()
+    for field in ("workspace_id", "storage_account_id", "event_hub_authorization_rule_id"):
+        dest = value(setting, field)
+        if dest:
+            destinations.add(str(dest).strip().lower())
+    return destinations
+
+
+def scan(azure_client: Any, subscription_id: str) -> List[Dict[str, Any]]:
+    """Flag a subscription with no activity-log export to any approved destination."""
+    policy = load_policy_from_env(RULE_ID)
+    if policy is None:
+        return []
+
+    collector = build_collector(azure_client, subscription_id)
+    result = collector.subscription_diagnostic_settings()
+    if not is_usable(result):
+        logger.warning(
+            "%s: subscription diagnostic settings unavailable (%s); result is UNKNOWN", RULE_ID, result.error_code
+        )
+        return []
+
+    approved_hit = False
+    for setting in result.items:
+        if _destinations(setting) & policy.approved_destination_ids:
+            approved_hit = True
+            break
+
+    if approved_hit:
+        return []
+
+    finding = build_finding(
+        rule_id=RULE_ID,
+        rule_name=RULE_NAME,
+        severity=SEVERITY,
+        category=CATEGORY,
+        resource_id=f"/subscriptions/{subscription_id}",
+        resource_name=subscription_id,
+        resource_type="Microsoft.Resources/subscriptions",
+        description=DESCRIPTION,
+        remediation=REMEDIATION,
+        playbook=PLAYBOOK,
+        frameworks=FRAMEWORKS,
+        scope="subscription-activity-log",
+        metadata={
+            "destination": "none-approved",
+            "approved_destination_ids": sorted(policy.approved_destination_ids),
+            "diagnostic_settings_found": len(result.items),
+            "collection_status": result.status.value,
+            "permissions_required": ["Microsoft.Insights/diagnosticSettings/read"],
+            "unknown_reason": None,
+        },
+    )
+    return [finding]

--- a/scanner/rules/az_secops_002.py
+++ b/scanner/rules/az_secops_002.py
@@ -1,0 +1,103 @@
+"""AZ-SECOPS-002: Required administrative, security, policy, or service-health categories are missing."""
+
+import logging
+from typing import Any, Dict, List
+
+from scanner.rules._security_operations_common import (
+    build_collector,
+    build_finding,
+    enum_value,
+    is_usable,
+    load_policy_from_env,
+    value,
+)
+
+logger = logging.getLogger(__name__)
+
+RULE_ID = "AZ-SECOPS-002"
+RULE_NAME = "Required Activity Log Categories Missing From Central Export"
+SEVERITY = "HIGH"
+CATEGORY = "Security Operations"
+FRAMEWORKS = {"CIS": "5.1.2", "NIST": "PR.PT-1", "ISO27001": "A.12.4.1", "SOC2": "CC7.2"}
+DESCRIPTION = (
+    "The subscription's Activity Log diagnostic setting(s) exporting to an approved destination "
+    "do not enable every organisation-required log category (e.g. Administrative, Security, "
+    "Policy, ServiceHealth). A partial category export leaves gaps in the events available for "
+    "detection and investigation even though an export destination exists."
+)
+REMEDIATION = (
+    "Update the Activity Log diagnostic setting to enable every required category, e.g.:\n"
+    "  az monitor diagnostic-settings subscription update \\\n"
+    "    --name <setting-name> \\\n"
+    '    --logs \'[{"category":"Administrative","enabled":true},'
+    '{"category":"Security","enabled":true},{"category":"Policy","enabled":true},'
+    '{"category":"ServiceHealth","enabled":true}]\''
+)
+PLAYBOOK = "playbooks/cli/fix_az_secops_002.sh"
+
+
+def _enabled_categories_at_approved_destinations(settings: Any, approved_destination_ids: frozenset) -> set:
+    enabled: set = set()
+    for setting in settings:
+        destinations = set()
+        for field in ("workspace_id", "storage_account_id", "event_hub_authorization_rule_id"):
+            dest = value(setting, field)
+            if dest:
+                destinations.add(str(dest).strip().lower())
+        if not destinations & approved_destination_ids:
+            continue
+        for log in value(setting, "logs", []) or []:
+            if value(log, "enabled", False):
+                category = value(log, "category") or value(log, "category_group")
+                if category:
+                    enabled.add(str(enum_value(category) or category).strip().lower())
+    return enabled
+
+
+def scan(azure_client: Any, subscription_id: str) -> List[Dict[str, Any]]:
+    """Flag missing required activity-log categories among approved-destination exports."""
+    policy = load_policy_from_env(RULE_ID)
+    if policy is None:
+        return []
+
+    collector = build_collector(azure_client, subscription_id)
+    result = collector.subscription_diagnostic_settings()
+    if not is_usable(result):
+        logger.warning(
+            "%s: subscription diagnostic settings unavailable (%s); result is UNKNOWN", RULE_ID, result.error_code
+        )
+        return []
+
+    enabled = _enabled_categories_at_approved_destinations(result.items, policy.approved_destination_ids)
+    if not enabled:
+        # AZ-SECOPS-001 already reports the missing-export case; avoid a
+        # duplicate, less-specific finding here when there is no approved
+        # export to evaluate categories against.
+        return []
+
+    missing = {c for c in policy.required_activity_categories if c not in enabled}
+    if not missing:
+        return []
+
+    finding = build_finding(
+        rule_id=RULE_ID,
+        rule_name=RULE_NAME,
+        severity=SEVERITY,
+        category=CATEGORY,
+        resource_id=f"/subscriptions/{subscription_id}",
+        resource_name=subscription_id,
+        resource_type="Microsoft.Resources/subscriptions",
+        description=DESCRIPTION,
+        remediation=REMEDIATION,
+        playbook=PLAYBOOK,
+        frameworks=FRAMEWORKS,
+        scope="subscription-activity-log",
+        metadata={
+            "category": sorted(missing),
+            "enabled_categories": sorted(enabled),
+            "required_categories": sorted(policy.required_activity_categories),
+            "permissions_required": ["Microsoft.Insights/diagnosticSettings/read"],
+            "unknown_reason": None,
+        },
+    )
+    return [finding]

--- a/scanner/rules/az_secops_003.py
+++ b/scanner/rules/az_secops_003.py
@@ -1,0 +1,103 @@
+"""AZ-SECOPS-003: A critical resource lacks required diagnostic settings."""
+
+import logging
+from typing import Any, Dict, List
+
+from scanner.rules._security_operations_common import (
+    build_collector,
+    build_finding,
+    is_excluded,
+    is_usable,
+    load_policy_from_env,
+    value,
+)
+
+logger = logging.getLogger(__name__)
+
+RULE_ID = "AZ-SECOPS-003"
+RULE_NAME = "Critical Resource Missing Required Diagnostic Settings"
+SEVERITY = "HIGH"
+CATEGORY = "Security Operations"
+FRAMEWORKS = {"CIS": "5.4", "NIST": "DE.AE-3", "ISO27001": "A.12.4.1", "SOC2": "CC7.2"}
+DESCRIPTION = (
+    "A resource of an organisation-defined critical type has no diagnostic setting exporting to "
+    "an approved central destination. Critical resources (e.g. Key Vaults, SQL servers, Storage "
+    "accounts) without diagnostic export are invisible to central detection even when subscription "
+    "activity logging is otherwise correctly configured."
+)
+REMEDIATION = (
+    "Create a diagnostic setting on the resource that sends logs to an approved destination, e.g.:\n"
+    "  az monitor diagnostic-settings create \\\n"
+    "    --name central-security-export \\\n"
+    "    --resource <resource-id> \\\n"
+    "    --workspace <approved-log-analytics-workspace-resource-id> \\\n"
+    '    --logs \'[{"categoryGroup":"allLogs","enabled":true}]\''
+)
+PLAYBOOK = "playbooks/cli/fix_az_secops_003.sh"
+
+
+def _has_approved_export(settings: Any, approved_destination_ids: frozenset) -> bool:
+    for setting in settings or ():
+        for field in ("workspace_id", "storage_account_id", "event_hub_authorization_rule_id"):
+            dest = value(setting, field)
+            if dest and str(dest).strip().lower() in approved_destination_ids:
+                return True
+    return False
+
+
+def scan(azure_client: Any, subscription_id: str) -> List[Dict[str, Any]]:
+    """Flag critical resources with no diagnostic setting at an approved destination."""
+    policy = load_policy_from_env(RULE_ID)
+    if policy is None:
+        return []
+
+    collector = build_collector(azure_client, subscription_id)
+    critical_result = collector.critical_resource_ids(policy)
+    if not is_usable(critical_result):
+        logger.warning(
+            "%s: critical resource inventory unavailable (%s); result is UNKNOWN", RULE_ID, critical_result.error_code
+        )
+        return []
+
+    critical_ids = [rid for rid in critical_result.items if not is_excluded(rid, policy)]
+    if not critical_ids:
+        logger.info("%s: no in-scope critical resources; rule is not applicable", RULE_ID)
+        return []
+
+    diag_result = collector.resource_diagnostic_settings(critical_ids)
+    if not is_usable(diag_result) or not diag_result.items:
+        logger.warning(
+            "%s: resource diagnostic settings unavailable (%s); result is UNKNOWN", RULE_ID, diag_result.error_code
+        )
+        return []
+
+    per_resource = diag_result.items[0]
+    findings: List[Dict[str, Any]] = []
+    for resource_id in critical_ids:
+        settings = per_resource.get(resource_id, ())
+        if _has_approved_export(settings, policy.approved_destination_ids):
+            continue
+        findings.append(
+            build_finding(
+                rule_id=RULE_ID,
+                rule_name=RULE_NAME,
+                severity=SEVERITY,
+                category=CATEGORY,
+                resource_id=resource_id,
+                resource_name=resource_id.rsplit("/", 1)[-1],
+                resource_type="critical-resource",
+                description=DESCRIPTION,
+                remediation=REMEDIATION,
+                playbook=PLAYBOOK,
+                frameworks=FRAMEWORKS,
+                scope="critical-resource-diagnostics",
+                metadata={
+                    "destination": "none-approved",
+                    "approved_destination_ids": sorted(policy.approved_destination_ids),
+                    "diagnostic_settings_found": len(settings),
+                    "permissions_required": ["Microsoft.Insights/diagnosticSettings/read"],
+                    "unknown_reason": None,
+                },
+            )
+        )
+    return findings

--- a/scanner/rules/az_secops_004.py
+++ b/scanner/rules/az_secops_004.py
@@ -1,0 +1,128 @@
+"""AZ-SECOPS-004: Security logs have insufficient retention."""
+
+import logging
+from typing import Any, Dict, List
+
+from scanner.rules._security_operations_common import (
+    build_collector,
+    build_finding,
+    is_excluded,
+    is_usable,
+    load_policy_from_env,
+    value,
+)
+
+logger = logging.getLogger(__name__)
+
+RULE_ID = "AZ-SECOPS-004"
+RULE_NAME = "Security Logs Have Insufficient Retention"
+SEVERITY = "MEDIUM"
+CATEGORY = "Security Operations"
+FRAMEWORKS = {"CIS": "N/A-SECOPS-004", "NIST": "PR.PT-1", "ISO27001": "A.12.4.1", "SOC2": "CC7.2"}
+DESCRIPTION = (
+    "A diagnostic setting exporting security-relevant logs to a Storage Account has a retention "
+    "policy configured below the organisation's minimum retention requirement (or retention is "
+    "disabled entirely). Insufficient retention limits how far back an investigation can look once "
+    "an incident is detected. Log Analytics workspace retention is governed by the workspace's own "
+    "retention setting rather than the diagnostic setting's retention_policy field and is evaluated "
+    "separately; this rule covers the Storage Account destination retention_policy field only. "
+    "CIS Azure Foundations Benchmark control 5.1.1 covers the existence of a diagnostic setting "
+    "(AZ-SECOPS-001) and does not assign a distinct numbered control ID to the retention duration "
+    "itself, so no single-control CIS mapping applies here."
+)
+REMEDIATION = (
+    "Increase the diagnostic setting's Storage Account retention to at least the organisation's "
+    "minimum, e.g.:\n"
+    "  az monitor diagnostic-settings update \\\n"
+    "    --name <setting-name> \\\n"
+    "    --resource <resource-id> \\\n"
+    '    --logs \'[{"categoryGroup":"allLogs","enabled":true,'
+    '"retentionPolicy":{"enabled":true,"days":<minimum-retention-days>}}]\''
+)
+PLAYBOOK = "playbooks/cli/fix_az_secops_004.sh"
+
+
+def _insufficient_storage_retentions(settings: Any, minimum_days: int) -> List[Dict[str, Any]]:
+    """Return log entries whose Storage Account retention_policy is below minimum_days.
+
+    Only settings that actually target a Storage Account are evaluated: a
+    setting exporting solely to Log Analytics or Event Hub has no
+    retention_policy semantics of its own (see DESCRIPTION).
+    """
+    violations = []
+    for setting in settings or ():
+        if not value(setting, "storage_account_id"):
+            continue
+        for log in value(setting, "logs", []) or []:
+            if not value(log, "enabled", False):
+                continue
+            retention = value(log, "retention_policy")
+            enabled = value(retention, "enabled", False) if retention is not None else False
+            days = value(retention, "days", 0) if retention is not None else 0
+            if not enabled or int(days or 0) < minimum_days:
+                violations.append(
+                    {
+                        "category": value(log, "category") or value(log, "category_group") or "unknown",
+                        "retention_enabled": bool(enabled),
+                        "retention_days": int(days or 0),
+                    }
+                )
+    return violations
+
+
+def scan(azure_client: Any, subscription_id: str) -> List[Dict[str, Any]]:
+    """Flag critical-resource Storage Account log exports below minimum retention."""
+    policy = load_policy_from_env(RULE_ID)
+    if policy is None:
+        return []
+
+    collector = build_collector(azure_client, subscription_id)
+    critical_result = collector.critical_resource_ids(policy)
+    if not is_usable(critical_result):
+        logger.warning(
+            "%s: critical resource inventory unavailable (%s); result is UNKNOWN", RULE_ID, critical_result.error_code
+        )
+        return []
+
+    critical_ids = [rid for rid in critical_result.items if not is_excluded(rid, policy)]
+    if not critical_ids:
+        logger.info("%s: no in-scope critical resources; rule is not applicable", RULE_ID)
+        return []
+
+    diag_result = collector.resource_diagnostic_settings(critical_ids)
+    if not is_usable(diag_result) or not diag_result.items:
+        logger.warning(
+            "%s: resource diagnostic settings unavailable (%s); result is UNKNOWN", RULE_ID, diag_result.error_code
+        )
+        return []
+
+    per_resource = diag_result.items[0]
+    findings: List[Dict[str, Any]] = []
+    for resource_id in critical_ids:
+        settings = per_resource.get(resource_id, ())
+        violations = _insufficient_storage_retentions(settings, policy.minimum_retention_days)
+        if not violations:
+            continue
+        findings.append(
+            build_finding(
+                rule_id=RULE_ID,
+                rule_name=RULE_NAME,
+                severity=SEVERITY,
+                category=CATEGORY,
+                resource_id=resource_id,
+                resource_name=resource_id.rsplit("/", 1)[-1],
+                resource_type="critical-resource",
+                description=DESCRIPTION,
+                remediation=REMEDIATION,
+                playbook=PLAYBOOK,
+                frameworks=FRAMEWORKS,
+                scope="critical-resource-log-retention",
+                metadata={
+                    "retention": violations,
+                    "minimum_retention_days": policy.minimum_retention_days,
+                    "permissions_required": ["Microsoft.Insights/diagnosticSettings/read"],
+                    "unknown_reason": None,
+                },
+            )
+        )
+    return findings

--- a/scanner/rules/az_secops_005.py
+++ b/scanner/rules/az_secops_005.py
@@ -66,7 +66,7 @@ def _only_same_resource_group_destination(settings: Any, resource_id: str) -> bo
     workload_rg = _resource_group_of(resource_id)
     destinations = []
     for setting in settings or ():
-        for field in ("workspace_id", "storage_account_id"):
+        for field in ("workspace_id", "storage_account_id", "event_hub_authorization_rule_id"):
             dest = value(setting, field)
             if dest:
                 destinations.append(str(dest))

--- a/scanner/rules/az_secops_005.py
+++ b/scanner/rules/az_secops_005.py
@@ -1,0 +1,138 @@
+"""AZ-SECOPS-005: Security logs are stored only in a destination modifiable by workload administrators."""
+
+import logging
+from typing import Any, Dict, List, Optional
+
+from scanner.rules._security_operations_common import (
+    build_collector,
+    build_finding,
+    is_excluded,
+    is_usable,
+    load_policy_from_env,
+    value,
+)
+
+logger = logging.getLogger(__name__)
+
+RULE_ID = "AZ-SECOPS-005"
+RULE_NAME = "Security Logs Stored Only in a Destination the Workload Administrator Can Modify"
+SEVERITY = "HIGH"
+CATEGORY = "Security Operations"
+FRAMEWORKS = {"CIS": "N/A-SECOPS-005", "NIST": "PR.DS-6", "ISO27001": "A.12.4.2", "SOC2": "CC7.2"}
+DESCRIPTION = (
+    "A critical resource's diagnostic setting exports logs only to a destination that lives in "
+    "the same resource group (and therefore the same administrative scope) as the workload itself, "
+    "and no copy reaches an organisation-approved, centrally-owned destination. An administrator "
+    "with Contributor/Owner on the workload's own resource group can delete or alter that "
+    "destination's contents, defeating tamper-evidence for security-relevant logs. This is a "
+    "resource-group/ownership comparison, not a live Storage immutability-policy read: the "
+    "Monitor diagnostic-settings API does not expose the destination's own access-control or "
+    "immutability configuration. The CIS Azure Foundations Benchmark does not assign a distinct "
+    "numbered control to log-destination ownership/tamper-protection, so no single-control CIS "
+    "mapping applies here; ISO 27001 A.12.4.2 (Protection of log information) is the closest direct match."
+)
+REMEDIATION = (
+    "Add a second export from the resource's diagnostic setting to an organisation-approved, "
+    "centrally-owned destination that the workload's administrators do not control, e.g.:\n"
+    "  az monitor diagnostic-settings update \\\n"
+    "    --name <setting-name> \\\n"
+    "    --resource <resource-id> \\\n"
+    "    --workspace <approved-log-analytics-workspace-resource-id>\n"
+    "Consider enabling an immutability policy on any Storage Account destination as defence in depth."
+)
+PLAYBOOK = "playbooks/cli/fix_az_secops_005.sh"
+
+
+def _resource_group_of(resource_id: str) -> Optional[str]:
+    parts = str(resource_id or "").split("/")
+    try:
+        idx = [p.lower() for p in parts].index("resourcegroups")
+        return parts[idx + 1].lower()
+    except (ValueError, IndexError):
+        return None
+
+
+def _has_approved_destination(settings: Any, approved_destination_ids: frozenset) -> bool:
+    for setting in settings or ():
+        for field in ("workspace_id", "storage_account_id", "event_hub_authorization_rule_id"):
+            dest = value(setting, field)
+            if dest and str(dest).strip().lower() in approved_destination_ids:
+                return True
+    return False
+
+
+def _only_same_resource_group_destination(settings: Any, resource_id: str) -> bool:
+    """True when every configured destination sits in the workload's own resource group."""
+    workload_rg = _resource_group_of(resource_id)
+    destinations = []
+    for setting in settings or ():
+        for field in ("workspace_id", "storage_account_id"):
+            dest = value(setting, field)
+            if dest:
+                destinations.append(str(dest))
+    if not destinations or workload_rg is None:
+        return False
+    return all(_resource_group_of(dest) == workload_rg for dest in destinations)
+
+
+def scan(azure_client: Any, subscription_id: str) -> List[Dict[str, Any]]:
+    """Flag critical resources whose only log export sits in the workload's own resource group."""
+    policy = load_policy_from_env(RULE_ID)
+    if policy is None:
+        return []
+
+    collector = build_collector(azure_client, subscription_id)
+    critical_result = collector.critical_resource_ids(policy)
+    if not is_usable(critical_result):
+        logger.warning(
+            "%s: critical resource inventory unavailable (%s); result is UNKNOWN", RULE_ID, critical_result.error_code
+        )
+        return []
+
+    critical_ids = [rid for rid in critical_result.items if not is_excluded(rid, policy)]
+    if not critical_ids:
+        logger.info("%s: no in-scope critical resources; rule is not applicable", RULE_ID)
+        return []
+
+    diag_result = collector.resource_diagnostic_settings(critical_ids)
+    if not is_usable(diag_result) or not diag_result.items:
+        logger.warning(
+            "%s: resource diagnostic settings unavailable (%s); result is UNKNOWN", RULE_ID, diag_result.error_code
+        )
+        return []
+
+    per_resource = diag_result.items[0]
+    findings: List[Dict[str, Any]] = []
+    for resource_id in critical_ids:
+        settings = per_resource.get(resource_id, ())
+        if not settings:
+            # No export at all is AZ-SECOPS-003's finding; nothing to say here.
+            continue
+        if _has_approved_destination(settings, policy.approved_destination_ids):
+            continue
+        if not _only_same_resource_group_destination(settings, resource_id):
+            continue
+        findings.append(
+            build_finding(
+                rule_id=RULE_ID,
+                rule_name=RULE_NAME,
+                severity=SEVERITY,
+                category=CATEGORY,
+                resource_id=resource_id,
+                resource_name=resource_id.rsplit("/", 1)[-1],
+                resource_type="critical-resource",
+                description=DESCRIPTION,
+                remediation=REMEDIATION,
+                playbook=PLAYBOOK,
+                frameworks=FRAMEWORKS,
+                scope="critical-resource-log-destination-ownership",
+                metadata={
+                    "destination": "workload-owned-only",
+                    "ownership": "workload-administrator",
+                    "approved_destination_ids": sorted(policy.approved_destination_ids),
+                    "permissions_required": ["Microsoft.Insights/diagnosticSettings/read"],
+                    "unknown_reason": None,
+                },
+            )
+        )
+    return findings

--- a/scanner/rules/az_secops_006.py
+++ b/scanner/rules/az_secops_006.py
@@ -1,0 +1,116 @@
+"""AZ-SECOPS-006: Required Defender for Cloud protection is missing for a critical workload."""
+
+import logging
+from typing import Any, Dict, List
+
+from scanner.rules._security_operations_common import (
+    build_collector,
+    build_finding,
+    is_usable,
+    load_policy_from_env,
+    value,
+)
+
+logger = logging.getLogger(__name__)
+
+RULE_ID = "AZ-SECOPS-006"
+RULE_NAME = "Required Microsoft Defender for Cloud Plan Not Enabled"
+SEVERITY = "HIGH"
+CATEGORY = "Security Operations"
+FRAMEWORKS = {"CIS": "N/A-SECOPS-006", "NIST": "DE.CM-8", "ISO27001": "A.12.6.1", "SOC2": "CC7.1"}
+
+# The CIS Azure Foundations Benchmark maps each Defender plan to its own leaf
+# control (e.g. 2.1.1 Servers, 2.1.7 Storage, 2.1.5 SQL Servers on Machines,
+# 2.1.4 Azure SQL Databases). This rule is policy-driven across whatever
+# plans the organisation names in required_defender_plans, so no single
+# fixed control_id applies at the module level (see FRAMEWORKS["CIS"]
+# above and tests/test_cis_benchmark_mapping.py's one-CIS-control-per-rule
+# invariant); the real per-plan control is attached per finding instead.
+_CIS_PLAN_CONTROLS = {
+    "virtualmachines": "2.1.1",
+    "appservices": "2.1.2",
+    "azurecosmosdb": "2.1.9",
+    "sqlservers": "2.1.4",
+    "sqlservervirtualmachines": "2.1.5",
+    "opensourcerelationaldatabases": "2.1.6",
+    "storageaccounts": "2.1.7",
+    "containers": "2.1.8",
+    "keyvaults": "2.1.10",
+    "arm": "2.1.12",
+}
+
+DESCRIPTION = (
+    "A Microsoft Defender for Cloud plan the organisation requires for critical workloads (e.g. "
+    "VirtualMachines, StorageAccounts, SqlServers) is not enabled (pricing tier is not 'Standard') "
+    "at the subscription scope. Without the plan enabled, the corresponding workload type receives "
+    "no Defender threat detection, and no recommendations or alerts are generated for it."
+)
+REMEDIATION = (
+    "Enable the required Defender plan at subscription scope, e.g.:\n"
+    "  az security pricing create --name <PlanName> --tier Standard"
+)
+PLAYBOOK = "playbooks/cli/fix_az_secops_006.sh"
+
+_ENABLED_TIERS = {"standard"}
+
+
+def _plan_name(pricing: Any) -> str:
+    return str(value(pricing, "name") or "").strip()
+
+
+def _is_enabled(pricing: Any) -> bool:
+    tier = value(pricing, "pricing_tier")
+    tier_str = str(getattr(tier, "value", tier) or "").strip().lower()
+    return tier_str in _ENABLED_TIERS
+
+
+def scan(azure_client: Any, subscription_id: str) -> List[Dict[str, Any]]:
+    """Flag organisation-required Defender plans that are not set to Standard."""
+    policy = load_policy_from_env(RULE_ID)
+    if policy is None:
+        return []
+    if not policy.required_defender_plans:
+        logger.info("%s: no required Defender plans configured; rule is not applicable", RULE_ID)
+        return []
+
+    collector = build_collector(azure_client, subscription_id)
+    result = collector.defender_pricings()
+    if not is_usable(result):
+        logger.warning("%s: Defender pricing unavailable (%s); result is UNKNOWN", RULE_ID, result.error_code)
+        return []
+
+    enabled_plans = {_plan_name(p).lower() for p in result.items if _is_enabled(p)}
+    all_plan_names = {_plan_name(p) for p in result.items if _plan_name(p)}
+    # Case-insensitive comparison: policy plan names are normalised lowercase
+    # by load_security_operations_policy, Azure plan names are PascalCase.
+    plan_lookup = {name.lower(): name for name in all_plan_names}
+
+    findings: List[Dict[str, Any]] = []
+    for required_plan in sorted(policy.required_defender_plans):
+        if required_plan in enabled_plans:
+            continue
+        display_name = plan_lookup.get(required_plan, required_plan)
+        findings.append(
+            build_finding(
+                rule_id=RULE_ID,
+                rule_name=RULE_NAME,
+                severity=SEVERITY,
+                category=CATEGORY,
+                resource_id=f"/subscriptions/{subscription_id}/providers/Microsoft.Security/pricings/{display_name}",
+                resource_name=display_name,
+                resource_type="Microsoft.Security/pricings",
+                description=DESCRIPTION,
+                remediation=REMEDIATION,
+                playbook=PLAYBOOK,
+                frameworks=FRAMEWORKS,
+                scope="defender-plan-coverage",
+                metadata={
+                    "required_defender_plans": sorted(policy.required_defender_plans),
+                    "plan_found_in_subscription": display_name in all_plan_names,
+                    "cis_control_reference": _CIS_PLAN_CONTROLS.get(required_plan, "N/A"),
+                    "permissions_required": ["Microsoft.Security/pricings/read"],
+                    "unknown_reason": None,
+                },
+            )
+        )
+    return findings

--- a/scanner/rules/az_secops_007.py
+++ b/scanner/rules/az_secops_007.py
@@ -1,0 +1,137 @@
+"""AZ-SECOPS-007: A high-risk Defender recommendation remains unresolved beyond its SLA."""
+
+import logging
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional
+
+from scanner.rules._security_operations_common import (
+    build_collector,
+    build_finding,
+    is_usable,
+    load_policy_from_env,
+    value,
+)
+
+logger = logging.getLogger(__name__)
+
+RULE_ID = "AZ-SECOPS-007"
+RULE_NAME = "High-Risk Defender Recommendation Unresolved Beyond SLA"
+SEVERITY = "HIGH"
+CATEGORY = "Security Operations"
+FRAMEWORKS = {"CIS": "2.1.13", "NIST": "RS.MI-3", "ISO27001": "A.12.6.1", "SOC2": "CC7.1"}
+DESCRIPTION = (
+    "A Microsoft Defender for Cloud security assessment with High severity is Unhealthy and has "
+    "remained unresolved longer than the organisation's remediation SLA. The Defender assessment "
+    "API does not return a typed first-observed timestamp; the age used here is read from the "
+    "assessment's non-secret additional_data map when the resource provider populates a recognised "
+    "timestamp key. When no such timestamp is available the assessment's age cannot be determined "
+    "and it is excluded from this rule's findings (never assumed to be either compliant or overdue)."
+)
+REMEDIATION = (
+    "Review and remediate the Defender recommendation before its SLA expires:\n"
+    "  az security assessment show --name <assessment-name>\n"
+    "Address the underlying resource misconfiguration described by the recommendation, or record "
+    "an approved risk-acceptance exception with the security team if remediation is not currently possible."
+)
+PLAYBOOK = "playbooks/cli/fix_az_secops_007.sh"
+
+_HIGH_SEVERITY = {"high"}
+_UNHEALTHY = {"unhealthy"}
+
+# Recognised keys the Defender assessment API has been observed to populate in
+# additional_data for a first-evaluation/first-detected timestamp. Not a
+# formal SDK contract (additional_data is Dict[str, str]); read defensively.
+_TIMESTAMP_KEYS = ("firstEvaluationDate", "firstEvaluationTime", "timeGenerated", "detectedTimeUtc")
+
+
+def _severity(assessment: Any) -> str:
+    metadata = value(assessment, "metadata")
+    sev = value(metadata, "severity")
+    return str(getattr(sev, "value", sev) or "").strip().lower()
+
+
+def _status_code(assessment: Any) -> str:
+    status = value(assessment, "status")
+    code = value(status, "code")
+    return str(getattr(code, "value", code) or "").strip().lower()
+
+
+def _display_name(assessment: Any) -> str:
+    metadata = value(assessment, "metadata")
+    return str(value(metadata, "display_name") or value(assessment, "name") or "Defender recommendation")
+
+
+def _first_observed(assessment: Any) -> Optional[datetime]:
+    additional_data = value(assessment, "additional_data") or {}
+    if not isinstance(additional_data, dict):
+        return None
+    for key in _TIMESTAMP_KEYS:
+        raw = additional_data.get(key)
+        if not raw:
+            continue
+        try:
+            return datetime.fromisoformat(str(raw).replace("Z", "+00:00"))
+        except ValueError:
+            continue
+    return None
+
+
+def scan(azure_client: Any, subscription_id: str) -> List[Dict[str, Any]]:
+    """Flag unresolved High-severity Defender assessments older than the SLA."""
+    policy = load_policy_from_env(RULE_ID)
+    if policy is None:
+        return []
+
+    collector = build_collector(azure_client, subscription_id)
+    result = collector.defender_assessments()
+    if not is_usable(result):
+        logger.warning("%s: Defender assessments unavailable (%s); result is UNKNOWN", RULE_ID, result.error_code)
+        return []
+
+    now = datetime.now(timezone.utc)
+    findings: List[Dict[str, Any]] = []
+    for assessment in result.items:
+        if _severity(assessment) not in _HIGH_SEVERITY or _status_code(assessment) not in _UNHEALTHY:
+            continue
+        first_observed = _first_observed(assessment)
+        if first_observed is None:
+            logger.info(
+                "%s: assessment %s has no usable first-observed timestamp; age is UNKNOWN, skipped",
+                RULE_ID,
+                _display_name(assessment),
+            )
+            continue
+        if first_observed.tzinfo is None:
+            first_observed = first_observed.replace(tzinfo=timezone.utc)
+        age_days = (now - first_observed).days
+        if age_days <= policy.defender_recommendation_sla_days:
+            continue
+
+        resource_details = value(assessment, "resource_details")
+        resource_id = str(value(resource_details, "id") or value(assessment, "id") or "")
+        findings.append(
+            build_finding(
+                rule_id=RULE_ID,
+                rule_name=RULE_NAME,
+                severity=SEVERITY,
+                category=CATEGORY,
+                resource_id=resource_id or str(value(assessment, "id") or ""),
+                resource_name=_display_name(assessment),
+                resource_type="Microsoft.Security/assessments",
+                description=DESCRIPTION,
+                remediation=REMEDIATION,
+                playbook=PLAYBOOK,
+                frameworks=FRAMEWORKS,
+                scope="defender-recommendation-sla",
+                metadata={
+                    "severity_source": "High",
+                    "status": "Unhealthy",
+                    "age_days": age_days,
+                    "sla_days": policy.defender_recommendation_sla_days,
+                    "first_observed": first_observed.isoformat(),
+                    "permissions_required": ["Microsoft.Security/assessments/read"],
+                    "unknown_reason": None,
+                },
+            )
+        )
+    return findings

--- a/scanner/rules/az_secops_008.py
+++ b/scanner/rules/az_secops_008.py
@@ -1,0 +1,134 @@
+"""AZ-SECOPS-008: A required Microsoft Sentinel data connector is disconnected or unhealthy."""
+
+import logging
+from typing import Any, Dict, List
+
+from scanner.rules._security_operations_common import build_collector, build_finding, load_policy_from_env, value
+from scanner.security_operations import CollectionStatus, workspace_scope_key
+
+logger = logging.getLogger(__name__)
+
+RULE_ID = "AZ-SECOPS-008"
+RULE_NAME = "Required Microsoft Sentinel Data Connector Disconnected or Unhealthy"
+SEVERITY = "HIGH"
+CATEGORY = "Security Operations"
+FRAMEWORKS = {"CIS": "N/A-SECOPS-008", "NIST": "DE.AE-3", "ISO27001": "A.12.4.1", "SOC2": "CC7.2"}
+DESCRIPTION = (
+    "An organisation-required Microsoft Sentinel data connector is either missing from a "
+    "Sentinel-onboarded workspace or present with every one of its log data types disabled, which "
+    "Azure surfaces as the connector showing 'Not connected' in the Sentinel portal. Sentinel "
+    "workspace scope is auto-discovered: every Log Analytics workspace in the subscription is "
+    "checked for Sentinel onboarding, and only confirmed-onboarded workspaces are evaluated here. "
+    "There is no CIS Azure Foundations Benchmark control covering Sentinel connector health; CIS is "
+    "an infrastructure-configuration benchmark and does not include SIEM/XDR operational controls."
+)
+REMEDIATION = (
+    "Open Microsoft Sentinel > Data connectors for the affected workspace, select the required "
+    "connector, and complete or repair its connection so at least one of its log data types is "
+    "Enabled and actively ingesting."
+)
+PLAYBOOK = "playbooks/cli/fix_az_secops_008.sh"
+
+
+def _connector_kind(connector: Any) -> str:
+    return str(value(connector, "kind") or "").strip().lower()
+
+
+def _connector_connected(connector: Any) -> bool:
+    """A connector is considered connected when at least one data type is Enabled.
+
+    Connectors without a typed data_types field (some connector kinds do not
+    expose one in this API version) are treated as connected once present,
+    since presence is the only signal available for that kind.
+    """
+    data_types = value(connector, "data_types")
+    if data_types is None:
+        return True
+    states = []
+    for attr in ("alerts", "logs"):
+        entry = value(data_types, attr)
+        if entry is not None:
+            states.append(str(getattr(value(entry, "state"), "value", value(entry, "state")) or "").lower())
+    if not states:
+        return True
+    return any(state == "enabled" for state in states)
+
+
+def scan(azure_client: Any, subscription_id: str) -> List[Dict[str, Any]]:
+    """Flag required Sentinel connectors missing or unhealthy on onboarded workspaces."""
+    policy = load_policy_from_env(RULE_ID)
+    if policy is None:
+        return []
+    if not policy.required_sentinel_connectors:
+        logger.info("%s: no required Sentinel connectors configured; rule is not applicable", RULE_ID)
+        return []
+
+    collector = build_collector(azure_client, subscription_id)
+    workspaces_result = collector.sentinel_onboarded_workspaces()
+    if workspaces_result.status is CollectionStatus.FAILED:
+        logger.warning(
+            "%s: Sentinel onboarding discovery unavailable (%s); result is UNKNOWN",
+            RULE_ID,
+            workspaces_result.error_code,
+        )
+        return []
+    if not workspaces_result.items:
+        logger.info("%s: no Sentinel-onboarded workspaces found; rule is not applicable", RULE_ID)
+        return []
+
+    connectors_result = collector.sentinel_data_connectors(workspaces_result.items)
+    if connectors_result.status is CollectionStatus.FAILED:
+        logger.warning(
+            "%s: Sentinel data connectors unavailable (%s); result is UNKNOWN", RULE_ID, connectors_result.error_code
+        )
+        return []
+    if not connectors_result.items:
+        return []
+
+    per_workspace = connectors_result.items[0]
+    findings: List[Dict[str, Any]] = []
+    for workspace in workspaces_result.items:
+        workspace_name = str(value(workspace, "name") or "")
+        scope_key = workspace_scope_key(workspace)
+        if scope_key in connectors_result.failed_scopes:
+            logger.warning(
+                "%s: connector collection failed for %s; result is UNKNOWN for that scope", RULE_ID, scope_key
+            )
+            continue
+
+        connectors = per_workspace.get(scope_key, ())
+        by_kind = {}
+        for connector in connectors:
+            by_kind.setdefault(_connector_kind(connector), []).append(connector)
+
+        for required in sorted(policy.required_sentinel_connectors):
+            candidates = by_kind.get(required, [])
+            if candidates and any(_connector_connected(c) for c in candidates):
+                continue
+            state = "missing" if not candidates else "disconnected"
+            findings.append(
+                build_finding(
+                    rule_id=RULE_ID,
+                    rule_name=RULE_NAME,
+                    severity=SEVERITY,
+                    category=CATEGORY,
+                    resource_id=(
+                        f"{value(workspace, 'id', '')}/providers/Microsoft.SecurityInsights/dataConnectors/{required}"
+                    ),
+                    resource_name=f"{workspace_name}/{required}",
+                    resource_type="Microsoft.SecurityInsights/dataConnectors",
+                    description=DESCRIPTION,
+                    remediation=REMEDIATION,
+                    playbook=PLAYBOOK,
+                    frameworks=FRAMEWORKS,
+                    scope=f"sentinel-workspace:{scope_key}",
+                    metadata={
+                        "destination": scope_key,
+                        "connector_kind": required,
+                        "connector_state": state,
+                        "permissions_required": ["Microsoft.SecurityInsights/dataConnectors/read"],
+                        "unknown_reason": None,
+                    },
+                )
+            )
+    return findings

--- a/scanner/rules/az_secops_009.py
+++ b/scanner/rules/az_secops_009.py
@@ -1,0 +1,126 @@
+"""AZ-SECOPS-009: Sentinel lacks required high-severity analytics coverage."""
+
+import logging
+from typing import Any, Dict, List
+
+from scanner.rules._security_operations_common import build_collector, build_finding, load_policy_from_env, value
+from scanner.security_operations import CollectionStatus, workspace_scope_key
+
+logger = logging.getLogger(__name__)
+
+RULE_ID = "AZ-SECOPS-009"
+RULE_NAME = "Sentinel Missing Required High-Severity Analytics Coverage"
+SEVERITY = "HIGH"
+CATEGORY = "Security Operations"
+FRAMEWORKS = {"CIS": "N/A-SECOPS-009", "NIST": "DE.CM-1", "ISO27001": "A.12.4.1", "SOC2": "CC7.2"}
+DESCRIPTION = (
+    "A Sentinel-onboarded workspace has no enabled analytics (alert) rule with High severity "
+    "covering an organisation-required detection use case (e.g. privileged-role-change, "
+    "credential-abuse). Detection use cases are matched against each enabled rule's name and "
+    "tactics; a use case present only as a disabled rule, or not present at all, provides no "
+    "actual detection coverage. There is no CIS Azure Foundations Benchmark control for Sentinel "
+    "analytics coverage; CIS is an infrastructure-configuration benchmark and does not evaluate "
+    "SIEM detection content."
+)
+REMEDIATION = (
+    "Create or enable a Sentinel scheduled analytics rule with High severity covering the missing "
+    "detection use case:\n"
+    "  az sentinel alert-rule create --resource-group <rg> --workspace-name <workspace> \\\n"
+    "    --kind Scheduled --severity High --display-name <use-case-name> ..."
+)
+PLAYBOOK = "playbooks/cli/fix_az_secops_009.sh"
+
+_HIGH_SEVERITY = {"high"}
+
+
+def _rule_enabled(rule: Any) -> bool:
+    return bool(value(rule, "enabled", False))
+
+
+def _rule_severity(rule: Any) -> str:
+    sev = value(rule, "severity")
+    return str(getattr(sev, "value", sev) or "").strip().lower()
+
+
+def _rule_covers(rule: Any, use_case: str) -> bool:
+    display_name = str(value(rule, "display_name") or "").strip().lower()
+    use_case_normalised = use_case.strip().lower().replace("-", " ").replace("_", " ")
+    display_normalised = display_name.replace("-", " ").replace("_", " ")
+    return use_case_normalised in display_normalised
+
+
+def scan(azure_client: Any, subscription_id: str) -> List[Dict[str, Any]]:
+    """Flag Sentinel workspaces missing enabled High-severity coverage for a required use case."""
+    policy = load_policy_from_env(RULE_ID)
+    if policy is None:
+        return []
+    if not policy.required_high_severity_analytics:
+        logger.info("%s: no required high-severity analytics configured; rule is not applicable", RULE_ID)
+        return []
+
+    collector = build_collector(azure_client, subscription_id)
+    workspaces_result = collector.sentinel_onboarded_workspaces()
+    if workspaces_result.status is CollectionStatus.FAILED:
+        logger.warning(
+            "%s: Sentinel onboarding discovery unavailable (%s); result is UNKNOWN",
+            RULE_ID,
+            workspaces_result.error_code,
+        )
+        return []
+    if not workspaces_result.items:
+        logger.info("%s: no Sentinel-onboarded workspaces found; rule is not applicable", RULE_ID)
+        return []
+
+    rules_result = collector.sentinel_alert_rules(workspaces_result.items)
+    if rules_result.status is CollectionStatus.FAILED:
+        logger.warning(
+            "%s: Sentinel analytics rules unavailable (%s); result is UNKNOWN", RULE_ID, rules_result.error_code
+        )
+        return []
+    if not rules_result.items:
+        return []
+
+    per_workspace = rules_result.items[0]
+    findings: List[Dict[str, Any]] = []
+    for workspace in workspaces_result.items:
+        scope_key = workspace_scope_key(workspace)
+        if scope_key in rules_result.failed_scopes:
+            logger.warning(
+                "%s: analytics rule collection failed for %s; result is UNKNOWN for that scope", RULE_ID, scope_key
+            )
+            continue
+
+        rules = per_workspace.get(scope_key, ())
+        covering_enabled_high = [
+            rule for rule in rules if _rule_enabled(rule) and _rule_severity(rule) in _HIGH_SEVERITY
+        ]
+
+        for use_case in policy.required_high_severity_analytics:
+            if any(_rule_covers(rule, use_case) for rule in covering_enabled_high):
+                continue
+            findings.append(
+                build_finding(
+                    rule_id=RULE_ID,
+                    rule_name=RULE_NAME,
+                    severity=SEVERITY,
+                    category=CATEGORY,
+                    resource_id=(
+                        f"{value(workspace, 'id', '')}/providers/Microsoft.SecurityInsights/alertRules/{use_case}"
+                    ),
+                    resource_name=f"{value(workspace, 'name', '')}/{use_case}",
+                    resource_type="Microsoft.SecurityInsights/alertRules",
+                    description=DESCRIPTION,
+                    remediation=REMEDIATION,
+                    playbook=PLAYBOOK,
+                    frameworks=FRAMEWORKS,
+                    scope=f"sentinel-workspace:{scope_key}",
+                    metadata={
+                        "destination": scope_key,
+                        "use_case": use_case,
+                        "required_high_severity_analytics": list(policy.required_high_severity_analytics),
+                        "permissions_required": ["Microsoft.SecurityInsights/alertRules/read"],
+                        "unknown_reason": None,
+                    },
+                )
+            )
+    return findings

--- a/scanner/rules/az_secops_010.py
+++ b/scanner/rules/az_secops_010.py
@@ -3,7 +3,13 @@
 import logging
 from typing import Any, Dict, List
 
-from scanner.rules._security_operations_common import build_collector, build_finding, load_policy_from_env, value
+from scanner.rules._security_operations_common import (
+    build_collector,
+    build_finding,
+    is_usable,
+    load_policy_from_env,
+    value,
+)
 from scanner.security_operations import CollectionStatus, workspace_scope_key
 
 logger = logging.getLogger(__name__)
@@ -53,17 +59,29 @@ def _action_group_is_monitored(group: Any) -> bool:
     return False
 
 
-def _has_automation_rule_coverage(automation_rules_result: Any, workspaces: Any) -> bool:
+def _automation_rule_coverage(automation_rules_result: Any, workspaces: Any) -> tuple[bool, bool]:
+    """Return (has_coverage, evidence_is_complete) for Sentinel automation-rule routing.
+
+    ``evidence_is_complete`` is False whenever any onboarded workspace's
+    automation rules could not be collected (a PARTIAL result, or a workspace
+    absent from an otherwise-COMPLETE result because its own scope failed).
+    A caller must never treat incomplete evidence as proof of "no coverage":
+    the workspace that could not be checked might be the one with the
+    routing rule.
+    """
     if automation_rules_result.status is CollectionStatus.FAILED or not automation_rules_result.items:
-        return False
+        return False, False
     per_workspace = automation_rules_result.items[0]
+    has_coverage = False
+    evidence_is_complete = True
     for workspace in workspaces:
         scope_key = workspace_scope_key(workspace)
         if scope_key in automation_rules_result.failed_scopes:
+            evidence_is_complete = False
             continue
         if per_workspace.get(scope_key, ()):
-            return True
-    return False
+            has_coverage = True
+    return has_coverage, evidence_is_complete
 
 
 def scan(azure_client: Any, subscription_id: str) -> List[Dict[str, Any]]:
@@ -87,12 +105,40 @@ def scan(azure_client: Any, subscription_id: str) -> List[Dict[str, Any]]:
     # No action group covers it; a Sentinel automation rule routing incidents
     # onward is an accepted alternative destination, so check before failing.
     workspaces_result = collector.sentinel_onboarded_workspaces()
+    if not is_usable(workspaces_result):
+        logger.warning(
+            "%s: Sentinel onboarding discovery unavailable (%s); result is UNKNOWN",
+            RULE_ID,
+            workspaces_result.error_code,
+        )
+        return []
+
     has_automation_coverage = False
-    if workspaces_result.status is not CollectionStatus.FAILED and workspaces_result.items:
+    evidence_is_complete = True
+    if workspaces_result.items:
         automation_rules_result = collector.sentinel_automation_rules(workspaces_result.items)
-        has_automation_coverage = _has_automation_rule_coverage(automation_rules_result, workspaces_result.items)
+        if not is_usable(automation_rules_result):
+            logger.warning(
+                "%s: Sentinel automation rules unavailable (%s); result is UNKNOWN",
+                RULE_ID,
+                automation_rules_result.error_code,
+            )
+            return []
+        has_automation_coverage, evidence_is_complete = _automation_rule_coverage(
+            automation_rules_result, workspaces_result.items
+        )
 
     if has_automation_coverage:
+        return []
+
+    # sentinel_onboarded_workspaces() itself can also be PARTIAL: some
+    # workspaces were confirmed onboarded (and checked above), but others
+    # could not be checked at all, so their automation-rule coverage is
+    # completely unknown, not just incomplete.
+    if not evidence_is_complete or workspaces_result.status is CollectionStatus.PARTIAL:
+        logger.warning(
+            "%s: incomplete Sentinel evidence (some workspace scopes unreachable); result is UNKNOWN", RULE_ID
+        )
         return []
 
     finding = build_finding(

--- a/scanner/rules/az_secops_010.py
+++ b/scanner/rules/az_secops_010.py
@@ -1,0 +1,122 @@
+"""AZ-SECOPS-010: Security alerts have no monitored incident-response destination."""
+
+import logging
+from typing import Any, Dict, List
+
+from scanner.rules._security_operations_common import build_collector, build_finding, load_policy_from_env, value
+from scanner.security_operations import CollectionStatus, workspace_scope_key
+
+logger = logging.getLogger(__name__)
+
+RULE_ID = "AZ-SECOPS-010"
+RULE_NAME = "Security Alerts Have No Monitored Incident-Response Destination"
+SEVERITY = "HIGH"
+CATEGORY = "Security Operations"
+FRAMEWORKS = {"CIS": "2.1.20", "NIST": "RS.CO-2", "ISO27001": "A.16.1.2", "SOC2": "CC7.4"}
+DESCRIPTION = (
+    "No enabled Azure Monitor action group with at least one notification receiver (email, SMS, "
+    "voice, webhook, ITSM, Logic App, Automation runbook, Azure Function, or Event Hub) exists at "
+    "subscription scope, and no Sentinel-onboarded workspace has an automation rule configured to "
+    "route incidents onward (e.g. to a playbook). Without either mechanism, a security alert or "
+    "Sentinel incident can be generated with nobody and nothing notified to respond to it."
+)
+REMEDIATION = (
+    "Create an enabled Azure Monitor action group with at least one receiver, e.g.:\n"
+    "  az monitor action-group create --name soc-notify --resource-group <rg> \\\n"
+    "    --action email soc-oncall ops@example.com\n"
+    "Or configure a Sentinel automation rule that runs a playbook when an incident is created:\n"
+    "  az sentinel automation-rule create --resource-group <rg> --workspace-name <workspace> ..."
+)
+PLAYBOOK = "playbooks/cli/fix_az_secops_010.sh"
+
+_RECEIVER_FIELDS = (
+    "email_receivers",
+    "sms_receivers",
+    "webhook_receivers",
+    "itsm_receivers",
+    "azure_app_push_receivers",
+    "automation_runbook_receivers",
+    "voice_receivers",
+    "logic_app_receivers",
+    "azure_function_receivers",
+    "event_hub_receivers",
+)
+
+
+def _action_group_is_monitored(group: Any) -> bool:
+    if not value(group, "enabled", True):
+        return False
+    for field in _RECEIVER_FIELDS:
+        receivers = value(group, field)
+        if receivers:
+            return True
+    return False
+
+
+def _has_automation_rule_coverage(automation_rules_result: Any, workspaces: Any) -> bool:
+    if automation_rules_result.status is CollectionStatus.FAILED or not automation_rules_result.items:
+        return False
+    per_workspace = automation_rules_result.items[0]
+    for workspace in workspaces:
+        scope_key = workspace_scope_key(workspace)
+        if scope_key in automation_rules_result.failed_scopes:
+            continue
+        if per_workspace.get(scope_key, ()):
+            return True
+    return False
+
+
+def scan(azure_client: Any, subscription_id: str) -> List[Dict[str, Any]]:
+    """Flag a subscription with no monitored action group and no Sentinel automation-rule routing."""
+    policy = load_policy_from_env(RULE_ID)
+    if policy is None:
+        return []
+
+    collector = build_collector(azure_client, subscription_id)
+    action_groups_result = collector.action_groups()
+    if action_groups_result.status is CollectionStatus.FAILED:
+        logger.warning(
+            "%s: action groups unavailable (%s); result is UNKNOWN", RULE_ID, action_groups_result.error_code
+        )
+        return []
+
+    has_monitored_action_group = any(_action_group_is_monitored(g) for g in action_groups_result.items)
+    if has_monitored_action_group:
+        return []
+
+    # No action group covers it; a Sentinel automation rule routing incidents
+    # onward is an accepted alternative destination, so check before failing.
+    workspaces_result = collector.sentinel_onboarded_workspaces()
+    has_automation_coverage = False
+    if workspaces_result.status is not CollectionStatus.FAILED and workspaces_result.items:
+        automation_rules_result = collector.sentinel_automation_rules(workspaces_result.items)
+        has_automation_coverage = _has_automation_rule_coverage(automation_rules_result, workspaces_result.items)
+
+    if has_automation_coverage:
+        return []
+
+    finding = build_finding(
+        rule_id=RULE_ID,
+        rule_name=RULE_NAME,
+        severity=SEVERITY,
+        category=CATEGORY,
+        resource_id=f"/subscriptions/{subscription_id}",
+        resource_name=subscription_id,
+        resource_type="Microsoft.Resources/subscriptions",
+        description=DESCRIPTION,
+        remediation=REMEDIATION,
+        playbook=PLAYBOOK,
+        frameworks=FRAMEWORKS,
+        scope="subscription-incident-response-destination",
+        metadata={
+            "destination": "none-monitored",
+            "action_groups_found": len(action_groups_result.items),
+            "sentinel_automation_rule_coverage": has_automation_coverage,
+            "permissions_required": [
+                "Microsoft.Insights/actionGroups/read",
+                "Microsoft.SecurityInsights/automationRules/read",
+            ],
+            "unknown_reason": None,
+        },
+    )
+    return [finding]

--- a/scanner/security_operations.py
+++ b/scanner/security_operations.py
@@ -1,0 +1,148 @@
+"""Read-only collection foundation for enterprise security-operations controls."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+from typing import Any, Callable, Generic, Mapping, Sequence, TypeVar
+
+from azure.mgmt.monitor import MonitorManagementClient
+
+T = TypeVar("T")
+
+
+class CollectionStatus(str, Enum):
+    """Whether a collector produced authoritative evidence."""
+
+    COMPLETE = "COMPLETE"
+    FAILED = "FAILED"
+
+
+@dataclass(frozen=True)
+class CollectionResult(Generic[T]):
+    """Explicit collector result; an API failure is never an empty inventory."""
+
+    status: CollectionStatus
+    items: tuple[T, ...]
+    source: str
+    error_code: str | None = None
+
+    @classmethod
+    def complete(cls, items: Sequence[T], source: str) -> CollectionResult[T]:
+        return cls(CollectionStatus.COMPLETE, tuple(items), source)
+
+    @classmethod
+    def failed(cls, source: str, error_code: str = "COLLECTION_FAILED") -> CollectionResult[T]:
+        return cls(CollectionStatus.FAILED, (), source, error_code)
+
+
+@dataclass(frozen=True)
+class SecurityOperationsPolicy:
+    """Organisation-owned inputs required before evaluating issue #262 rules."""
+
+    critical_resource_types: frozenset[str]
+    approved_destination_ids: frozenset[str]
+    required_activity_categories: frozenset[str]
+    minimum_retention_days: int
+    required_defender_plans: frozenset[str]
+    defender_recommendation_sla_days: int
+    required_sentinel_connectors: frozenset[str]
+    required_high_severity_analytics: tuple[str, ...]
+    approved_exclusions: frozenset[str]
+
+
+_POLICY_FIELDS = {
+    "critical_resource_types",
+    "approved_destination_ids",
+    "required_activity_categories",
+    "minimum_retention_days",
+    "required_defender_plans",
+    "defender_recommendation_sla_days",
+    "required_sentinel_connectors",
+    "required_high_severity_analytics",
+    "approved_exclusions",
+}
+
+
+def load_security_operations_policy(path: str | Path) -> SecurityOperationsPolicy:
+    """Load a strict policy file without silently inventing enterprise defaults."""
+    with Path(path).open(encoding="utf-8") as handle:
+        raw = json.load(handle)
+    if not isinstance(raw, dict) or set(raw) != _POLICY_FIELDS:
+        raise ValueError("security-operations policy has missing or unsupported fields")
+
+    list_fields = _POLICY_FIELDS - {"minimum_retention_days", "defender_recommendation_sla_days"}
+    for field in list_fields:
+        values = raw[field]
+        if not isinstance(values, list) or any(not isinstance(value, str) or not value.strip() for value in values):
+            raise ValueError(f"{field} must be a list of non-empty strings")
+    for field in ("minimum_retention_days", "defender_recommendation_sla_days"):
+        if not isinstance(raw[field], int) or isinstance(raw[field], bool) or raw[field] <= 0:
+            raise ValueError(f"{field} must be a positive integer")
+
+    normalised = {field: frozenset(value.strip().lower() for value in raw[field]) for field in list_fields}
+    return SecurityOperationsPolicy(
+        critical_resource_types=normalised["critical_resource_types"],
+        approved_destination_ids=normalised["approved_destination_ids"],
+        required_activity_categories=normalised["required_activity_categories"],
+        minimum_retention_days=raw["minimum_retention_days"],
+        required_defender_plans=normalised["required_defender_plans"],
+        defender_recommendation_sla_days=raw["defender_recommendation_sla_days"],
+        required_sentinel_connectors=normalised["required_sentinel_connectors"],
+        required_high_severity_analytics=tuple(value.strip() for value in raw["required_high_severity_analytics"]),
+        approved_exclusions=normalised["approved_exclusions"],
+    )
+
+
+class SecurityOperationsCollector:
+    """Collect Azure Monitor configuration without reading log content."""
+
+    def __init__(
+        self,
+        credential: Any,
+        subscription_id: str,
+        *,
+        monitor_client: Any | None = None,
+        resource_inventory: Callable[[], Sequence[Any]] | None = None,
+    ) -> None:
+        self.monitor = monitor_client or MonitorManagementClient(credential, subscription_id)
+        self.resource_inventory = resource_inventory
+
+    def subscription_diagnostic_settings(self) -> CollectionResult[Any]:
+        source = "Microsoft.Insights/subscriptionDiagnosticSettings"
+        try:
+            return CollectionResult.complete(list(self.monitor.subscription_diagnostic_settings.list()), source)
+        except Exception:
+            return CollectionResult.failed(source)
+
+    def resource_diagnostic_settings(
+        self, resource_ids: Sequence[str]
+    ) -> CollectionResult[Mapping[str, tuple[Any, ...]]]:
+        source = "Microsoft.Insights/diagnosticSettings"
+        collected: dict[str, tuple[Any, ...]] = {}
+        try:
+            for resource_id in resource_ids:
+                if not isinstance(resource_id, str) or not resource_id.strip():
+                    raise ValueError("resource IDs must be non-empty strings")
+                collected[resource_id] = tuple(self.monitor.diagnostic_settings.list(resource_id))
+            return CollectionResult.complete((collected,), source)
+        except Exception:
+            return CollectionResult.failed(source)
+
+    def critical_resource_ids(self, policy: SecurityOperationsPolicy) -> CollectionResult[str]:
+        source = "Azure resource inventory"
+        if self.resource_inventory is None:
+            return CollectionResult.failed(source, "INVENTORY_NOT_CONFIGURED")
+        try:
+            resources = self.resource_inventory()
+            ids = []
+            for resource in resources:
+                resource_id = str(getattr(resource, "id", "") or "").strip()
+                resource_type = str(getattr(resource, "type", "") or "").strip().lower()
+                if resource_id and resource_type in policy.critical_resource_types:
+                    ids.append(resource_id)
+            return CollectionResult.complete(ids, source)
+        except Exception:
+            return CollectionResult.failed(source)

--- a/scanner/security_operations.py
+++ b/scanner/security_operations.py
@@ -3,21 +3,60 @@
 from __future__ import annotations
 
 import json
+import logging
 from dataclasses import dataclass
+from dataclasses import field as dataclass_field
 from enum import Enum
 from pathlib import Path
 from typing import Any, Callable, Generic, Mapping, Sequence, TypeVar
 
 from azure.mgmt.monitor import MonitorManagementClient
 
+logger = logging.getLogger(__name__)
+
 T = TypeVar("T")
 
 
+def workspace_resource_group(workspace: Any) -> str:
+    """Extract the resource group name from a Log Analytics workspace's ARM resource ID.
+
+    Shared, module-level helper (not collector-private) so rule modules can
+    compute the same per-workspace scope key used internally by the
+    Sentinel collection methods without reaching into a private attribute.
+    """
+    resource_id = str(getattr(workspace, "id", "") or "")
+    parts = resource_id.split("/")
+    try:
+        idx = [p.lower() for p in parts].index("resourcegroups")
+        return parts[idx + 1]
+    except (ValueError, IndexError):
+        return ""
+
+
+def workspace_scope_key(workspace: Any) -> str:
+    """Return the "resource_group/workspace_name" key used to index per-workspace collections."""
+    resource_group = workspace_resource_group(workspace)
+    workspace_name = str(getattr(workspace, "name", "") or "")
+    return f"{resource_group}/{workspace_name}"
+
+
 class CollectionStatus(str, Enum):
-    """Whether a collector produced authoritative evidence."""
+    """Whether a collector produced authoritative evidence.
+
+    COMPLETE and FAILED are the original, subscription-wide outcomes: either
+    the whole collection succeeded (possibly with zero items) or it could not
+    be attempted/finished at all. PARTIAL is additive and only used by
+    collectors that fan out across multiple independent scopes (for example
+    one Sentinel onboarding check per Log Analytics workspace): some scopes
+    produced evidence while others did not. Rules must treat PARTIAL like
+    COMPLETE for the scopes present in ``items`` and treat the scopes listed
+    in ``failed_scopes`` the same way they treat a FAILED collector — as
+    UNKNOWN, never as a compliant or non-compliant result.
+    """
 
     COMPLETE = "COMPLETE"
     FAILED = "FAILED"
+    PARTIAL = "PARTIAL"
 
 
 @dataclass(frozen=True)
@@ -28,6 +67,7 @@ class CollectionResult(Generic[T]):
     items: tuple[T, ...]
     source: str
     error_code: str | None = None
+    failed_scopes: tuple[str, ...] = dataclass_field(default_factory=tuple)
 
     @classmethod
     def complete(cls, items: Sequence[T], source: str) -> CollectionResult[T]:
@@ -36,6 +76,16 @@ class CollectionResult(Generic[T]):
     @classmethod
     def failed(cls, source: str, error_code: str = "COLLECTION_FAILED") -> CollectionResult[T]:
         return cls(CollectionStatus.FAILED, (), source, error_code)
+
+    @classmethod
+    def partial(
+        cls,
+        items: Sequence[T],
+        source: str,
+        failed_scopes: Sequence[str],
+        error_code: str = "PARTIAL_COLLECTION",
+    ) -> CollectionResult[T]:
+        return cls(CollectionStatus.PARTIAL, tuple(items), source, error_code, tuple(failed_scopes))
 
 
 @dataclass(frozen=True)
@@ -106,9 +156,55 @@ class SecurityOperationsCollector:
         *,
         monitor_client: Any | None = None,
         resource_inventory: Callable[[], Sequence[Any]] | None = None,
+        security_client: Any | None = None,
+        log_analytics_client: Any | None = None,
+        sentinel_client_factory: Callable[[str], Any] | None = None,
     ) -> None:
         self.monitor = monitor_client or MonitorManagementClient(credential, subscription_id)
         self.resource_inventory = resource_inventory
+        self._credential = credential
+        self._subscription_id = subscription_id
+        self._security_client = security_client
+        self._log_analytics_client = log_analytics_client
+        self._sentinel_client_factory = sentinel_client_factory
+        self._sentinel_client_cache: dict[str, Any] = {}
+
+    # ------------------------------------------------------------------ #
+    # Lazily constructed SDK clients (never built until first use, so a  #
+    # test double supplied via the constructor is always preferred).    #
+    # ------------------------------------------------------------------ #
+
+    @property
+    def security(self) -> Any:
+        if self._security_client is None:
+            from azure.mgmt.security import SecurityCenter
+
+            self._security_client = SecurityCenter(self._credential, self._subscription_id)
+        return self._security_client
+
+    @property
+    def log_analytics(self) -> Any:
+        if self._log_analytics_client is None:
+            from azure.mgmt.loganalytics import LogAnalyticsManagementClient
+
+            self._log_analytics_client = LogAnalyticsManagementClient(self._credential, self._subscription_id)
+        return self._log_analytics_client
+
+    def _sentinel_client(self, resource_group: str) -> Any:
+        """Return a Sentinel client for ``resource_group``, honouring an injected factory.
+
+        Microsoft Sentinel's SDK client is not subscription-wide: every
+        operation takes a resource group and workspace name. Tests provide a
+        ``sentinel_client_factory`` callable; production code builds one
+        ``SecurityInsights`` client per resource group and reuses it.
+        """
+        if self._sentinel_client_factory is not None:
+            return self._sentinel_client_factory(resource_group)
+        if resource_group not in self._sentinel_client_cache:
+            from azure.mgmt.securityinsight import SecurityInsights
+
+            self._sentinel_client_cache[resource_group] = SecurityInsights(self._credential, self._subscription_id)
+        return self._sentinel_client_cache[resource_group]
 
     def subscription_diagnostic_settings(self) -> CollectionResult[Any]:
         source = "Microsoft.Insights/subscriptionDiagnosticSettings"
@@ -144,5 +240,175 @@ class SecurityOperationsCollector:
                 if resource_id and resource_type in policy.critical_resource_types:
                     ids.append(resource_id)
             return CollectionResult.complete(ids, source)
+        except Exception:
+            return CollectionResult.failed(source)
+
+    # ------------------------------------------------------------------ #
+    # Defender for Cloud (controls 6-7)                                  #
+    # ------------------------------------------------------------------ #
+
+    def defender_pricings(self) -> CollectionResult[Any]:
+        """Collect Defender for Cloud plan pricing/enablement at subscription scope.
+
+        ``pricings.list`` returns a non-paginated ``PricingList`` wrapper
+        (``.value``), not an iterable of ``Pricing`` directly, unlike most
+        other list operations used by this collector.
+        """
+        source = "Microsoft.Security/pricings"
+        scope_id = f"/subscriptions/{self._subscription_id}"
+        try:
+            response = self.security.pricings.list(scope_id)
+            items = list(getattr(response, "value", response) or [])
+            return CollectionResult.complete(items, source)
+        except Exception:
+            return CollectionResult.failed(source)
+
+    def defender_assessments(self) -> CollectionResult[Any]:
+        """Collect Defender for Cloud security assessments (recommendations).
+
+        Only configuration metadata is collected: assessment status, severity,
+        and non-secret identifiers. Assessment content is never inspected for
+        secrets because the SDK model does not expose log or credential data.
+        """
+        source = "Microsoft.Security/assessments"
+        scope = f"/subscriptions/{self._subscription_id}"
+        try:
+            return CollectionResult.complete(list(self.security.assessments.list(scope)), source)
+        except Exception:
+            return CollectionResult.failed(source)
+
+    # ------------------------------------------------------------------ #
+    # Sentinel auto-discovery (controls 8-10)                            #
+    #                                                                    #
+    # Design decision (explicitly confirmed): Sentinel workspace scope   #
+    # is discovered, never configured. Every Log Analytics workspace in  #
+    # the subscription is enumerated, then each workspace's Sentinel     #
+    # onboarding state is checked individually. Only workspaces          #
+    # confirmed onboarded are queried for data connectors, analytics     #
+    # rules, and automation rules. This keeps the policy file free of a  #
+    # workspace name so newly onboarded Sentinel workspaces are covered  #
+    # automatically on the next scan without a policy change.            #
+    # ------------------------------------------------------------------ #
+
+    def log_analytics_workspaces(self) -> CollectionResult[Any]:
+        """Collect every Log Analytics workspace in the subscription (subscription-wide)."""
+        source = "Microsoft.OperationalInsights/workspaces"
+        try:
+            return CollectionResult.complete(list(self.log_analytics.workspaces.list()), source)
+        except Exception:
+            return CollectionResult.failed(source)
+
+    @staticmethod
+    def _workspace_resource_group(workspace: Any) -> str:
+        """Extract the resource group name from a workspace's ARM resource ID.
+
+        Retained as a thin delegate to the module-level ``workspace_resource_group``
+        for backward compatibility with any existing internal call sites.
+        """
+        return workspace_resource_group(workspace)
+
+    def sentinel_onboarded_workspaces(self) -> CollectionResult[Any]:
+        """Discover which Log Analytics workspaces have Microsoft Sentinel onboarded.
+
+        Returns workspace objects (not just names) for every workspace whose
+        Sentinel onboarding state was confirmed. Workspaces whose onboarding
+        state could not be checked (permission or transport failure) are
+        reported as failed scopes via a PARTIAL result rather than silently
+        dropped, so callers can distinguish "not onboarded" from "unknown".
+        """
+        source = "Microsoft.SecurityInsights/onboardingStates"
+        workspaces_result = self.log_analytics_workspaces()
+        if workspaces_result.status is CollectionStatus.FAILED:
+            return CollectionResult.failed(source, workspaces_result.error_code or "COLLECTION_FAILED")
+
+        onboarded: list[Any] = []
+        failed_scopes: list[str] = []
+        for workspace in workspaces_result.items:
+            workspace_name = str(getattr(workspace, "name", "") or "")
+            resource_group = self._workspace_resource_group(workspace)
+            if not workspace_name or not resource_group:
+                failed_scopes.append(str(getattr(workspace, "id", "") or workspace_name or "unknown"))
+                continue
+            try:
+                client = self._sentinel_client(resource_group)
+                states = client.sentinel_onboarding_states.list(resource_group, workspace_name)
+                values = getattr(states, "value", states) or []
+                if len(list(values)) > 0:
+                    onboarded.append(workspace)
+            except Exception as exc:
+                logger.warning(
+                    "Sentinel onboarding check failed for workspace %s/%s: %s",
+                    resource_group,
+                    workspace_name,
+                    exc,
+                )
+                failed_scopes.append(f"{resource_group}/{workspace_name}")
+
+        if failed_scopes and not onboarded:
+            return CollectionResult.failed(source, "COLLECTION_FAILED")
+        if failed_scopes:
+            return CollectionResult.partial(onboarded, source, failed_scopes)
+        return CollectionResult.complete(onboarded, source)
+
+    def sentinel_data_connectors(self, workspaces: Sequence[Any]) -> CollectionResult[Mapping[str, tuple[Any, ...]]]:
+        """Collect Sentinel data connectors per onboarded workspace."""
+        return self._sentinel_collect_per_workspace(
+            workspaces, "dataConnectors", lambda c, rg, wn: c.data_connectors.list(rg, wn)
+        )
+
+    def sentinel_alert_rules(self, workspaces: Sequence[Any]) -> CollectionResult[Mapping[str, tuple[Any, ...]]]:
+        """Collect Sentinel analytics (alert) rules per onboarded workspace."""
+        return self._sentinel_collect_per_workspace(
+            workspaces, "alertRules", lambda c, rg, wn: c.alert_rules.list(rg, wn)
+        )
+
+    def sentinel_automation_rules(self, workspaces: Sequence[Any]) -> CollectionResult[Mapping[str, tuple[Any, ...]]]:
+        """Collect Sentinel automation rules per onboarded workspace.
+
+        Automation rules are the Sentinel-native mechanism that routes
+        incidents to a playbook (Logic App) or updates incident ownership;
+        together with Azure Monitor action groups they are the evidence used
+        for control 10's "monitored incident-response destination".
+        """
+        return self._sentinel_collect_per_workspace(
+            workspaces, "automationRules", lambda c, rg, wn: c.automation_rules.list(rg, wn)
+        )
+
+    def _sentinel_collect_per_workspace(
+        self,
+        workspaces: Sequence[Any],
+        label: str,
+        call: Callable[[Any, str, str], Any],
+    ) -> CollectionResult[Mapping[str, tuple[Any, ...]]]:
+        source = f"Microsoft.SecurityInsights/{label}"
+        collected: dict[str, tuple[Any, ...]] = {}
+        failed_scopes: list[str] = []
+        for workspace in workspaces:
+            workspace_name = str(getattr(workspace, "name", "") or "")
+            resource_group = self._workspace_resource_group(workspace)
+            key = f"{resource_group}/{workspace_name}"
+            try:
+                client = self._sentinel_client(resource_group)
+                collected[key] = tuple(call(client, resource_group, workspace_name))
+            except Exception as exc:
+                logger.warning("%s collection failed for workspace %s: %s", label, key, exc)
+                failed_scopes.append(key)
+
+        if failed_scopes and not collected:
+            return CollectionResult.failed(source)
+        if failed_scopes:
+            return CollectionResult.partial((collected,), source, failed_scopes)
+        return CollectionResult.complete((collected,), source)
+
+    def action_groups(self) -> CollectionResult[Any]:
+        """Collect Azure Monitor action groups (subscription-wide).
+
+        Action groups are the concrete Azure notification-destination
+        primitive (email/SMS/webhook/ITSM/etc.) available directly through
+        the Monitor client that this collector already depends on.
+        """
+        source = "Microsoft.Insights/actionGroups"
+        try:
+            return CollectionResult.complete(list(self.monitor.action_groups.list_by_subscription_id()), source)
         except Exception:
             return CollectionResult.failed(source)

--- a/tests/helpers/security_operations.py
+++ b/tests/helpers/security_operations.py
@@ -1,0 +1,102 @@
+"""Shared test helpers for the AZ-SECOPS-001..010 rule test suite."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, Dict, Optional
+
+from scanner.security_operations import SecurityOperationsCollector
+
+DEFAULT_POLICY_PAYLOAD: Dict[str, Any] = {
+    "critical_resource_types": ["Microsoft.KeyVault/vaults", "Microsoft.Sql/servers"],
+    "approved_destination_ids": [
+        "/subscriptions/sub/resourcegroups/security/providers/microsoft.operationalinsights/workspaces/central-security"
+    ],
+    "required_activity_categories": ["Administrative", "Security", "Policy", "ServiceHealth"],
+    "minimum_retention_days": 90,
+    "required_defender_plans": ["VirtualMachines", "StorageAccounts"],
+    "defender_recommendation_sla_days": 30,
+    "required_sentinel_connectors": ["AzureActiveDirectory", "AzureSecurityCenter"],
+    "required_high_severity_analytics": ["privileged-role-change", "credential-abuse"],
+    "approved_exclusions": [],
+}
+
+
+def write_policy(tmp_path: Path, **overrides: Any) -> Path:
+    """Write a valid security-operations policy JSON file and return its path."""
+    payload = json.loads(json.dumps(DEFAULT_POLICY_PAYLOAD))
+    payload.update(overrides)
+    path = tmp_path / "secops-policy.json"
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return path
+
+
+def set_policy_env(monkeypatch: Any, tmp_path: Path, **overrides: Any) -> Path:
+    """Write a policy file and point OPENSHIELD_SECURITY_OPERATIONS_POLICY at it."""
+    path = write_policy(tmp_path, **overrides)
+    monkeypatch.setenv("OPENSHIELD_SECURITY_OPERATIONS_POLICY", str(path))
+    return path
+
+
+def stub_collector(monkeypatch: Any, module: Any, collector: SecurityOperationsCollector) -> None:
+    """Patch a rule module's build_collector() to return a preconfigured collector."""
+    monkeypatch.setattr(module, "build_collector", lambda azure_client, subscription_id: collector)
+
+
+def make_collector(**overrides: Any) -> SecurityOperationsCollector:
+    """Build a SecurityOperationsCollector with any combination of test-double clients."""
+    return SecurityOperationsCollector(
+        credential=None,
+        subscription_id="00000000-0000-0000-0000-000000000001",
+        monitor_client=overrides.get("monitor_client", SimpleNamespace()),
+        resource_inventory=overrides.get("resource_inventory"),
+        security_client=overrides.get("security_client"),
+        log_analytics_client=overrides.get("log_analytics_client"),
+        sentinel_client_factory=overrides.get("sentinel_client_factory"),
+    )
+
+
+def diagnostic_setting(
+    *,
+    workspace_id: Optional[str] = None,
+    storage_account_id: Optional[str] = None,
+    event_hub_authorization_rule_id: Optional[str] = None,
+    logs: Optional[list] = None,
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        workspace_id=workspace_id,
+        storage_account_id=storage_account_id,
+        event_hub_authorization_rule_id=event_hub_authorization_rule_id,
+        logs=logs or [],
+    )
+
+
+def log_setting(
+    *,
+    category: Optional[str] = None,
+    category_group: Optional[str] = None,
+    enabled: bool = True,
+    retention_policy: Optional[SimpleNamespace] = None,
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        category=category,
+        category_group=category_group,
+        enabled=enabled,
+        retention_policy=retention_policy,
+    )
+
+
+def retention_policy(*, enabled: bool, days: int) -> SimpleNamespace:
+    return SimpleNamespace(enabled=enabled, days=days)
+
+
+def workspace(*, name: str, resource_group: str = "rg-sec") -> SimpleNamespace:
+    return SimpleNamespace(
+        id=(
+            f"/subscriptions/00000000-0000-0000-0000-000000000001/resourceGroups/{resource_group}"
+            f"/providers/Microsoft.OperationalInsights/workspaces/{name}"
+        ),
+        name=name,
+    )

--- a/tests/test_rules_security_operations_defender.py
+++ b/tests/test_rules_security_operations_defender.py
@@ -1,0 +1,182 @@
+"""Tests for AZ-SECOPS-006 (Defender plan coverage) and AZ-SECOPS-007 (recommendation SLA)."""
+
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+
+import scanner.rules.az_secops_006 as az_secops_006
+import scanner.rules.az_secops_007 as az_secops_007
+from tests.helpers.mock_azure import MockAzureClient
+from tests.helpers.security_operations import make_collector, set_policy_env, stub_collector
+
+_SUB = "00000000-0000-0000-0000-000000000001"
+
+
+def _client() -> MockAzureClient:
+    return MockAzureClient()
+
+
+def _pricing(name: str, tier: str) -> SimpleNamespace:
+    return SimpleNamespace(name=name, pricing_tier=tier)
+
+
+def _pricing_list(items):
+    return SimpleNamespace(value=items)
+
+
+# ── AZ-SECOPS-006: Defender plan coverage ───────────────────────────────────
+
+
+def test_secops_006_all_required_plans_enabled_is_compliant(monkeypatch, tmp_path):
+    set_policy_env(monkeypatch, tmp_path, required_defender_plans=["VirtualMachines", "StorageAccounts"])
+    security = SimpleNamespace(
+        pricings=SimpleNamespace(
+            list=lambda scope_id, **kw: _pricing_list(
+                [_pricing("VirtualMachines", "Standard"), _pricing("StorageAccounts", "Standard")]
+            )
+        )
+    )
+    collector = make_collector(security_client=security)
+    stub_collector(monkeypatch, az_secops_006, collector)
+    assert az_secops_006.scan(_client(), _SUB) == []
+
+
+def test_secops_006_missing_plan_is_noncompliant(monkeypatch, tmp_path):
+    set_policy_env(monkeypatch, tmp_path, required_defender_plans=["VirtualMachines", "StorageAccounts"])
+    security = SimpleNamespace(
+        pricings=SimpleNamespace(list=lambda scope_id, **kw: _pricing_list([_pricing("VirtualMachines", "Standard")]))
+    )
+    collector = make_collector(security_client=security)
+    stub_collector(monkeypatch, az_secops_006, collector)
+    findings = az_secops_006.scan(_client(), _SUB)
+    assert len(findings) == 1
+    assert findings[0]["resource_name"] == "storageaccounts"
+    assert findings[0]["metadata"]["plan_found_in_subscription"] is False
+    assert findings[0]["metadata"]["cis_control_reference"] == "2.1.7"
+
+
+def test_secops_006_free_tier_is_noncompliant(monkeypatch, tmp_path):
+    set_policy_env(monkeypatch, tmp_path, required_defender_plans=["VirtualMachines"])
+    security = SimpleNamespace(
+        pricings=SimpleNamespace(list=lambda scope_id, **kw: _pricing_list([_pricing("VirtualMachines", "Free")]))
+    )
+    collector = make_collector(security_client=security)
+    stub_collector(monkeypatch, az_secops_006, collector)
+    findings = az_secops_006.scan(_client(), _SUB)
+    assert len(findings) == 1
+    assert findings[0]["metadata"]["plan_found_in_subscription"] is True
+
+
+def test_secops_006_empty_required_plans_is_not_applicable(monkeypatch, tmp_path):
+    set_policy_env(monkeypatch, tmp_path, required_defender_plans=[])
+    security = SimpleNamespace(pricings=SimpleNamespace(list=lambda scope_id, **kw: _pricing_list([])))
+    collector = make_collector(security_client=security)
+    stub_collector(monkeypatch, az_secops_006, collector)
+    assert az_secops_006.scan(_client(), _SUB) == []
+
+
+def test_secops_006_pricing_api_failure_is_unknown(monkeypatch, tmp_path):
+    set_policy_env(monkeypatch, tmp_path, required_defender_plans=["VirtualMachines"])
+
+    def fail(scope_id, **kw):
+        raise PermissionError("denied")
+
+    security = SimpleNamespace(pricings=SimpleNamespace(list=fail))
+    collector = make_collector(security_client=security)
+    stub_collector(monkeypatch, az_secops_006, collector)
+    assert az_secops_006.scan(_client(), _SUB) == []
+
+
+# ── AZ-SECOPS-007: Defender recommendation SLA ──────────────────────────────
+
+
+def _assessment(*, severity: str, status_code: str, first_evaluation: str = None, name: str = "assess-1"):
+    metadata = SimpleNamespace(display_name=f"Recommendation {name}", severity=severity)
+    status = SimpleNamespace(code=status_code)
+    additional_data = {"firstEvaluationDate": first_evaluation} if first_evaluation else {}
+    return SimpleNamespace(
+        id=f"/subscriptions/sub/providers/Microsoft.Security/assessments/{name}",
+        name=name,
+        metadata=metadata,
+        status=status,
+        additional_data=additional_data,
+        resource_details=SimpleNamespace(id="/subscriptions/sub/resourceGroups/rg/providers/x/y"),
+    )
+
+
+def _iso(days_ago: int) -> str:
+    return (datetime.now(timezone.utc) - timedelta(days=days_ago)).isoformat()
+
+
+def test_secops_007_unresolved_beyond_sla_is_noncompliant(monkeypatch, tmp_path):
+    set_policy_env(monkeypatch, tmp_path, defender_recommendation_sla_days=30)
+    security = SimpleNamespace(
+        assessments=SimpleNamespace(
+            list=lambda scope: [_assessment(severity="High", status_code="Unhealthy", first_evaluation=_iso(45))]
+        )
+    )
+    collector = make_collector(security_client=security)
+    stub_collector(monkeypatch, az_secops_007, collector)
+    findings = az_secops_007.scan(_client(), _SUB)
+    assert len(findings) == 1
+    assert findings[0]["metadata"]["age_days"] >= 45
+
+
+def test_secops_007_within_sla_is_compliant(monkeypatch, tmp_path):
+    set_policy_env(monkeypatch, tmp_path, defender_recommendation_sla_days=30)
+    security = SimpleNamespace(
+        assessments=SimpleNamespace(
+            list=lambda scope: [_assessment(severity="High", status_code="Unhealthy", first_evaluation=_iso(10))]
+        )
+    )
+    collector = make_collector(security_client=security)
+    stub_collector(monkeypatch, az_secops_007, collector)
+    assert az_secops_007.scan(_client(), _SUB) == []
+
+
+def test_secops_007_healthy_status_is_compliant(monkeypatch, tmp_path):
+    set_policy_env(monkeypatch, tmp_path, defender_recommendation_sla_days=30)
+    security = SimpleNamespace(
+        assessments=SimpleNamespace(
+            list=lambda scope: [_assessment(severity="High", status_code="Healthy", first_evaluation=_iso(400))]
+        )
+    )
+    collector = make_collector(security_client=security)
+    stub_collector(monkeypatch, az_secops_007, collector)
+    assert az_secops_007.scan(_client(), _SUB) == []
+
+
+def test_secops_007_low_severity_is_not_evaluated(monkeypatch, tmp_path):
+    set_policy_env(monkeypatch, tmp_path, defender_recommendation_sla_days=30)
+    security = SimpleNamespace(
+        assessments=SimpleNamespace(
+            list=lambda scope: [_assessment(severity="Low", status_code="Unhealthy", first_evaluation=_iso(400))]
+        )
+    )
+    collector = make_collector(security_client=security)
+    stub_collector(monkeypatch, az_secops_007, collector)
+    assert az_secops_007.scan(_client(), _SUB) == []
+
+
+def test_secops_007_no_timestamp_is_skipped_not_fabricated(monkeypatch, tmp_path):
+    """An assessment with no usable timestamp must never be silently marked compliant or overdue."""
+    set_policy_env(monkeypatch, tmp_path, defender_recommendation_sla_days=30)
+    security = SimpleNamespace(
+        assessments=SimpleNamespace(
+            list=lambda scope: [_assessment(severity="High", status_code="Unhealthy", first_evaluation=None)]
+        )
+    )
+    collector = make_collector(security_client=security)
+    stub_collector(monkeypatch, az_secops_007, collector)
+    assert az_secops_007.scan(_client(), _SUB) == []
+
+
+def test_secops_007_assessments_api_failure_is_unknown(monkeypatch, tmp_path):
+    set_policy_env(monkeypatch, tmp_path)
+
+    def fail(scope):
+        raise RuntimeError("boom")
+
+    security = SimpleNamespace(assessments=SimpleNamespace(list=fail))
+    collector = make_collector(security_client=security)
+    stub_collector(monkeypatch, az_secops_007, collector)
+    assert az_secops_007.scan(_client(), _SUB) == []

--- a/tests/test_rules_security_operations_logging.py
+++ b/tests/test_rules_security_operations_logging.py
@@ -1,0 +1,210 @@
+"""Tests for AZ-SECOPS-001..003: activity log export, categories, critical-resource diagnostics."""
+
+from types import SimpleNamespace
+
+import scanner.rules.az_secops_001 as az_secops_001
+import scanner.rules.az_secops_002 as az_secops_002
+import scanner.rules.az_secops_003 as az_secops_003
+from tests.helpers.mock_azure import MockAzureClient
+from tests.helpers.security_operations import (
+    diagnostic_setting,
+    log_setting,
+    make_collector,
+    set_policy_env,
+    stub_collector,
+)
+
+_APPROVED = (
+    "/subscriptions/sub/resourcegroups/security/providers/microsoft.operationalinsights/workspaces/central-security"
+)
+_SUB = "00000000-0000-0000-0000-000000000001"
+
+
+def _client() -> MockAzureClient:
+    return MockAzureClient()
+
+
+# ── AZ-SECOPS-001: subscription activity log export ────────────────────────
+
+
+def test_secops_001_no_policy_configured_returns_no_findings(monkeypatch):
+    monkeypatch.delenv("OPENSHIELD_SECURITY_OPERATIONS_POLICY", raising=False)
+    assert az_secops_001.scan(_client(), _SUB) == []
+
+
+def test_secops_001_approved_export_is_compliant(monkeypatch, tmp_path):
+    set_policy_env(monkeypatch, tmp_path)
+    monitor = SimpleNamespace(
+        subscription_diagnostic_settings=SimpleNamespace(list=lambda: [diagnostic_setting(workspace_id=_APPROVED)])
+    )
+    stub_collector(monkeypatch, az_secops_001, make_collector(monitor_client=monitor))
+    assert az_secops_001.scan(_client(), _SUB) == []
+
+
+def test_secops_001_no_export_is_noncompliant(monkeypatch, tmp_path):
+    set_policy_env(monkeypatch, tmp_path)
+    monitor = SimpleNamespace(subscription_diagnostic_settings=SimpleNamespace(list=lambda: []))
+    stub_collector(monkeypatch, az_secops_001, make_collector(monitor_client=monitor))
+    findings = az_secops_001.scan(_client(), _SUB)
+    assert len(findings) == 1
+    assert findings[0]["rule_id"] == "AZ-SECOPS-001"
+    assert findings[0]["metadata"]["destination"] == "none-approved"
+    assert findings[0]["metadata"]["confidence"] == "HIGH"
+
+
+def test_secops_001_export_to_unapproved_destination_is_noncompliant(monkeypatch, tmp_path):
+    set_policy_env(monkeypatch, tmp_path)
+    monitor = SimpleNamespace(
+        subscription_diagnostic_settings=SimpleNamespace(
+            list=lambda: [diagnostic_setting(workspace_id="/subscriptions/sub/workspaces/unapproved")]
+        )
+    )
+    stub_collector(monkeypatch, az_secops_001, make_collector(monitor_client=monitor))
+    findings = az_secops_001.scan(_client(), _SUB)
+    assert len(findings) == 1
+
+
+def test_secops_001_collection_failure_is_unknown_not_fail(monkeypatch, tmp_path):
+    set_policy_env(monkeypatch, tmp_path)
+
+    def fail():
+        raise PermissionError("no access")
+
+    monitor = SimpleNamespace(subscription_diagnostic_settings=SimpleNamespace(list=fail))
+    stub_collector(monkeypatch, az_secops_001, make_collector(monitor_client=monitor))
+    assert az_secops_001.scan(_client(), _SUB) == []
+
+
+# ── AZ-SECOPS-002: required activity-log categories ─────────────────────────
+
+
+def test_secops_002_all_categories_enabled_is_compliant(monkeypatch, tmp_path):
+    set_policy_env(monkeypatch, tmp_path)
+    logs = [log_setting(category=c, enabled=True) for c in ("Administrative", "Security", "Policy", "ServiceHealth")]
+    monitor = SimpleNamespace(
+        subscription_diagnostic_settings=SimpleNamespace(
+            list=lambda: [diagnostic_setting(workspace_id=_APPROVED, logs=logs)]
+        )
+    )
+    stub_collector(monkeypatch, az_secops_002, make_collector(monitor_client=monitor))
+    assert az_secops_002.scan(_client(), _SUB) == []
+
+
+def test_secops_002_missing_category_is_noncompliant(monkeypatch, tmp_path):
+    set_policy_env(monkeypatch, tmp_path)
+    logs = [log_setting(category=c, enabled=True) for c in ("Administrative", "Security")]
+    monitor = SimpleNamespace(
+        subscription_diagnostic_settings=SimpleNamespace(
+            list=lambda: [diagnostic_setting(workspace_id=_APPROVED, logs=logs)]
+        )
+    )
+    stub_collector(monkeypatch, az_secops_002, make_collector(monitor_client=monitor))
+    findings = az_secops_002.scan(_client(), _SUB)
+    assert len(findings) == 1
+    assert set(findings[0]["metadata"]["category"]) == {"policy", "servicehealth"}
+
+
+def test_secops_002_disabled_category_counts_as_missing(monkeypatch, tmp_path):
+    set_policy_env(monkeypatch, tmp_path)
+    logs = [
+        log_setting(category="Administrative", enabled=True),
+        log_setting(category="Security", enabled=False),
+        log_setting(category="Policy", enabled=True),
+        log_setting(category="ServiceHealth", enabled=True),
+    ]
+    monitor = SimpleNamespace(
+        subscription_diagnostic_settings=SimpleNamespace(
+            list=lambda: [diagnostic_setting(workspace_id=_APPROVED, logs=logs)]
+        )
+    )
+    stub_collector(monkeypatch, az_secops_002, make_collector(monitor_client=monitor))
+    findings = az_secops_002.scan(_client(), _SUB)
+    assert len(findings) == 1
+    assert findings[0]["metadata"]["category"] == ["security"]
+
+
+def test_secops_002_no_approved_export_defers_to_secops_001(monkeypatch, tmp_path):
+    """When there's no approved-destination export at all, AZ-SECOPS-001 owns that finding."""
+    set_policy_env(monkeypatch, tmp_path)
+    monitor = SimpleNamespace(subscription_diagnostic_settings=SimpleNamespace(list=lambda: []))
+    stub_collector(monkeypatch, az_secops_002, make_collector(monitor_client=monitor))
+    assert az_secops_002.scan(_client(), _SUB) == []
+
+
+def test_secops_002_collection_failure_is_unknown(monkeypatch, tmp_path):
+    set_policy_env(monkeypatch, tmp_path)
+
+    def fail():
+        raise RuntimeError("boom")
+
+    monitor = SimpleNamespace(subscription_diagnostic_settings=SimpleNamespace(list=fail))
+    stub_collector(monkeypatch, az_secops_002, make_collector(monitor_client=monitor))
+    assert az_secops_002.scan(_client(), _SUB) == []
+
+
+# ── AZ-SECOPS-003: critical resource diagnostics ────────────────────────────
+
+_KV_ID = "/subscriptions/sub/resourceGroups/rg/providers/Microsoft.KeyVault/vaults/kv1"
+
+
+def _resource_inventory():
+    return [SimpleNamespace(id=_KV_ID, type="Microsoft.KeyVault/vaults")]
+
+
+def test_secops_003_empty_inventory_is_not_applicable(monkeypatch, tmp_path):
+    set_policy_env(monkeypatch, tmp_path)
+    collector = make_collector(resource_inventory=lambda: [])
+    stub_collector(monkeypatch, az_secops_003, collector)
+    assert az_secops_003.scan(_client(), _SUB) == []
+
+
+def test_secops_003_critical_resource_with_approved_export_is_compliant(monkeypatch, tmp_path):
+    set_policy_env(monkeypatch, tmp_path)
+    monitor = SimpleNamespace(
+        diagnostic_settings=SimpleNamespace(list=lambda resource_id: [diagnostic_setting(workspace_id=_APPROVED)])
+    )
+    collector = make_collector(monitor_client=monitor, resource_inventory=_resource_inventory)
+    stub_collector(monkeypatch, az_secops_003, collector)
+    assert az_secops_003.scan(_client(), _SUB) == []
+
+
+def test_secops_003_critical_resource_with_no_export_is_noncompliant(monkeypatch, tmp_path):
+    set_policy_env(monkeypatch, tmp_path)
+    monitor = SimpleNamespace(diagnostic_settings=SimpleNamespace(list=lambda resource_id: []))
+    collector = make_collector(monitor_client=monitor, resource_inventory=_resource_inventory)
+    stub_collector(monkeypatch, az_secops_003, collector)
+    findings = az_secops_003.scan(_client(), _SUB)
+    assert len(findings) == 1
+    assert findings[0]["resource_id"] == _KV_ID
+    assert findings[0]["metadata"]["destination"] == "none-approved"
+
+
+def test_secops_003_approved_exclusion_suppresses_finding(monkeypatch, tmp_path):
+    set_policy_env(monkeypatch, tmp_path, approved_exclusions=[_KV_ID])
+    monitor = SimpleNamespace(diagnostic_settings=SimpleNamespace(list=lambda resource_id: []))
+    collector = make_collector(monitor_client=monitor, resource_inventory=_resource_inventory)
+    stub_collector(monkeypatch, az_secops_003, collector)
+    assert az_secops_003.scan(_client(), _SUB) == []
+
+
+def test_secops_003_inventory_failure_is_unknown(monkeypatch, tmp_path):
+    set_policy_env(monkeypatch, tmp_path)
+
+    def fail_inventory():
+        raise RuntimeError("no access")
+
+    collector = make_collector(resource_inventory=fail_inventory)
+    stub_collector(monkeypatch, az_secops_003, collector)
+    assert az_secops_003.scan(_client(), _SUB) == []
+
+
+def test_secops_003_diagnostic_settings_failure_is_unknown(monkeypatch, tmp_path):
+    set_policy_env(monkeypatch, tmp_path)
+
+    def fail_list(resource_id):
+        raise PermissionError("denied")
+
+    monitor = SimpleNamespace(diagnostic_settings=SimpleNamespace(list=fail_list))
+    collector = make_collector(monitor_client=monitor, resource_inventory=_resource_inventory)
+    stub_collector(monkeypatch, az_secops_003, collector)
+    assert az_secops_003.scan(_client(), _SUB) == []

--- a/tests/test_rules_security_operations_retention.py
+++ b/tests/test_rules_security_operations_retention.py
@@ -1,0 +1,199 @@
+"""Tests for AZ-SECOPS-004 (retention) and AZ-SECOPS-005 (destination ownership)."""
+
+from types import SimpleNamespace
+
+import scanner.rules.az_secops_004 as az_secops_004
+import scanner.rules.az_secops_005 as az_secops_005
+from tests.helpers.mock_azure import MockAzureClient
+from tests.helpers.security_operations import (
+    diagnostic_setting,
+    log_setting,
+    make_collector,
+    retention_policy,
+    set_policy_env,
+    stub_collector,
+)
+
+_APPROVED = (
+    "/subscriptions/sub/resourcegroups/security/providers/microsoft.operationalinsights/workspaces/central-security"
+)
+_SUB = "00000000-0000-0000-0000-000000000001"
+_KV_ID = "/subscriptions/sub/resourceGroups/rg/providers/Microsoft.KeyVault/vaults/kv1"
+_LOCAL_STORAGE = "/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Storage/storageAccounts/localsa"
+
+
+def _client() -> MockAzureClient:
+    return MockAzureClient()
+
+
+def _resource_inventory():
+    return [SimpleNamespace(id=_KV_ID, type="Microsoft.KeyVault/vaults")]
+
+
+# ── AZ-SECOPS-004: retention boundaries ─────────────────────────────────────
+
+
+def test_secops_004_retention_at_minimum_is_compliant(monkeypatch, tmp_path):
+    """Boundary: exactly the minimum retention must not be flagged."""
+    set_policy_env(monkeypatch, tmp_path, minimum_retention_days=90)
+    logs = [log_setting(category="AuditEvent", enabled=True, retention_policy=retention_policy(enabled=True, days=90))]
+    monitor = SimpleNamespace(
+        diagnostic_settings=SimpleNamespace(
+            list=lambda resource_id: [diagnostic_setting(storage_account_id=_LOCAL_STORAGE, logs=logs)]
+        )
+    )
+    collector = make_collector(monitor_client=monitor, resource_inventory=_resource_inventory)
+    stub_collector(monkeypatch, az_secops_004, collector)
+    assert az_secops_004.scan(_client(), _SUB) == []
+
+
+def test_secops_004_retention_one_day_below_minimum_is_noncompliant(monkeypatch, tmp_path):
+    """Boundary: one day below the minimum must be flagged."""
+    set_policy_env(monkeypatch, tmp_path, minimum_retention_days=90)
+    logs = [log_setting(category="AuditEvent", enabled=True, retention_policy=retention_policy(enabled=True, days=89))]
+    monitor = SimpleNamespace(
+        diagnostic_settings=SimpleNamespace(
+            list=lambda resource_id: [diagnostic_setting(storage_account_id=_LOCAL_STORAGE, logs=logs)]
+        )
+    )
+    collector = make_collector(monitor_client=monitor, resource_inventory=_resource_inventory)
+    stub_collector(monkeypatch, az_secops_004, collector)
+    findings = az_secops_004.scan(_client(), _SUB)
+    assert len(findings) == 1
+    assert findings[0]["metadata"]["retention"][0]["retention_days"] == 89
+
+
+def test_secops_004_retention_disabled_is_noncompliant(monkeypatch, tmp_path):
+    set_policy_env(monkeypatch, tmp_path, minimum_retention_days=90)
+    logs = [
+        log_setting(category="AuditEvent", enabled=True, retention_policy=retention_policy(enabled=False, days=365))
+    ]
+    monitor = SimpleNamespace(
+        diagnostic_settings=SimpleNamespace(
+            list=lambda resource_id: [diagnostic_setting(storage_account_id=_LOCAL_STORAGE, logs=logs)]
+        )
+    )
+    collector = make_collector(monitor_client=monitor, resource_inventory=_resource_inventory)
+    stub_collector(monkeypatch, az_secops_004, collector)
+    findings = az_secops_004.scan(_client(), _SUB)
+    assert len(findings) == 1
+    assert findings[0]["metadata"]["retention"][0]["retention_enabled"] is False
+
+
+def test_secops_004_log_analytics_only_export_is_not_evaluated(monkeypatch, tmp_path):
+    """Workspace-only exports have no Storage retention_policy semantics; rule must not flag them."""
+    set_policy_env(monkeypatch, tmp_path, minimum_retention_days=90)
+    monitor = SimpleNamespace(
+        diagnostic_settings=SimpleNamespace(list=lambda resource_id: [diagnostic_setting(workspace_id=_APPROVED)])
+    )
+    collector = make_collector(monitor_client=monitor, resource_inventory=_resource_inventory)
+    stub_collector(monkeypatch, az_secops_004, collector)
+    assert az_secops_004.scan(_client(), _SUB) == []
+
+
+def test_secops_004_empty_inventory_is_not_applicable(monkeypatch, tmp_path):
+    set_policy_env(monkeypatch, tmp_path)
+    collector = make_collector(resource_inventory=lambda: [])
+    stub_collector(monkeypatch, az_secops_004, collector)
+    assert az_secops_004.scan(_client(), _SUB) == []
+
+
+def test_secops_004_approved_exclusion_suppresses_finding(monkeypatch, tmp_path):
+    set_policy_env(monkeypatch, tmp_path, minimum_retention_days=90, approved_exclusions=[_KV_ID])
+    logs = [log_setting(category="AuditEvent", enabled=True, retention_policy=retention_policy(enabled=False, days=1))]
+    monitor = SimpleNamespace(
+        diagnostic_settings=SimpleNamespace(
+            list=lambda resource_id: [diagnostic_setting(storage_account_id=_LOCAL_STORAGE, logs=logs)]
+        )
+    )
+    collector = make_collector(monitor_client=monitor, resource_inventory=_resource_inventory)
+    stub_collector(monkeypatch, az_secops_004, collector)
+    assert az_secops_004.scan(_client(), _SUB) == []
+
+
+def test_secops_004_permission_failure_is_unknown(monkeypatch, tmp_path):
+    set_policy_env(monkeypatch, tmp_path)
+
+    def fail(resource_id):
+        raise PermissionError("denied")
+
+    monitor = SimpleNamespace(diagnostic_settings=SimpleNamespace(list=fail))
+    collector = make_collector(monitor_client=monitor, resource_inventory=_resource_inventory)
+    stub_collector(monkeypatch, az_secops_004, collector)
+    assert az_secops_004.scan(_client(), _SUB) == []
+
+
+# ── AZ-SECOPS-005: destination modifiable by workload administrators ───────
+
+
+def test_secops_005_approved_destination_present_is_compliant(monkeypatch, tmp_path):
+    set_policy_env(monkeypatch, tmp_path)
+    monitor = SimpleNamespace(
+        diagnostic_settings=SimpleNamespace(list=lambda resource_id: [diagnostic_setting(workspace_id=_APPROVED)])
+    )
+    collector = make_collector(monitor_client=monitor, resource_inventory=_resource_inventory)
+    stub_collector(monkeypatch, az_secops_005, collector)
+    assert az_secops_005.scan(_client(), _SUB) == []
+
+
+def test_secops_005_only_same_resource_group_destination_is_noncompliant(monkeypatch, tmp_path):
+    """Destination lives in the same RG as the workload -> workload admin can modify it."""
+    set_policy_env(monkeypatch, tmp_path)
+    monitor = SimpleNamespace(
+        diagnostic_settings=SimpleNamespace(
+            list=lambda resource_id: [diagnostic_setting(storage_account_id=_LOCAL_STORAGE)]
+        )
+    )
+    collector = make_collector(monitor_client=monitor, resource_inventory=_resource_inventory)
+    stub_collector(monkeypatch, az_secops_005, collector)
+    findings = az_secops_005.scan(_client(), _SUB)
+    assert len(findings) == 1
+    assert findings[0]["metadata"]["ownership"] == "workload-administrator"
+
+
+def test_secops_005_no_export_defers_to_secops_003(monkeypatch, tmp_path):
+    set_policy_env(monkeypatch, tmp_path)
+    monitor = SimpleNamespace(diagnostic_settings=SimpleNamespace(list=lambda resource_id: []))
+    collector = make_collector(monitor_client=monitor, resource_inventory=_resource_inventory)
+    stub_collector(monkeypatch, az_secops_005, collector)
+    assert az_secops_005.scan(_client(), _SUB) == []
+
+
+def test_secops_005_different_resource_group_destination_is_compliant(monkeypatch, tmp_path):
+    """A destination outside the workload's own RG (but not on the approved list) is not flagged
+    by this rule even though it's not centrally approved — that gap is AZ-SECOPS-001/003's job."""
+    set_policy_env(monkeypatch, tmp_path)
+    other_rg_dest = (
+        "/subscriptions/sub/resourceGroups/other-team-rg/providers/Microsoft.Storage/storageAccounts/othersa"
+    )
+    monitor = SimpleNamespace(
+        diagnostic_settings=SimpleNamespace(
+            list=lambda resource_id: [diagnostic_setting(storage_account_id=other_rg_dest)]
+        )
+    )
+    collector = make_collector(monitor_client=monitor, resource_inventory=_resource_inventory)
+    stub_collector(monkeypatch, az_secops_005, collector)
+    assert az_secops_005.scan(_client(), _SUB) == []
+
+
+def test_secops_005_approved_exclusion_suppresses_finding(monkeypatch, tmp_path):
+    set_policy_env(monkeypatch, tmp_path, approved_exclusions=[_KV_ID])
+    monitor = SimpleNamespace(
+        diagnostic_settings=SimpleNamespace(
+            list=lambda resource_id: [diagnostic_setting(storage_account_id=_LOCAL_STORAGE)]
+        )
+    )
+    collector = make_collector(monitor_client=monitor, resource_inventory=_resource_inventory)
+    stub_collector(monkeypatch, az_secops_005, collector)
+    assert az_secops_005.scan(_client(), _SUB) == []
+
+
+def test_secops_005_inventory_failure_is_unknown(monkeypatch, tmp_path):
+    set_policy_env(monkeypatch, tmp_path)
+
+    def fail_inventory():
+        raise RuntimeError("no access")
+
+    collector = make_collector(resource_inventory=fail_inventory)
+    stub_collector(monkeypatch, az_secops_005, collector)
+    assert az_secops_005.scan(_client(), _SUB) == []

--- a/tests/test_rules_security_operations_retention.py
+++ b/tests/test_rules_security_operations_retention.py
@@ -151,6 +151,27 @@ def test_secops_005_only_same_resource_group_destination_is_noncompliant(monkeyp
     assert findings[0]["metadata"]["ownership"] == "workload-administrator"
 
 
+def test_secops_005_same_resource_group_event_hub_is_noncompliant(monkeypatch, tmp_path):
+    """An Event Hub destination in the workload RG is evaluated like Storage and Log Analytics."""
+    set_policy_env(monkeypatch, tmp_path)
+    local_event_hub_rule = (
+        "/subscriptions/sub/resourceGroups/rg/providers/Microsoft.EventHub/namespaces/app-hub/"
+        "authorizationRules/diagnostics"
+    )
+    monitor = SimpleNamespace(
+        diagnostic_settings=SimpleNamespace(
+            list=lambda resource_id: [diagnostic_setting(event_hub_authorization_rule_id=local_event_hub_rule)]
+        )
+    )
+    collector = make_collector(monitor_client=monitor, resource_inventory=_resource_inventory)
+    stub_collector(monkeypatch, az_secops_005, collector)
+
+    findings = az_secops_005.scan(_client(), _SUB)
+
+    assert len(findings) == 1
+    assert findings[0]["metadata"]["ownership"] == "workload-administrator"
+
+
 def test_secops_005_no_export_defers_to_secops_003(monkeypatch, tmp_path):
     set_policy_env(monkeypatch, tmp_path)
     monitor = SimpleNamespace(diagnostic_settings=SimpleNamespace(list=lambda resource_id: []))

--- a/tests/test_rules_security_operations_sentinel.py
+++ b/tests/test_rules_security_operations_sentinel.py
@@ -319,3 +319,89 @@ def test_secops_010_action_groups_api_failure_is_unknown(monkeypatch, tmp_path):
     collector = make_collector(monitor_client=monitor)
     stub_collector(monkeypatch, az_secops_010, collector)
     assert az_secops_010.scan(_client(), _SUB) == []
+
+
+def test_secops_010_onboarding_discovery_partial_is_unknown_not_fail(monkeypatch, tmp_path):
+    """One workspace's Sentinel onboarding check fails; the other is confirmed onboarded with
+    no automation rule. The failed workspace might have had the routing rule, so this must be
+    UNKNOWN, not a confident FAIL."""
+    set_policy_env(monkeypatch, tmp_path)
+    ws_ok = workspace(name="ws-ok", resource_group="rg-ok")
+    ws_denied = workspace(name="ws-denied", resource_group="rg-denied")
+    monitor = SimpleNamespace(action_groups=SimpleNamespace(list_by_subscription_id=lambda: []))
+
+    def sentinel_factory(rg):
+        if rg == "rg-denied":
+            return _sentinel_client(raise_onboarding=True)
+        return _sentinel_client(onboarded=True, automation_rules=[])
+
+    collector = make_collector(
+        monitor_client=monitor,
+        log_analytics_client=_log_analytics([ws_ok, ws_denied]),
+        sentinel_client_factory=sentinel_factory,
+    )
+    stub_collector(monkeypatch, az_secops_010, collector)
+    assert az_secops_010.scan(_client(), _SUB) == []
+
+
+def test_secops_010_automation_rules_partial_is_unknown_not_fail(monkeypatch, tmp_path):
+    """Both workspaces are confirmed Sentinel-onboarded, but the automation-rules collection
+    fails for one of them. The reachable workspace has no automation rule, but the unreachable
+    one might have had the routing rule, so this must be UNKNOWN, not a confident FAIL."""
+    set_policy_env(monkeypatch, tmp_path)
+    ws_ok = workspace(name="ws-ok", resource_group="rg-ok")
+    ws_broken = workspace(name="ws-broken", resource_group="rg-broken")
+    monitor = SimpleNamespace(action_groups=SimpleNamespace(list_by_subscription_id=lambda: []))
+
+    def automation_rules_list(rg, wn):
+        if rg == "rg-broken":
+            raise RuntimeError("boom")
+        return []
+
+    def sentinel_factory(rg):
+        return SimpleNamespace(
+            sentinel_onboarding_states=SimpleNamespace(list=lambda rg, wn: _onboarding_states_list(1)),
+            data_connectors=SimpleNamespace(list=lambda rg, wn: []),
+            alert_rules=SimpleNamespace(list=lambda rg, wn: []),
+            automation_rules=SimpleNamespace(list=automation_rules_list),
+        )
+
+    collector = make_collector(
+        monitor_client=monitor,
+        log_analytics_client=_log_analytics([ws_ok, ws_broken]),
+        sentinel_client_factory=sentinel_factory,
+    )
+    stub_collector(monkeypatch, az_secops_010, collector)
+    assert az_secops_010.scan(_client(), _SUB) == []
+
+
+def test_secops_010_automation_rules_partial_but_coverage_found_is_compliant(monkeypatch, tmp_path):
+    """Automation-rules collection fails for one workspace, but the reachable workspace already
+    has a routing rule. Coverage is real evidence and should short-circuit before the incomplete
+    evidence from the other workspace is even considered."""
+    set_policy_env(monkeypatch, tmp_path)
+    ws_covered = workspace(name="ws-covered", resource_group="rg-covered")
+    ws_broken = workspace(name="ws-broken", resource_group="rg-broken")
+    monitor = SimpleNamespace(action_groups=SimpleNamespace(list_by_subscription_id=lambda: []))
+    automation_rules = [SimpleNamespace(display_name="route-to-playbook")]
+
+    def automation_rules_list(rg, wn):
+        if rg == "rg-broken":
+            raise RuntimeError("boom")
+        return automation_rules
+
+    def sentinel_factory(rg):
+        return SimpleNamespace(
+            sentinel_onboarding_states=SimpleNamespace(list=lambda rg, wn: _onboarding_states_list(1)),
+            data_connectors=SimpleNamespace(list=lambda rg, wn: []),
+            alert_rules=SimpleNamespace(list=lambda rg, wn: []),
+            automation_rules=SimpleNamespace(list=automation_rules_list),
+        )
+
+    collector = make_collector(
+        monitor_client=monitor,
+        log_analytics_client=_log_analytics([ws_covered, ws_broken]),
+        sentinel_client_factory=sentinel_factory,
+    )
+    stub_collector(monkeypatch, az_secops_010, collector)
+    assert az_secops_010.scan(_client(), _SUB) == []

--- a/tests/test_rules_security_operations_sentinel.py
+++ b/tests/test_rules_security_operations_sentinel.py
@@ -1,0 +1,321 @@
+"""Tests for AZ-SECOPS-008 (connector health), AZ-SECOPS-009 (analytics coverage),
+and AZ-SECOPS-010 (incident-response destination)."""
+
+from types import SimpleNamespace
+
+import scanner.rules.az_secops_008 as az_secops_008
+import scanner.rules.az_secops_009 as az_secops_009
+import scanner.rules.az_secops_010 as az_secops_010
+from tests.helpers.mock_azure import MockAzureClient
+from tests.helpers.security_operations import make_collector, set_policy_env, stub_collector, workspace
+
+_SUB = "00000000-0000-0000-0000-000000000001"
+
+
+def _client() -> MockAzureClient:
+    return MockAzureClient()
+
+
+def _onboarding_states_list(count: int = 1):
+    return SimpleNamespace(value=[SimpleNamespace(name=f"state-{i}") for i in range(count)])
+
+
+def _sentinel_client(onboarded=True, connectors=None, alert_rules=None, automation_rules=None, raise_onboarding=False):
+    def onboarding_list(rg, wn):
+        if raise_onboarding:
+            raise PermissionError("denied")
+        return _onboarding_states_list(1 if onboarded else 0)
+
+    return SimpleNamespace(
+        sentinel_onboarding_states=SimpleNamespace(list=onboarding_list),
+        data_connectors=SimpleNamespace(list=lambda rg, wn: connectors or []),
+        alert_rules=SimpleNamespace(list=lambda rg, wn: alert_rules or []),
+        automation_rules=SimpleNamespace(list=lambda rg, wn: automation_rules or []),
+    )
+
+
+def _log_analytics(workspaces):
+    return SimpleNamespace(workspaces=SimpleNamespace(list=lambda: workspaces))
+
+
+def _connector(kind: str, enabled: bool = True):
+    data_types = SimpleNamespace(alerts=SimpleNamespace(state="Enabled" if enabled else "Disabled"), logs=None)
+    return SimpleNamespace(kind=kind, data_types=data_types)
+
+
+def _alert_rule(display_name: str, severity: str, enabled: bool = True):
+    return SimpleNamespace(display_name=display_name, severity=severity, enabled=enabled)
+
+
+# ── AZ-SECOPS-008: Sentinel data connector health ───────────────────────────
+
+
+def test_secops_008_no_log_analytics_workspaces_is_not_applicable(monkeypatch, tmp_path):
+    set_policy_env(monkeypatch, tmp_path)
+    collector = make_collector(log_analytics_client=_log_analytics([]))
+    stub_collector(monkeypatch, az_secops_008, collector)
+    assert az_secops_008.scan(_client(), _SUB) == []
+
+
+def test_secops_008_no_sentinel_onboarded_workspaces_is_not_applicable(monkeypatch, tmp_path):
+    set_policy_env(monkeypatch, tmp_path)
+    ws = workspace(name="ws1")
+    collector = make_collector(
+        log_analytics_client=_log_analytics([ws]),
+        sentinel_client_factory=lambda rg: _sentinel_client(onboarded=False),
+    )
+    stub_collector(monkeypatch, az_secops_008, collector)
+    assert az_secops_008.scan(_client(), _SUB) == []
+
+
+def test_secops_008_required_connector_present_and_enabled_is_compliant(monkeypatch, tmp_path):
+    set_policy_env(monkeypatch, tmp_path, required_sentinel_connectors=["AzureActiveDirectory"])
+    ws = workspace(name="ws1")
+    connectors = [_connector("AzureActiveDirectory", enabled=True)]
+    collector = make_collector(
+        log_analytics_client=_log_analytics([ws]),
+        sentinel_client_factory=lambda rg: _sentinel_client(onboarded=True, connectors=connectors),
+    )
+    stub_collector(monkeypatch, az_secops_008, collector)
+    assert az_secops_008.scan(_client(), _SUB) == []
+
+
+def test_secops_008_required_connector_missing_is_noncompliant(monkeypatch, tmp_path):
+    set_policy_env(monkeypatch, tmp_path, required_sentinel_connectors=["AzureActiveDirectory"])
+    ws = workspace(name="ws1")
+    collector = make_collector(
+        log_analytics_client=_log_analytics([ws]),
+        sentinel_client_factory=lambda rg: _sentinel_client(onboarded=True, connectors=[]),
+    )
+    stub_collector(monkeypatch, az_secops_008, collector)
+    findings = az_secops_008.scan(_client(), _SUB)
+    assert len(findings) == 1
+    assert findings[0]["metadata"]["connector_state"] == "missing"
+
+
+def test_secops_008_required_connector_disconnected_is_noncompliant(monkeypatch, tmp_path):
+    set_policy_env(monkeypatch, tmp_path, required_sentinel_connectors=["AzureActiveDirectory"])
+    ws = workspace(name="ws1")
+    connectors = [_connector("AzureActiveDirectory", enabled=False)]
+    collector = make_collector(
+        log_analytics_client=_log_analytics([ws]),
+        sentinel_client_factory=lambda rg: _sentinel_client(onboarded=True, connectors=connectors),
+    )
+    stub_collector(monkeypatch, az_secops_008, collector)
+    findings = az_secops_008.scan(_client(), _SUB)
+    assert len(findings) == 1
+    assert findings[0]["metadata"]["connector_state"] == "disconnected"
+
+
+def test_secops_008_empty_required_connectors_is_not_applicable(monkeypatch, tmp_path):
+    set_policy_env(monkeypatch, tmp_path, required_sentinel_connectors=[])
+    collector = make_collector(log_analytics_client=_log_analytics([]))
+    stub_collector(monkeypatch, az_secops_008, collector)
+    assert az_secops_008.scan(_client(), _SUB) == []
+
+
+def test_secops_008_workspace_discovery_failure_is_unknown(monkeypatch, tmp_path):
+    set_policy_env(monkeypatch, tmp_path, required_sentinel_connectors=["AzureActiveDirectory"])
+
+    def fail():
+        raise RuntimeError("boom")
+
+    collector = make_collector(log_analytics_client=SimpleNamespace(workspaces=SimpleNamespace(list=fail)))
+    stub_collector(monkeypatch, az_secops_008, collector)
+    assert az_secops_008.scan(_client(), _SUB) == []
+
+
+def test_secops_008_onboarding_permission_failure_is_unknown_not_fail(monkeypatch, tmp_path):
+    """A workspace whose Sentinel onboarding check 403s must be UNKNOWN, not silently skipped as compliant."""
+    set_policy_env(monkeypatch, tmp_path, required_sentinel_connectors=["AzureActiveDirectory"])
+    ws = workspace(name="ws1")
+    collector = make_collector(
+        log_analytics_client=_log_analytics([ws]),
+        sentinel_client_factory=lambda rg: _sentinel_client(raise_onboarding=True),
+    )
+    stub_collector(monkeypatch, az_secops_008, collector)
+    # Only workspace fails and none succeed -> whole collection reported FAILED -> UNKNOWN -> no findings.
+    assert az_secops_008.scan(_client(), _SUB) == []
+
+
+# ── AZ-SECOPS-009: Sentinel high-severity analytics coverage ────────────────
+
+
+def test_secops_009_covered_by_enabled_high_severity_rule_is_compliant(monkeypatch, tmp_path):
+    set_policy_env(monkeypatch, tmp_path, required_high_severity_analytics=["privileged-role-change"])
+    ws = workspace(name="ws1")
+    rules = [_alert_rule("Privileged Role Change Detected", "High", enabled=True)]
+    collector = make_collector(
+        log_analytics_client=_log_analytics([ws]),
+        sentinel_client_factory=lambda rg: _sentinel_client(onboarded=True, alert_rules=rules),
+    )
+    stub_collector(monkeypatch, az_secops_009, collector)
+    assert az_secops_009.scan(_client(), _SUB) == []
+
+
+def test_secops_009_disabled_rule_does_not_count_as_coverage(monkeypatch, tmp_path):
+    set_policy_env(monkeypatch, tmp_path, required_high_severity_analytics=["privileged-role-change"])
+    ws = workspace(name="ws1")
+    rules = [_alert_rule("Privileged Role Change Detected", "High", enabled=False)]
+    collector = make_collector(
+        log_analytics_client=_log_analytics([ws]),
+        sentinel_client_factory=lambda rg: _sentinel_client(onboarded=True, alert_rules=rules),
+    )
+    stub_collector(monkeypatch, az_secops_009, collector)
+    findings = az_secops_009.scan(_client(), _SUB)
+    assert len(findings) == 1
+    assert findings[0]["metadata"]["use_case"] == "privileged-role-change"
+
+
+def test_secops_009_low_severity_rule_does_not_count_as_coverage(monkeypatch, tmp_path):
+    set_policy_env(monkeypatch, tmp_path, required_high_severity_analytics=["privileged-role-change"])
+    ws = workspace(name="ws1")
+    rules = [_alert_rule("Privileged Role Change Detected", "Low", enabled=True)]
+    collector = make_collector(
+        log_analytics_client=_log_analytics([ws]),
+        sentinel_client_factory=lambda rg: _sentinel_client(onboarded=True, alert_rules=rules),
+    )
+    stub_collector(monkeypatch, az_secops_009, collector)
+    findings = az_secops_009.scan(_client(), _SUB)
+    assert len(findings) == 1
+
+
+def test_secops_009_no_onboarded_workspaces_is_not_applicable(monkeypatch, tmp_path):
+    set_policy_env(monkeypatch, tmp_path, required_high_severity_analytics=["privileged-role-change"])
+    collector = make_collector(log_analytics_client=_log_analytics([]))
+    stub_collector(monkeypatch, az_secops_009, collector)
+    assert az_secops_009.scan(_client(), _SUB) == []
+
+
+def test_secops_009_empty_required_analytics_is_not_applicable(monkeypatch, tmp_path):
+    set_policy_env(monkeypatch, tmp_path, required_high_severity_analytics=[])
+    collector = make_collector(log_analytics_client=_log_analytics([]))
+    stub_collector(monkeypatch, az_secops_009, collector)
+    assert az_secops_009.scan(_client(), _SUB) == []
+
+
+def test_secops_009_alert_rules_collection_failure_is_unknown(monkeypatch, tmp_path):
+    set_policy_env(monkeypatch, tmp_path, required_high_severity_analytics=["privileged-role-change"])
+    ws = workspace(name="ws1")
+
+    def fail(rg, wn):
+        raise RuntimeError("boom")
+
+    sentinel = SimpleNamespace(
+        sentinel_onboarding_states=SimpleNamespace(list=lambda rg, wn: _onboarding_states_list(1)),
+        alert_rules=SimpleNamespace(list=fail),
+        data_connectors=SimpleNamespace(list=lambda rg, wn: []),
+        automation_rules=SimpleNamespace(list=lambda rg, wn: []),
+    )
+    collector = make_collector(log_analytics_client=_log_analytics([ws]), sentinel_client_factory=lambda rg: sentinel)
+    stub_collector(monkeypatch, az_secops_009, collector)
+    assert az_secops_009.scan(_client(), _SUB) == []
+
+
+# ── AZ-SECOPS-010: incident-response destination ────────────────────────────
+
+
+def _action_group(enabled=True, email_receivers=None):
+    return SimpleNamespace(
+        enabled=enabled,
+        email_receivers=email_receivers or [],
+        sms_receivers=[],
+        webhook_receivers=[],
+        itsm_receivers=[],
+        azure_app_push_receivers=[],
+        automation_runbook_receivers=[],
+        voice_receivers=[],
+        logic_app_receivers=[],
+        azure_function_receivers=[],
+        event_hub_receivers=[],
+    )
+
+
+def test_secops_010_monitored_action_group_is_compliant(monkeypatch, tmp_path):
+    set_policy_env(monkeypatch, tmp_path)
+    monitor = SimpleNamespace(
+        action_groups=SimpleNamespace(
+            list_by_subscription_id=lambda: [_action_group(enabled=True, email_receivers=[SimpleNamespace()])]
+        )
+    )
+    collector = make_collector(monitor_client=monitor)
+    stub_collector(monkeypatch, az_secops_010, collector)
+    assert az_secops_010.scan(_client(), _SUB) == []
+
+
+def test_secops_010_action_group_with_no_receivers_is_not_monitored(monkeypatch, tmp_path):
+    set_policy_env(monkeypatch, tmp_path)
+    monitor = SimpleNamespace(
+        action_groups=SimpleNamespace(list_by_subscription_id=lambda: [_action_group(enabled=True)])
+    )
+    collector = make_collector(monitor_client=monitor, log_analytics_client=_log_analytics([]))
+    stub_collector(monkeypatch, az_secops_010, collector)
+    findings = az_secops_010.scan(_client(), _SUB)
+    assert len(findings) == 1
+    assert findings[0]["metadata"]["destination"] == "none-monitored"
+
+
+def test_secops_010_disabled_action_group_is_not_monitored(monkeypatch, tmp_path):
+    set_policy_env(monkeypatch, tmp_path)
+    monitor = SimpleNamespace(
+        action_groups=SimpleNamespace(
+            list_by_subscription_id=lambda: [_action_group(enabled=False, email_receivers=[SimpleNamespace()])]
+        )
+    )
+    collector = make_collector(monitor_client=monitor, log_analytics_client=_log_analytics([]))
+    stub_collector(monkeypatch, az_secops_010, collector)
+    findings = az_secops_010.scan(_client(), _SUB)
+    assert len(findings) == 1
+
+
+def test_secops_010_no_action_group_but_sentinel_automation_rule_is_compliant(monkeypatch, tmp_path):
+    """A Sentinel automation rule routing incidents is an accepted alternative destination."""
+    set_policy_env(monkeypatch, tmp_path)
+    ws = workspace(name="ws1")
+    monitor = SimpleNamespace(action_groups=SimpleNamespace(list_by_subscription_id=lambda: []))
+    automation_rules = [SimpleNamespace(display_name="route-to-playbook")]
+    collector = make_collector(
+        monitor_client=monitor,
+        log_analytics_client=_log_analytics([ws]),
+        sentinel_client_factory=lambda rg: _sentinel_client(onboarded=True, automation_rules=automation_rules),
+    )
+    stub_collector(monkeypatch, az_secops_010, collector)
+    assert az_secops_010.scan(_client(), _SUB) == []
+
+
+def test_secops_010_no_action_group_and_no_automation_rule_is_noncompliant(monkeypatch, tmp_path):
+    set_policy_env(monkeypatch, tmp_path)
+    ws = workspace(name="ws1")
+    monitor = SimpleNamespace(action_groups=SimpleNamespace(list_by_subscription_id=lambda: []))
+    collector = make_collector(
+        monitor_client=monitor,
+        log_analytics_client=_log_analytics([ws]),
+        sentinel_client_factory=lambda rg: _sentinel_client(onboarded=True, automation_rules=[]),
+    )
+    stub_collector(monkeypatch, az_secops_010, collector)
+    findings = az_secops_010.scan(_client(), _SUB)
+    assert len(findings) == 1
+    assert findings[0]["metadata"]["sentinel_automation_rule_coverage"] is False
+
+
+def test_secops_010_empty_action_groups_inventory_is_noncompliant_not_unknown(monkeypatch, tmp_path):
+    """An empty (but successfully collected) action-group inventory is real evidence of absence."""
+    set_policy_env(monkeypatch, tmp_path)
+    monitor = SimpleNamespace(action_groups=SimpleNamespace(list_by_subscription_id=lambda: []))
+    collector = make_collector(monitor_client=monitor, log_analytics_client=_log_analytics([]))
+    stub_collector(monkeypatch, az_secops_010, collector)
+    findings = az_secops_010.scan(_client(), _SUB)
+    assert len(findings) == 1
+    assert findings[0]["metadata"]["action_groups_found"] == 0
+
+
+def test_secops_010_action_groups_api_failure_is_unknown(monkeypatch, tmp_path):
+    set_policy_env(monkeypatch, tmp_path)
+
+    def fail():
+        raise PermissionError("denied")
+
+    monitor = SimpleNamespace(action_groups=SimpleNamespace(list_by_subscription_id=fail))
+    collector = make_collector(monitor_client=monitor)
+    stub_collector(monkeypatch, az_secops_010, collector)
+    assert az_secops_010.scan(_client(), _SUB) == []

--- a/tests/test_security_operations_collectors.py
+++ b/tests/test_security_operations_collectors.py
@@ -1,0 +1,197 @@
+"""Tests for the issue #262 collector extensions: Defender pricing/assessments and
+Sentinel auto-discovery (controls 6-10). Complements test_security_operations_foundation.py,
+which covers the original subscription/resource diagnostic-settings collectors and must not change."""
+
+from types import SimpleNamespace
+
+from scanner.security_operations import CollectionStatus, SecurityOperationsCollector, workspace_scope_key
+
+
+def _workspace(name: str, rg: str = "rg-sec") -> SimpleNamespace:
+    return SimpleNamespace(
+        id=f"/subscriptions/sub/resourceGroups/{rg}/providers/Microsoft.OperationalInsights/workspaces/{name}",
+        name=name,
+    )
+
+
+# ── Defender pricing / assessments ──────────────────────────────────────────
+
+
+def test_defender_pricings_unwraps_pricing_list_value():
+    security = SimpleNamespace(
+        pricings=SimpleNamespace(
+            list=lambda scope_id, **kw: SimpleNamespace(value=[SimpleNamespace(name="VirtualMachines")])
+        )
+    )
+    collector = SecurityOperationsCollector(None, "sub", monitor_client=object(), security_client=security)
+    result = collector.defender_pricings()
+    assert result.status is CollectionStatus.COMPLETE
+    assert result.items[0].name == "VirtualMachines"
+
+
+def test_defender_pricings_failure_is_failed():
+    def fail(scope_id, **kw):
+        raise PermissionError("denied")
+
+    security = SimpleNamespace(pricings=SimpleNamespace(list=fail))
+    collector = SecurityOperationsCollector(None, "sub", monitor_client=object(), security_client=security)
+    assert collector.defender_pricings().status is CollectionStatus.FAILED
+
+
+def test_defender_assessments_empty_success_is_complete():
+    security = SimpleNamespace(assessments=SimpleNamespace(list=lambda scope: []))
+    collector = SecurityOperationsCollector(None, "sub", monitor_client=object(), security_client=security)
+    result = collector.defender_assessments()
+    assert result.status is CollectionStatus.COMPLETE
+    assert result.items == ()
+
+
+def test_defender_assessments_failure_is_failed():
+    def fail(scope):
+        raise RuntimeError("boom")
+
+    security = SimpleNamespace(assessments=SimpleNamespace(list=fail))
+    collector = SecurityOperationsCollector(None, "sub", monitor_client=object(), security_client=security)
+    assert collector.defender_assessments().status is CollectionStatus.FAILED
+
+
+# ── Sentinel auto-discovery ──────────────────────────────────────────────────
+
+
+def test_log_analytics_workspaces_complete_and_failed():
+    log_analytics = SimpleNamespace(workspaces=SimpleNamespace(list=lambda: [_workspace("ws1")]))
+    collector = SecurityOperationsCollector(None, "sub", monitor_client=object(), log_analytics_client=log_analytics)
+    result = collector.log_analytics_workspaces()
+    assert result.status is CollectionStatus.COMPLETE
+    assert result.items[0].name == "ws1"
+
+    def fail():
+        raise RuntimeError("boom")
+
+    failing_la = SimpleNamespace(workspaces=SimpleNamespace(list=fail))
+    failing_collector = SecurityOperationsCollector(
+        None, "sub", monitor_client=object(), log_analytics_client=failing_la
+    )
+    assert failing_collector.log_analytics_workspaces().status is CollectionStatus.FAILED
+
+
+def test_workspace_scope_key_extracts_resource_group_and_name():
+    ws = _workspace("ws1", rg="rg-sec")
+    assert workspace_scope_key(ws) == "rg-sec/ws1"
+
+
+def test_sentinel_onboarded_workspaces_filters_to_onboarded_only():
+    ws1 = _workspace("ws-onboarded")
+    ws2 = _workspace("ws-not-onboarded")
+    log_analytics = SimpleNamespace(workspaces=SimpleNamespace(list=lambda: [ws1, ws2]))
+
+    def factory(rg):
+        def list_states(resource_group, workspace_name):
+            if workspace_name == "ws-onboarded":
+                return SimpleNamespace(value=[SimpleNamespace(name="state")])
+            return SimpleNamespace(value=[])
+
+        return SimpleNamespace(sentinel_onboarding_states=SimpleNamespace(list=list_states))
+
+    collector = SecurityOperationsCollector(
+        None, "sub", monitor_client=object(), log_analytics_client=log_analytics, sentinel_client_factory=factory
+    )
+    result = collector.sentinel_onboarded_workspaces()
+    assert result.status is CollectionStatus.COMPLETE
+    assert [w.name for w in result.items] == ["ws-onboarded"]
+
+
+def test_sentinel_onboarded_workspaces_partial_when_some_checks_fail():
+    ws1 = _workspace("ws-ok")
+    ws2 = _workspace("ws-denied")
+    log_analytics = SimpleNamespace(workspaces=SimpleNamespace(list=lambda: [ws1, ws2]))
+
+    def factory(rg):
+        def list_states(resource_group, workspace_name):
+            if workspace_name == "ws-denied":
+                raise PermissionError("denied")
+            return SimpleNamespace(value=[SimpleNamespace(name="state")])
+
+        return SimpleNamespace(sentinel_onboarding_states=SimpleNamespace(list=list_states))
+
+    collector = SecurityOperationsCollector(
+        None, "sub", monitor_client=object(), log_analytics_client=log_analytics, sentinel_client_factory=factory
+    )
+    result = collector.sentinel_onboarded_workspaces()
+    assert result.status is CollectionStatus.PARTIAL
+    assert [w.name for w in result.items] == ["ws-ok"]
+    assert "rg-sec/ws-denied" in result.failed_scopes
+
+
+def test_sentinel_onboarded_workspaces_failed_when_all_checks_fail():
+    ws1 = _workspace("ws-denied-1")
+    log_analytics = SimpleNamespace(workspaces=SimpleNamespace(list=lambda: [ws1]))
+
+    def factory(rg):
+        def list_states(resource_group, workspace_name):
+            raise PermissionError("denied")
+
+        return SimpleNamespace(sentinel_onboarding_states=SimpleNamespace(list=list_states))
+
+    collector = SecurityOperationsCollector(
+        None, "sub", monitor_client=object(), log_analytics_client=log_analytics, sentinel_client_factory=factory
+    )
+    result = collector.sentinel_onboarded_workspaces()
+    assert result.status is CollectionStatus.FAILED
+
+
+def test_sentinel_onboarded_workspaces_propagates_log_analytics_failure():
+    def fail():
+        raise RuntimeError("boom")
+
+    log_analytics = SimpleNamespace(workspaces=SimpleNamespace(list=fail))
+    collector = SecurityOperationsCollector(None, "sub", monitor_client=object(), log_analytics_client=log_analytics)
+    assert collector.sentinel_onboarded_workspaces().status is CollectionStatus.FAILED
+
+
+def test_sentinel_data_connectors_collects_per_workspace():
+    ws1 = _workspace("ws1")
+    connector = SimpleNamespace(kind="AzureActiveDirectory")
+
+    def factory(rg):
+        return SimpleNamespace(data_connectors=SimpleNamespace(list=lambda rg_, wn: [connector]))
+
+    collector = SecurityOperationsCollector(None, "sub", monitor_client=object(), sentinel_client_factory=factory)
+    result = collector.sentinel_data_connectors([ws1])
+    assert result.status is CollectionStatus.COMPLETE
+    assert result.items[0]["rg-sec/ws1"][0].kind == "AzureActiveDirectory"
+
+
+def test_sentinel_data_connectors_partial_on_mixed_failure():
+    ws1 = _workspace("ws-ok")
+    ws2 = _workspace("ws-fail")
+
+    def factory(rg):
+        def list_connectors(rg_, wn):
+            if wn == "ws-fail":
+                raise RuntimeError("boom")
+            return [SimpleNamespace(kind="AzureActiveDirectory")]
+
+        return SimpleNamespace(data_connectors=SimpleNamespace(list=list_connectors))
+
+    collector = SecurityOperationsCollector(None, "sub", monitor_client=object(), sentinel_client_factory=factory)
+    result = collector.sentinel_data_connectors([ws1, ws2])
+    assert result.status is CollectionStatus.PARTIAL
+    assert "rg-sec/ws-fail" in result.failed_scopes
+
+
+def test_action_groups_complete_and_failed():
+    monitor = SimpleNamespace(
+        action_groups=SimpleNamespace(list_by_subscription_id=lambda: [SimpleNamespace(enabled=True)])
+    )
+    collector = SecurityOperationsCollector(None, "sub", monitor_client=monitor)
+    result = collector.action_groups()
+    assert result.status is CollectionStatus.COMPLETE
+    assert len(result.items) == 1
+
+    def fail():
+        raise PermissionError("secret must not leak")
+
+    failing_monitor = SimpleNamespace(action_groups=SimpleNamespace(list_by_subscription_id=fail))
+    failing_collector = SecurityOperationsCollector(None, "sub", monitor_client=failing_monitor)
+    assert failing_collector.action_groups().status is CollectionStatus.FAILED

--- a/tests/test_security_operations_foundation.py
+++ b/tests/test_security_operations_foundation.py
@@ -1,0 +1,99 @@
+"""Tests for issue #262 policy and read-only collection contracts."""
+
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from scanner.security_operations import (
+    CollectionStatus,
+    SecurityOperationsCollector,
+    load_security_operations_policy,
+)
+
+
+def _policy(tmp_path, **overrides):
+    payload = {
+        "critical_resource_types": ["Microsoft.KeyVault/vaults"],
+        "approved_destination_ids": ["/subscriptions/sub/workspaces/security"],
+        "required_activity_categories": ["Administrative", "Security"],
+        "minimum_retention_days": 90,
+        "required_defender_plans": ["VirtualMachines"],
+        "defender_recommendation_sla_days": 30,
+        "required_sentinel_connectors": ["AzureActiveDirectory"],
+        "required_high_severity_analytics": ["privileged-role-change"],
+        "approved_exclusions": [],
+    }
+    payload.update(overrides)
+    path = tmp_path / "policy.json"
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return path
+
+
+def test_policy_is_strict_and_normalised(tmp_path):
+    policy = load_security_operations_policy(_policy(tmp_path))
+    assert policy.critical_resource_types == {"microsoft.keyvault/vaults"}
+    assert policy.minimum_retention_days == 90
+
+
+@pytest.mark.parametrize(
+    "override",
+    [
+        {"minimum_retention_days": 0},
+        {"required_activity_categories": "Security"},
+        {"approved_exclusions": [""]},
+    ],
+)
+def test_policy_rejects_unsafe_shapes(tmp_path, override):
+    with pytest.raises(ValueError):
+        load_security_operations_policy(_policy(tmp_path, **override))
+
+
+def test_subscription_diagnostics_distinguish_empty_success_from_failure():
+    complete_monitor = SimpleNamespace(
+        subscription_diagnostic_settings=SimpleNamespace(list=lambda: []),
+    )
+    complete = SecurityOperationsCollector(None, "sub", monitor_client=complete_monitor)
+    assert complete.subscription_diagnostic_settings().status is CollectionStatus.COMPLETE
+    assert complete.subscription_diagnostic_settings().items == ()
+
+    def fail():
+        raise PermissionError("secret response must not escape")
+
+    failed_monitor = SimpleNamespace(subscription_diagnostic_settings=SimpleNamespace(list=fail))
+    failed = SecurityOperationsCollector(None, "sub", monitor_client=failed_monitor)
+    result = failed.subscription_diagnostic_settings()
+    assert result.status is CollectionStatus.FAILED
+    assert result.error_code == "COLLECTION_FAILED"
+
+
+def test_resource_diagnostics_are_read_per_resource_and_fail_closed():
+    calls = []
+    monitor = SimpleNamespace(
+        diagnostic_settings=SimpleNamespace(list=lambda resource_id: calls.append(resource_id) or [resource_id]),
+    )
+    collector = SecurityOperationsCollector(None, "sub", monitor_client=monitor)
+    result = collector.resource_diagnostic_settings(["/resource/one", "/resource/two"])
+    assert result.status is CollectionStatus.COMPLETE
+    assert calls == ["/resource/one", "/resource/two"]
+    assert result.items[0]["/resource/one"] == ("/resource/one",)
+
+
+def test_critical_resource_inventory_uses_policy_and_preserves_failure(tmp_path):
+    policy = load_security_operations_policy(_policy(tmp_path))
+    resources = [
+        SimpleNamespace(id="/critical", type="Microsoft.KeyVault/vaults"),
+        SimpleNamespace(id="/other", type="Microsoft.Compute/virtualMachines"),
+    ]
+    collector = SecurityOperationsCollector(None, "sub", monitor_client=object(), resource_inventory=lambda: resources)
+    result = collector.critical_resource_ids(policy)
+    assert result.status is CollectionStatus.COMPLETE
+    assert result.items == ("/critical",)
+
+    failed = SecurityOperationsCollector(
+        None,
+        "sub",
+        monitor_client=object(),
+        resource_inventory=lambda: (_ for _ in ()).throw(RuntimeError("boom")),
+    )
+    assert failed.critical_resource_ids(policy).status is CollectionStatus.FAILED


### PR DESCRIPTION
## Summary

Implements issue #262 as a policy-driven Azure security-operations rule pack covering subscription logging, critical-resource diagnostics, retention, Defender for Cloud operational coverage, and Microsoft Sentinel detection and response readiness.

## What changed

- Added `AZ-SECOPS-001` through `AZ-SECOPS-010` with explicit fail-closed collection behavior.
- Added read-only collectors for Azure Monitor, Defender for Cloud, Log Analytics, and Microsoft Sentinel.
- Added organisation-owned policy configuration with no automatic production defaults.
- Added one CLI remediation playbook per rule.
- Added CIS Azure, NIST CSF, ISO 27001, and SOC 2 mappings without inventing unsupported CIS control IDs.
- Added documentation covering scope, permissions, outcomes, limitations, and evidence behavior.
- Added regression coverage ensuring incomplete Sentinel evidence returns UNKNOWN rather than a false FAIL.

## Validation

- Security-operations tests: 84 passed.
- Ruff: passed.
- Ruff formatting check: 261 files formatted.
- Full local suite: 639 passed, 3 skipped, 1 unrelated local failure caused by a pre-existing Chroma package mismatch in the shared virtual environment.
- Preliminary live, read-only Azure validation completed against an Azure student subscription:
  - Defender plans: 18 collected.
  - Defender assessments: 17 collected.
  - Log Analytics workspaces: 1 collected.
  - Sentinel onboarding: 1 workspace confirmed.
  - Sentinel analytics rules: 1 collected.
  - Sentinel data connectors and automation rules: successfully queried.
  - All ten rules executed with zero execution errors and zero Azure write operations.

## Validation limits

The student subscription contained no in-scope Key Vault, SQL, or Storage resources, so controls 003-005 still require representative enterprise-resource validation. Control 007 also requires a high-severity unhealthy Defender assessment with usable age evidence to validate the complete SLA path. This preliminary test is integration evidence, not final enterprise acceptance certification.

Closes #262
