### PR TITLE
fix(deps): bump nanoid to 3.3.18 (CVE-2026-67213)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -2510,9 +2510,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
## What does this PR do?
Resolves the one open Dependabot alert (#15, high severity).

- **Package:** nanoid (transitive, runtime scope, frontend)
- **Vulnerability:** CVE-2026-67213 / GHSA-2v37-7h3g-55p8: custom generators can loop indefinitely when size is zero
- **Change:** 3.3.16 -> 3.3.18 (first patched version), lockfile-only bump within the existing semver range

No source changes; `npm audit` reports 0 vulnerabilities after the bump.