### PR TITLE
feat: add recoverable dashboard error states

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -616,6 +616,9 @@ jobs:
       - name: Run aiSettings tests
         run: node src/utils/aiApi.test.mjs
 
+      - name: Run dashboard load-state tests
+        run: node src/hooks/usePageData.test.mjs
+
       - name: Run accessibility and internationalization checks
         run: npm run test:a11y && npm run test:i18n
 

--- a/frontend/src/components/shared/ErrorState.jsx
+++ b/frontend/src/components/shared/ErrorState.jsx
@@ -1,0 +1,30 @@
+import { FiAlertCircle, FiRefreshCw } from 'react-icons/fi';
+import Button from './Button';
+
+export default function ErrorState({
+  title = 'Unable to load this page',
+  description = 'Check your connection and try again.',
+  onRetry,
+}) {
+  return (
+    <div
+      role="alert"
+      aria-live="assertive"
+      className="flex flex-col items-center justify-center py-16 px-6 text-center rounded-2xl border border-severity-high/30 bg-bg-primary dark:bg-bg-dark-secondary"
+    >
+      <div className="w-14 h-14 rounded-2xl bg-severity-high/10 flex items-center justify-center mb-4">
+        <FiAlertCircle size={24} className="text-severity-high" aria-hidden="true" />
+      </div>
+      <h2 className="text-base font-semibold text-text-primary dark:text-text-dark-primary mb-1">
+        {title}
+      </h2>
+      <p className="text-sm text-text-secondary dark:text-text-dark-tertiary max-w-md mb-5">
+        {description}
+      </p>
+      <Button onClick={onRetry}>
+        <FiRefreshCw size={14} aria-hidden="true" />
+        Try again
+      </Button>
+    </div>
+  );
+}

--- a/frontend/src/hooks/usePageData.js
+++ b/frontend/src/hooks/usePageData.js
@@ -47,14 +47,23 @@ export function createPageDataLoader(load, dispatch) {
   };
 }
 
+export function schedulePageDataLoad(loader) {
+  let active = true;
+  queueMicrotask(() => {
+    if (active) loader.retry();
+  });
+
+  return () => {
+    active = false;
+    loader.cancel();
+  };
+}
+
 export default function usePageData(load) {
   const [state, dispatch] = useReducer(pageDataReducer, initialPageDataState);
   const loader = useMemo(() => createPageDataLoader(load, dispatch), [load]);
 
-  useEffect(() => {
-    loader.retry();
-    return () => loader.cancel();
-  }, [loader]);
+  useEffect(() => schedulePageDataLoad(loader), [loader]);
 
   return { ...state, retry: loader.retry };
 }

--- a/frontend/src/hooks/usePageData.js
+++ b/frontend/src/hooks/usePageData.js
@@ -1,0 +1,60 @@
+import { useEffect, useMemo, useReducer } from 'react';
+
+export const initialPageDataState = {
+  status: 'loading',
+  data: null,
+  error: null,
+};
+
+export function pageDataReducer(state, action) {
+  switch (action.type) {
+    case 'loading':
+      return initialPageDataState;
+    case 'success':
+      return { status: 'success', data: action.data, error: null };
+    case 'error':
+      return { status: 'error', data: null, error: action.error };
+    default:
+      return state;
+  }
+}
+
+export function createPageDataLoader(load, dispatch) {
+  let requestId = 0;
+  let inFlight = false;
+
+  return {
+    async retry() {
+      if (inFlight) return;
+      inFlight = true;
+      const currentRequest = ++requestId;
+      dispatch({ type: 'loading' });
+
+      try {
+        const data = await load();
+        if (currentRequest === requestId) dispatch({ type: 'success', data });
+      } catch (error) {
+        if (currentRequest === requestId) dispatch({ type: 'error', error });
+      } finally {
+        if (currentRequest === requestId) inFlight = false;
+      }
+    },
+
+    cancel() {
+      requestId++;
+      inFlight = false;
+    },
+  };
+}
+
+export default function usePageData(load) {
+  const [state, dispatch] = useReducer(pageDataReducer, initialPageDataState);
+  const loader = useMemo(() => createPageDataLoader(load, dispatch), [load]);
+
+  useEffect(() => {
+    loader.retry();
+    return () => loader.cancel();
+  }, [loader]);
+
+  return { ...state, retry: loader.retry };
+}

--- a/frontend/src/hooks/usePageData.test.mjs
+++ b/frontend/src/hooks/usePageData.test.mjs
@@ -3,6 +3,7 @@ import {
   createPageDataLoader,
   initialPageDataState,
   pageDataReducer,
+  schedulePageDataLoad,
 } from './usePageData.js';
 
 function createHarness(load) {
@@ -97,6 +98,26 @@ test('cancelled loads cannot overwrite state after unmount', async () => {
   harness.loader.cancel();
   resolveLoad('stale');
   await request;
+  assert.deepEqual(harness.transitions.map(({ status }) => status), ['loading']);
+});
+
+test('Strict Mode effect replay starts only one initial request', async () => {
+  let calls = 0;
+  let resolveLoad;
+  const harness = createHarness(() => {
+    calls++;
+    return new Promise((resolve) => { resolveLoad = resolve; });
+  });
+
+  const cancelFirstSetup = schedulePageDataLoad(harness.loader);
+  cancelFirstSetup();
+  const cancelSecondSetup = schedulePageDataLoad(harness.loader);
+  await new Promise((resolve) => queueMicrotask(resolve));
+
+  assert.equal(calls, 1);
+  cancelSecondSetup();
+  resolveLoad('stale');
+  await new Promise((resolve) => queueMicrotask(resolve));
   assert.deepEqual(harness.transitions.map(({ status }) => status), ['loading']);
 });
 

--- a/frontend/src/hooks/usePageData.test.mjs
+++ b/frontend/src/hooks/usePageData.test.mjs
@@ -1,0 +1,118 @@
+import assert from 'node:assert/strict';
+import {
+  createPageDataLoader,
+  initialPageDataState,
+  pageDataReducer,
+} from './usePageData.js';
+
+function createHarness(load) {
+  let state = initialPageDataState;
+  const transitions = [];
+  const dispatch = (action) => {
+    state = pageDataReducer(state, action);
+    transitions.push(state);
+  };
+  return {
+    loader: createPageDataLoader(load, dispatch),
+    getState: () => state,
+    transitions,
+  };
+}
+
+const tests = [];
+function test(description, fn) { tests.push({ description, fn }); }
+
+test('a successful populated load transitions from loading to success', async () => {
+  const data = [{ id: 1 }];
+  const harness = createHarness(async () => data);
+  await harness.loader.retry();
+  assert.deepEqual(harness.transitions.map(({ status }) => status), ['loading', 'success']);
+  assert.equal(harness.getState().data, data);
+});
+
+test('a successful empty load remains distinct from loading', async () => {
+  const harness = createHarness(async () => []);
+  await harness.loader.retry();
+  assert.equal(harness.getState().status, 'success');
+  assert.deepEqual(harness.getState().data, []);
+});
+
+test('a rejected load transitions to an observable error state', async () => {
+  const error = new Error('backend unavailable');
+  const harness = createHarness(async () => { throw error; });
+  await harness.loader.retry();
+  assert.equal(harness.getState().status, 'error');
+  assert.equal(harness.getState().error, error);
+  assert.equal(harness.getState().data, null);
+});
+
+test('retry clears the failure and can transition to populated success', async () => {
+  let attempt = 0;
+  const harness = createHarness(async () => {
+    attempt++;
+    if (attempt === 1) throw new Error('temporary failure');
+    return [{ id: 'recovered' }];
+  });
+  await harness.loader.retry();
+  await harness.loader.retry();
+  assert.deepEqual(
+    harness.transitions.map(({ status }) => status),
+    ['loading', 'error', 'loading', 'success'],
+  );
+  assert.deepEqual(harness.getState().data, [{ id: 'recovered' }]);
+});
+
+test('retry can recover to a successful empty response', async () => {
+  let attempt = 0;
+  const harness = createHarness(async () => {
+    attempt++;
+    if (attempt === 1) throw new Error('temporary failure');
+    return [];
+  });
+  await harness.loader.retry();
+  await harness.loader.retry();
+  assert.equal(harness.getState().status, 'success');
+  assert.deepEqual(harness.getState().data, []);
+});
+
+test('rapid retry attempts do not start duplicate concurrent requests', async () => {
+  let resolveLoad;
+  let calls = 0;
+  const harness = createHarness(() => {
+    calls++;
+    return new Promise((resolve) => { resolveLoad = resolve; });
+  });
+  const first = harness.loader.retry();
+  await harness.loader.retry();
+  assert.equal(calls, 1);
+  resolveLoad('done');
+  await first;
+  assert.equal(harness.getState().status, 'success');
+});
+
+test('cancelled loads cannot overwrite state after unmount', async () => {
+  let resolveLoad;
+  const harness = createHarness(() => new Promise((resolve) => { resolveLoad = resolve; }));
+  const request = harness.loader.retry();
+  harness.loader.cancel();
+  resolveLoad('stale');
+  await request;
+  assert.deepEqual(harness.transitions.map(({ status }) => status), ['loading']);
+});
+
+let failures = 0;
+for (const { description, fn } of tests) {
+  try {
+    await fn();
+    console.log(`PASS: ${description}`);
+  } catch (error) {
+    failures++;
+    console.error(`FAIL: ${description}\n  ${error.stack || error.message}`);
+  }
+}
+
+if (failures > 0) {
+  console.error(`\n${failures} test(s) failed`);
+  process.exit(1);
+}
+console.log(`\nAll ${tests.length} page data tests passed`);

--- a/frontend/src/pages/Compliance.jsx
+++ b/frontend/src/pages/Compliance.jsx
@@ -13,11 +13,7 @@ import usePageData from '../hooks/usePageData';
 export default function Compliance() {
   const [selectedFw, setSelectedFw] = useState(null);
   const [statusFilter, setStatusFilter] = useState('All');
-  const loadCompliance = useCallback(async () => {
-    const loaded = await api.getCompliance();
-    setSelectedFw(loaded.frameworks[0] ?? null);
-    return loaded;
-  }, []);
+  const loadCompliance = useCallback(() => api.getCompliance(), []);
   const { status, data, retry } = usePageData(loadCompliance);
 
   if (status === 'loading') return <Loader rows={8} />;
@@ -35,15 +31,23 @@ export default function Compliance() {
     />
   );
 
+  const activeFramework = data.frameworks.find((framework) => framework.name === selectedFw?.name)
+    ?? data.frameworks[0]
+    ?? null;
+
   const filteredControls = data.controls.filter((c) => {
-    if (selectedFw && c.framework !== selectedFw.name) return false;
+    if (activeFramework && c.framework !== activeFramework.name) return false;
     if (statusFilter !== 'All' && c.status !== statusFilter) return false;
     return true;
   });
 
   return (
     <div className="space-y-6">
-      <FrameworkCards frameworks={data.frameworks} selected={selectedFw} onSelect={setSelectedFw} />
+      <FrameworkCards
+        frameworks={data.frameworks}
+        selected={activeFramework}
+        onSelect={setSelectedFw}
+      />
 
       <Card>
         <h2 className="text-base font-semibold text-text-primary dark:text-text-dark-primary mb-4">Framework Score Trends</h2>

--- a/frontend/src/pages/Compliance.jsx
+++ b/frontend/src/pages/Compliance.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useCallback, useState } from 'react';
 import { api } from '../utils/api';
 import FrameworkCards from '../components/compliance/FrameworkCards';
 import ComplianceTable from '../components/compliance/ComplianceTable';
@@ -6,20 +6,34 @@ import ComparisonChart from '../components/compliance/ComparisonChart';
 import ExportButton from '../components/compliance/ExportButton';
 import Card from '../components/shared/Card';
 import Loader from '../components/shared/Loader';
+import EmptyState from '../components/shared/EmptyState';
+import ErrorState from '../components/shared/ErrorState';
+import usePageData from '../hooks/usePageData';
 
 export default function Compliance() {
-  const [data, setData] = useState(null);
   const [selectedFw, setSelectedFw] = useState(null);
   const [statusFilter, setStatusFilter] = useState('All');
-
-  useEffect(() => {
-    api.getCompliance().then((d) => {
-      setData(d);
-      setSelectedFw(d.frameworks[0]);
-    });
+  const loadCompliance = useCallback(async () => {
+    const loaded = await api.getCompliance();
+    setSelectedFw(loaded.frameworks[0] ?? null);
+    return loaded;
   }, []);
+  const { status, data, retry } = usePageData(loadCompliance);
 
-  if (!data) return <Loader rows={8} />;
+  if (status === 'loading') return <Loader rows={8} />;
+  if (status === 'error') return (
+    <ErrorState
+      title="Could not load compliance data"
+      description="Compliance frameworks and controls are unavailable right now."
+      onRetry={retry}
+    />
+  );
+  if (data.frameworks.length === 0 && data.controls.length === 0) return (
+    <EmptyState
+      title="No compliance results"
+      description="Run a scan to assess resources against compliance frameworks."
+    />
+  );
 
   const filteredControls = data.controls.filter((c) => {
     if (selectedFw && c.framework !== selectedFw.name) return false;

--- a/frontend/src/pages/DetailedScan.jsx
+++ b/frontend/src/pages/DetailedScan.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router';
 import { FiArrowLeft, FiX, FiAlertTriangle } from 'react-icons/fi';
 import { api } from '../utils/api';
@@ -8,12 +8,22 @@ import AskAIButton from '../components/scan/AskAIButton';
 import SeverityBadge from '../components/shared/SeverityBadge';
 import Card from '../components/shared/Card';
 import Loader from '../components/shared/Loader';
+import EmptyState from '../components/shared/EmptyState';
+import ErrorState from '../components/shared/ErrorState';
+import usePageData from '../hooks/usePageData';
 
 const IMPACT_COLORS = {
   CRITICAL: 'text-red-600 dark:text-red-400',
   HIGH:     'text-orange-500 dark:text-orange-400',
   MEDIUM:   'text-yellow-600 dark:text-yellow-400',
   LOW:      'text-green-600 dark:text-green-400',
+};
+
+const EMPTY_PLAYBOOK = {
+  portalSteps: [],
+  cliCommands: [],
+  validationSteps: [],
+  references: [],
 };
 
 function FromPrioritizationBanner({ state, finding, onDismiss }) {
@@ -77,36 +87,51 @@ function FromPrioritizationBanner({ state, finding, onDismiss }) {
 
 export default function DetailedScan() {
   const location = useLocation();
-  const [findings, setFindings]     = useState([]);
-  const [selected, setSelected]     = useState(null);
-  const [playbook, setPlaybook]     = useState(null);
+  const [selectedId, setSelectedId] = useState(null);
+  const [playbookState, setPlaybookState] = useState({ findingId: null, data: null });
   const [showBanner, setShowBanner] = useState(!!location.state?.fromPrioritization);
   const preSelectRuleId = location.state?.ruleId;
+  const loadFindings = useCallback(() => api.getFindings(), []);
+  const { status, data: findings, retry } = usePageData(loadFindings);
 
-  // Load findings on mount
+  const preselected = preSelectRuleId
+    ? findings?.find((finding) => finding.ruleId === preSelectRuleId)
+    : null;
+  const selected = findings?.find((finding) => finding.id === selectedId)
+    ?? preselected
+    ?? findings?.[0]
+    ?? null;
+  const playbook = playbookState.findingId === selected?.id ? playbookState.data : null;
+
+  // Fetch the playbook for the derived initial finding or a user selection.
   useEffect(() => {
-    api.getFindings().then((data) => {
-      setFindings(data);
-      const initial = preSelectRuleId
-        ? (data.find((f) => f.ruleId === preSelectRuleId) ?? data[0])
-        : data[0];
-      selectFinding(initial);
+    if (!selected?.id) return undefined;
+    let active = true;
+    api.getPlaybook(selected.id).then((data) => {
+      if (active) setPlaybookState({ findingId: selected.id, data });
+    }).catch(() => {
+      if (active) setPlaybookState({ findingId: selected.id, data: EMPTY_PLAYBOOK });
     });
-  }, [preSelectRuleId]);
-
-  // Fetch playbook whenever selected finding changes
-  async function selectFinding(f) {
-    setSelected(f);
-    setPlaybook(null);
-    if (!f?.id) return;
-    const pb = await api.getPlaybook(f.id);
-    setPlaybook(pb);
-  }
+    return () => { active = false; };
+  }, [selected?.id]);
 
   // Merge playbook data into the selected finding for rendering
   const enriched = selected ? { ...selected, ...(playbook || {}) } : null;
 
-  if (!findings.length) return <Loader rows={6} />;
+  if (status === 'loading') return <Loader rows={6} />;
+  if (status === 'error') return (
+    <ErrorState
+      title="Could not load scan findings"
+      description="Detailed findings are unavailable right now."
+      onRetry={retry}
+    />
+  );
+  if (findings.length === 0) return (
+    <EmptyState
+      title="No findings detected"
+      description="The latest scan completed without reporting security findings."
+    />
+  );
 
   const fromState = location.state?.fromPrioritization ? location.state : null;
 
@@ -134,7 +159,7 @@ export default function DetailedScan() {
               return (
                 <button
                   key={f.id}
-                  onClick={() => selectFinding(f)}
+                  onClick={() => setSelectedId(f.id)}
                   className={`w-full text-left p-4 rounded-2xl border transition-all duration-200 ${
                     isActive
                       ? 'border-brand-primary bg-brand-primary/5 dark:bg-brand-primary/10 shadow-soft'

--- a/frontend/src/pages/Discovery.jsx
+++ b/frontend/src/pages/Discovery.jsx
@@ -1,9 +1,12 @@
-import { useEffect, useState } from 'react';
+import { useCallback, useState } from 'react';
 import { api } from '../utils/api';
 import ResourceSummary from '../components/discovery/ResourceSummary';
 import ResourceFilter from '../components/discovery/ResourceFilter';
 import ResourceTable from '../components/discovery/ResourceTable';
 import Loader from '../components/shared/Loader';
+import EmptyState from '../components/shared/EmptyState';
+import ErrorState from '../components/shared/ErrorState';
+import usePageData from '../hooks/usePageData';
 
 const DEFAULT_FILTERS = {
   search: '',
@@ -45,29 +48,43 @@ function buildIssueCounts(findings, matrix) {
 }
 
 export default function Discovery() {
-  const [data, setData] = useState(null);
-  const [issueCounts, setIssueCounts] = useState({});
   const [filters, setFilters] = useState(DEFAULT_FILTERS);
-
-  useEffect(() => {
-    Promise.all([
+  const loadDiscovery = useCallback(async () => {
+    const [resourceData, findings, prio] = await Promise.all([
       api.getResources(),
       api.getFindings(),
       api.getPrioritization(),
-    ]).then(([resourceData, findings, prio]) => {
-      setData(resourceData);
-      setIssueCounts(buildIssueCounts(findings, prio.matrix));
-    });
+    ]);
+    return {
+      resourceData,
+      issueCounts: buildIssueCounts(findings, prio.matrix),
+    };
   }, []);
+  const { status, data, retry } = usePageData(loadDiscovery);
 
-  if (!data) return <Loader rows={8} />;
+  if (status === 'loading') return <Loader rows={8} />;
+  if (status === 'error') return (
+    <ErrorState
+      title="Could not load discovery data"
+      description="Resources and their security findings are unavailable right now."
+      onRetry={retry}
+    />
+  );
 
-  const filtered = applyFilters(data.resources, filters);
+  const { resourceData, issueCounts } = data;
+  if (resourceData.resources.length === 0) return (
+    <EmptyState
+      title="No resources discovered"
+      description="Run a scan to populate your cloud resource inventory."
+    />
+  );
+
+  const filtered = applyFilters(resourceData.resources, filters);
 
   return (
     <div className="space-y-6">
       <ResourceSummary
-        summary={data.summary}
+        summary={resourceData.summary}
         activeCategory={filters.category}
         onCategoryClick={(cat) => setFilters((p) => ({ ...p, category: cat }))}
       />
@@ -78,7 +95,7 @@ export default function Discovery() {
             <h2 className="text-base font-semibold text-text-primary dark:text-text-dark-primary">
               Resources
               <span className="ml-2 text-sm font-normal text-text-tertiary dark:text-text-dark-tertiary">
-                {filtered.length} of {data.resources.length} shown
+                {filtered.length} of {resourceData.resources.length} shown
               </span>
             </h2>
             <div className="flex items-center gap-2 flex-wrap justify-end">

--- a/frontend/src/pages/Drift.jsx
+++ b/frontend/src/pages/Drift.jsx
@@ -1,20 +1,26 @@
-import { useEffect, useState } from 'react';
+import { useCallback, useState } from 'react';
 import { api } from '../utils/api';
 import DriftSummary from '../components/drift/DriftSummary';
 import DriftTimeline from '../components/drift/DriftTimeline';
 import DriftFilters from '../components/drift/DriftFilters';
 import Loader from '../components/shared/Loader';
+import ErrorState from '../components/shared/ErrorState';
+import usePageData from '../hooks/usePageData';
 import { formatDateTime } from '../utils/helpers';
 
 export default function Drift() {
-  const [data, setData] = useState(null);
   const [filters, setFilters] = useState({ type: 'All', severity: 'All' });
+  const loadDrift = useCallback(() => api.getDrift(), []);
+  const { status, data, retry } = usePageData(loadDrift);
 
-  useEffect(() => {
-    api.getDrift().then(setData);
-  }, []);
-
-  if (!data) return <Loader rows={6} />;
+  if (status === 'loading') return <Loader rows={6} />;
+  if (status === 'error') return (
+    <ErrorState
+      title="Could not load drift data"
+      description="Configuration change history is unavailable right now."
+      onRetry={retry}
+    />
+  );
 
   const filtered = data.events.filter((e) => {
     if (filters.type !== 'All' && e.type !== filters.type) return false;

--- a/frontend/src/pages/Monitoring.jsx
+++ b/frontend/src/pages/Monitoring.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useCallback } from 'react';
 import { api } from '../utils/api';
 import ScoreGauge from '../components/monitoring/ScoreGauge';
 import TrendChart from '../components/monitoring/TrendChart';
@@ -7,6 +7,8 @@ import FindingsDistribution from '../components/monitoring/FindingsDistribution'
 import ResourceGroupChart from '../components/monitoring/ResourceGroupChart';
 import Card from '../components/shared/Card';
 import Loader, { CardLoader } from '../components/shared/Loader';
+import ErrorState from '../components/shared/ErrorState';
+import usePageData from '../hooks/usePageData';
 import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, Cell } from 'recharts';
 
 function buildRgGroups(findings) {
@@ -51,48 +53,47 @@ function buildTrend(scans) {
 }
 
 export default function Monitoring() {
-  const [data,  setData]  = useState(null);
-  const [error, setError] = useState(false);
+  const loadMonitoring = useCallback(async () => {
+    const [scoreData, findings, scansData] = await Promise.all([
+      api.getScore(),
+      api.getFindings(),
+      api.getScans(),
+    ]);
+    const scans  = scansData.scans || [];
+    const high   = findings.filter((f) => f.severity?.toUpperCase() === 'HIGH').length;
+    const medium = findings.filter((f) => f.severity?.toUpperCase() === 'MEDIUM').length;
+    const low    = findings.filter((f) => f.severity?.toUpperCase() === 'LOW').length;
 
-  useEffect(() => {
-    Promise.all([api.getScore(), api.getFindings(), api.getScans()])
-      .then(([scoreData, findings, scansData]) => {
-        const scans  = scansData.scans || [];
-        const high   = findings.filter((f) => f.severity?.toUpperCase() === 'HIGH').length;
-        const medium = findings.filter((f) => f.severity?.toUpperCase() === 'MEDIUM').length;
-        const low    = findings.filter((f) => f.severity?.toUpperCase() === 'LOW').length;
-
-        setData({
-          score:    scoreData.score    ?? scoreData,
-          maxScore: scoreData.max_score ?? 100,
-          stats: {
-            totalFindings:  findings.length,
-            criticalIssues: high,
-            mediumRisk:     medium,
-            lowPriority:    low,
-          },
-          findingsDistribution: [
-            { name: 'High',   value: high,   color: '#ef4444' },
-            { name: 'Medium', value: medium, color: '#f97316' },
-            { name: 'Low',    value: low,    color: '#10b981' },
-          ],
-          categoryScores:          buildCategoryScores(findings),
-          trend:                   buildTrend(scans),
-          findingsByResourceGroup: buildRgGroups(findings),
-        });
-      })
-      .catch(() => setError(true));
+    return {
+      score:    scoreData.score    ?? scoreData,
+      maxScore: scoreData.max_score ?? 100,
+      stats: {
+        totalFindings:  findings.length,
+        criticalIssues: high,
+        mediumRisk:     medium,
+        lowPriority:    low,
+      },
+      findingsDistribution: [
+        { name: 'High',   value: high,   color: '#ef4444' },
+        { name: 'Medium', value: medium, color: '#f97316' },
+        { name: 'Low',    value: low,    color: '#10b981' },
+      ],
+      categoryScores:          buildCategoryScores(findings),
+      trend:                   buildTrend(scans),
+      findingsByResourceGroup: buildRgGroups(findings),
+    };
   }, []);
+  const { status, data, retry } = usePageData(loadMonitoring);
 
-  if (error) return (
-    <div className="flex items-center justify-center h-64">
-      <p className="text-sm text-text-secondary dark:text-text-dark-tertiary">
-        Could not load monitoring data — backend may be starting up. Refresh to retry.
-      </p>
-    </div>
+  if (status === 'error') return (
+    <ErrorState
+      title="Could not load monitoring data"
+      description="The backend may still be starting. Wait a moment and try again."
+      onRetry={retry}
+    />
   );
 
-  if (!data) return (
+  if (status === 'loading') return (
     <div className="space-y-6">
       <div className="grid grid-cols-2 lg:grid-cols-4 gap-4">
         {[...Array(4)].map((_, i) => <CardLoader key={i} />)}

--- a/frontend/src/pages/Prioritization.jsx
+++ b/frontend/src/pages/Prioritization.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useCallback, useState } from 'react';
 import { FiX } from 'react-icons/fi';
 import { api } from '../utils/api';
 import PriorityMatrix from '../components/prioritization/PriorityMatrix';
@@ -8,21 +8,35 @@ import PriorityFilters from '../components/prioritization/PriorityFilters';
 import QuickRemediation from '../components/prioritization/QuickRemediation';
 import Card from '../components/shared/Card';
 import Loader from '../components/shared/Loader';
+import EmptyState from '../components/shared/EmptyState';
+import ErrorState from '../components/shared/ErrorState';
+import usePageData from '../hooks/usePageData';
 
 export default function Prioritization() {
-  const [data, setData] = useState(null);
-  const [findings, setFindings] = useState([]);
   const [filters, setFilters] = useState({ category: 'All', severity: 'All' });
   const [selectedId, setSelectedId] = useState(null);
-
-  useEffect(() => {
-    Promise.all([api.getPrioritization(), api.getFindings()]).then(([prio, scan]) => {
-      setData(prio);
-      setFindings(scan);
-    });
+  const loadPrioritization = useCallback(async () => {
+    const [data, findings] = await Promise.all([api.getPrioritization(), api.getFindings()]);
+    return { data, findings };
   }, []);
+  const { status, data: loaded, retry } = usePageData(loadPrioritization);
 
-  if (!data) return <Loader rows={8} />;
+  if (status === 'loading') return <Loader rows={8} />;
+  if (status === 'error') return (
+    <ErrorState
+      title="Could not load prioritization data"
+      description="Risk rankings and action items are unavailable right now."
+      onRetry={retry}
+    />
+  );
+
+  const { data, findings } = loaded;
+  if (data.matrix.length === 0 && data.rankings.length === 0 && data.actionItems.length === 0) return (
+    <EmptyState
+      title="No issues to prioritize"
+      description="Prioritization results will appear after a scan finds security issues."
+    />
+  );
 
   const filteredMatrix = data.matrix.filter((item) => {
     if (filters.category !== 'All' && item.category !== filters.category) return false;


### PR DESCRIPTION
## What does this PR do?

Adds recoverable loading, error, empty, and populated states to the data-driven dashboard pages.

Discovery, Prioritization, Detailed Scan, Compliance, Drift, and Monitoring now use a small shared `usePageData` hook for their initial request lifecycle. Failed loads render a reusable inline error panel with a `Try again` action; retry returns to the loader and can resolve to populated, empty, or another error state without reloading the browser.

The hook ignores stale results after unmount and prevents repeated clicks from starting duplicate concurrent loads. Its cleanup-aware initial scheduling also prevents React Strict Mode effect replay from launching a duplicate initial request. Compliance derives its active framework after a successful load rather than writing component state from inside an async loader. Detailed Scan no longer treats an empty findings array as “still loading”; a successful zero-findings response displays a dedicated empty state. Existing page-specific empty states remain in use where appropriate.

The error panel uses `role="alert"`, an assertive live region, semantic headings, and a keyboard-accessible button. It displays page-specific safe copy rather than raw exception details.

This PR is independently based on current `dev` and does not depend on #282. Its request callbacks remain compatible with the timeout/cancellation API proposed there, but no stacked branch or automatic retry policy is introduced here.

## Type of change

- [ ] New scan rule
- [ ] Remediation playbook
- [ ] Bug fix
- [x] Dashboard/front-end work
- [ ] API endpoint
- [ ] Documentation
- [ ] Compliance mapping

## Rule details (if applicable)

Not applicable.

## Testing

- [ ] Tested against a real Azure free trial subscription (not applicable to load-state handling)
- [x] Returns correct JSON output
- [x] All GitHub CI and security checks pass
- [x] No hardcoded credentials or secrets

Executed from `frontend/`:

- `node src/hooks/usePageData.test.mjs` — 8 load-state and retry tests passed
- `node src/utils/aiApi.test.mjs` — 9 existing AI settings tests passed
- `npm run test:a11y` — passed
- `npm run test:i18n` — passed
- `npm run lint` — passed with zero warnings
- `npm run build` — passed

Focused tests cover initial loading, populated success, successful empty data, rejected requests, retry to populated success, retry to empty success, rapid duplicate retry prevention, stale completion suppression after unmount, and React Strict Mode effect replay.

## Related issue

Closes #281

## Checklist

- [x] Every commit includes a DCO `Signed-off-by` trailer (`git commit -s`; see `docs/dco.md`)
- [ ] My code follows the rule template in CONTRIBUTING.md (not applicable; no scan rule)
- [ ] I added or updated the matching CLI playbook (not applicable)
- [ ] I added or updated all four compliance framework mappings (not applicable)
- [x] I have not committed any real Azure credentials
- [x] My branch name follows the convention: feat/description
