### PR TITLE
fix(deps): update nanoid for CVE-2026-67213

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -2510,9 +2510,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
## What does this PR do?

Updates the transitive frontend `nanoid` lockfile resolution from `3.3.16` to the patched `3.3.18` release.

## Type of change
- [ ] New scan rule
- [ ] Remediation playbook
- [x] Bug fix
- [ ] Dashboard/front-end work
- [ ] API endpoint
- [ ] Documentation
- [ ] Compliance mapping

## Security context

- Advisory: `GHSA-2v37-7h3g-55p8`
- CVE: `CVE-2026-67213`
- Dependabot alert: #15
- Vulnerable range: `<3.3.18`
- Dependency relationship: transitive runtime dependency through `postcss@8.5.25`

The change is intentionally narrow: only the `nanoid` version, resolved tarball, and integrity entry change in `frontend/package-lock.json`. It does not add `nanoid` as a direct dependency or upgrade any unrelated package.

## Rule details (if applicable)

Not applicable — this is a dependency security fix.

## Testing
- [ ] Tested against a real Azure free trial subscription — not applicable
- [ ] Returns correct JSON output — not applicable
- [x] All GitHub CI and security checks pass
- [x] No hardcoded credentials or secrets

Validation performed from `frontend/`:

- `npm ci` — passed; 241 packages installed, 0 vulnerabilities
- `npm ls nanoid --all` — `postcss@8.5.25 -> nanoid@3.3.18`
- `npm audit --omit=dev` — passed; 0 vulnerabilities
- `npm run lint` — passed
- `npm run test:a11y` — passed
- `npm run test:i18n` — passed
- `npm run build` — passed; 694 modules transformed

Local npm emitted a pre-existing engine warning because the available Node.js version is `22.14.0` while the repository declares `>=22.22.0`; all validation commands still completed successfully.

## Related issue

Closes #284

## Checklist
- [x] Every commit includes a DCO `Signed-off-by` trailer (`git commit -s`; see `docs/dco.md`)
- [x] My code follows the repository conventions — no scanner rule changes
- [x] A remediation playbook is not applicable to this dependency fix
- [x] Compliance mappings are not applicable to this dependency fix
- [x] I have not committed any real Azure credentials
- [x] My branch name follows the convention: `fix/284-nanoid-cve-2026-67213`
