### PR TITLE
fix(platform): enforce container runtime gate

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,5 @@
 .git
+.gitdata
 .github
 .pytest_cache
 .ruff_cache

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -508,37 +508,98 @@ jobs:
           path: sbom.cyclonedx.json
           retention-days: 90
 
-  # ── Container image scan (Trivy) — scaffolded ahead of INFRA 1 (#154) ─────
+  # ── Container runtime contract + image scan (Trivy) ───────────────────────
   container-scan:
     name: Container Scan (Trivy)
     runs-on: ubuntu-latest
+    env:
+      IMAGE_TAG: openshield-ci-scan:${{ github.sha }}
+      CONTAINER_NAME: openshield-ci-runtime
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: ci
+          POSTGRES_PASSWORD: ci
+          POSTGRES_DB: ci_db
+        ports:
+          - 5432/tcp
+        options: >-
+          --health-cmd "pg_isready -U ci -d ci_db"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
     steps:
       - name: Checkout repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
-      - name: Check for Dockerfile
-        id: dockerfile_check
-        run: |
-          if [ -f "Dockerfile" ]; then
-            echo "found=true" >> "$GITHUB_OUTPUT"
-            echo "path=Dockerfile" >> "$GITHUB_OUTPUT"
-          elif [ -f "api/Dockerfile" ]; then
-            echo "found=true" >> "$GITHUB_OUTPUT"
-            echo "path=api/Dockerfile" >> "$GITHUB_OUTPUT"
-          else
-            echo "found=false" >> "$GITHUB_OUTPUT"
-            echo "No Dockerfile yet (INFRA 1 / #154 not merged) — nothing to scan, skipping."
-          fi
-
       - name: Build image
-        if: steps.dockerfile_check.outputs.found == 'true'
-        run: docker build -t openshield-ci-scan:${{ github.sha }} -f "${{ steps.dockerfile_check.outputs.path }}" .
+        id: build
+        run: docker build --tag "$IMAGE_TAG" --file Dockerfile .
+
+      - name: Start image
+        env:
+          POSTGRES_PORT: ${{ job.services.postgres.ports[5432] }}
+        run: |
+          set -euo pipefail
+          JWT_SECRET="$(python3 -c 'import secrets; print(secrets.token_urlsafe(32))')"
+          docker run --detach \
+            --name "$CONTAINER_NAME" \
+            --network host \
+            --env "DATABASE_URL=postgresql://ci:ci@127.0.0.1:${POSTGRES_PORT}/ci_db" \
+            --env OPENSHIELD_ENV=production \
+            --env OPENSHIELD_PUBLIC_DEMO=false \
+            --env ALLOWED_ORIGINS=http://127.0.0.1:8000 \
+            --env PORT=8000 \
+            --env "JWT_SECRET=$JWT_SECRET" \
+            "$IMAGE_TAG"
+
+      - name: Verify readiness and non-root runtime
+        run: |
+          python3 - <<'PYEOF'
+          import json
+          import time
+          import urllib.error
+          import urllib.request
+
+          url = "http://127.0.0.1:8000/ready"
+          last_error = "container did not answer"
+          for attempt in range(1, 31):
+              try:
+                  with urllib.request.urlopen(url, timeout=3) as response:
+                      status = response.status
+                      payload = json.load(response)
+                  if status == 200 and payload == {"status": "ready"}:
+                      print(f"Runtime readiness passed on attempt {attempt}: {payload}")
+                      break
+                  last_error = f"HTTP {status}: {payload!r}"
+              except (OSError, ValueError, urllib.error.URLError) as exc:
+                  last_error = repr(exc)
+              time.sleep(2)
+          else:
+              raise SystemExit(f"Runtime readiness failed after 30 attempts: {last_error}")
+          PYEOF
+
+          RUNTIME_UID="$(docker exec "$CONTAINER_NAME" id -u)"
+          if [ "$RUNTIME_UID" = "0" ]; then
+            echo "ERROR: container is running as root."
+            exit 1
+          fi
+          echo "Container runtime UID is $RUNTIME_UID (non-root)."
+
+      - name: Show runtime logs on failure
+        if: failure()
+        run: docker logs "$CONTAINER_NAME" || true
+
+      - name: Remove runtime smoke container
+        if: always()
+        run: docker rm --force "$CONTAINER_NAME" || true
 
       - name: Run Trivy
-        if: steps.dockerfile_check.outputs.found == 'true'
+        if: ${{ !cancelled() && steps.build.outcome == 'success' }}
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
-          image-ref: openshield-ci-scan:${{ github.sha }}
+          image-ref: ${{ env.IMAGE_TAG }}
           severity: CRITICAL,HIGH
           ignore-unfixed: true
           exit-code: "1"
@@ -693,7 +754,7 @@ jobs:
               ("SAST (Semgrep)",                     os.environ["SAST_SEMGREP"]),
               ("SCA (pip-audit)",                    os.environ["SCA_PIP_AUDIT"]),
               ("SBOM (Syft)",                        os.environ["SBOM"]),
-              ("Container Scan (Trivy, INFRA 1 pending)", os.environ["CONTAINER_SCAN"]),
+              ("Container Runtime + Scan (Trivy)",        os.environ["CONTAINER_SCAN"]),
               ("Backend Tests (pytest + coverage)",  os.environ["BACKEND_TESTS"]),
               ("Frontend (lint + build)",            os.environ["FRONTEND"]),
               ("Website (script tests)",             os.environ["WEBSITE"]),
@@ -736,7 +797,6 @@ jobs:
                   f.write(summary + "\n")
           PYEOF
 
-      # container-scan excluded until INFRA 1 (#154) gives it a real image to gate on
       - name: Fail if any required job failed
         if: |
           needs.lint.result != 'success' ||
@@ -746,6 +806,7 @@ jobs:
           needs.sast-semgrep.result != 'success' ||
           needs.sca-pip-audit.result != 'success' ||
           needs.sbom.result != 'success' ||
+          needs.container-scan.result != 'success' ||
           needs.backend-tests.result != 'success' ||
           needs.frontend.result != 'success' ||
           needs.website.result != 'success' ||

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,8 @@ RUN groupadd --system openshield && \
 
 USER openshield
 
+ENV PORT=8000
+
 EXPOSE 8000
 
-CMD ["gunicorn", "--workers", "2", "--threads", "2", "--timeout", "120", "--bind", "0.0.0.0:8000", "api.app:app"]
+CMD ["./startup.sh"]

--- a/README.md
+++ b/README.md
@@ -226,6 +226,18 @@ FLASK_APP=api/app.py flask run
 See [Database Migrations](docs/database-migrations.md) for schema changes and the
 one-time onboarding step required for existing production databases.
 
+**Local containers (Compose)**
+
+```bash
+# Starts PostgreSQL 16, applies migrations, then starts the API, worker, and dashboard
+docker compose --profile local up --build
+
+# Database-aware API readiness
+curl --fail http://127.0.0.1:8000/ready
+```
+
+The profile is intentionally named `local`: its database credentials and JWT secret are development-only values, ports bind to loopback, and the dashboard talks to `http://localhost:8000`. Set the four `AZURE_*` variables in your shell before starting Compose if you want the worker to execute real scans. Stop the stack with `docker compose --profile local down`; add `--volumes` only when you intentionally want to remove local database and frontend dependency data.
+
 **Frontend (React dashboard)**
 
 ```bash

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,7 @@
-version: '3.8'
-
 services:
   db:
-    image: postgres:15-alpine
+    profiles: ["local"]
+    image: postgres:16-alpine
     read_only: true
     security_opt:
       - no-new-privileges:true
@@ -16,28 +15,65 @@ services:
     volumes:
       - postgres_data:/var/lib/postgresql/data
     ports:
-      - "5432:5432"
+      - "127.0.0.1:5432:5432"
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U openshield"]
+      test: ["CMD-SHELL", "pg_isready -U $$POSTGRES_USER -d $$POSTGRES_DB"]
       interval: 10s
       timeout: 5s
       retries: 5
 
   api:
+    profiles: ["local"]
     build: .
     ports:
-      - "8000:8000"
+      - "127.0.0.1:8000:8000"
     environment:
+      PORT: "8000"
+      OPENSHIELD_ENV: development
       DATABASE_URL: postgresql://openshield:openshield@db:5432/openshield
-      JWT_SECRET: change-me-in-production
+      JWT_SECRET: local-development-only-secret-change-me
+      ALLOWED_ORIGINS: http://localhost:5173
       ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
       NVD_API_KEY: ${NVD_API_KEY:-}
     depends_on:
       db:
         condition: service_healthy
+    healthcheck:
+      test:
+        - CMD
+        - python
+        - -c
+        - >-
+          import json, urllib.request;
+          payload = json.load(urllib.request.urlopen('http://127.0.0.1:8000/ready', timeout=5));
+          assert payload.get('status') == 'ready'
+      interval: 10s
+      timeout: 6s
+      retries: 6
+      start_period: 30s
+
+  worker:
+    profiles: ["local"]
+    build: .
+    command: ["python", "-m", "scanner.worker"]
+    environment:
+      OPENSHIELD_ENV: development
+      DATABASE_URL: postgresql://openshield:openshield@db:5432/openshield
+      AZURE_SUBSCRIPTION_ID: ${AZURE_SUBSCRIPTION_ID:-}
+      AZURE_CLIENT_ID: ${AZURE_CLIENT_ID:-}
+      AZURE_CLIENT_SECRET: ${AZURE_CLIENT_SECRET:-}
+      AZURE_TENANT_ID: ${AZURE_TENANT_ID:-}
+      AZURE_DEVOPS_ORG_URL: ${AZURE_DEVOPS_ORG_URL:-}
+      AZURE_DEVOPS_PROJECT: ${AZURE_DEVOPS_PROJECT:-}
+      ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
+      NVD_API_KEY: ${NVD_API_KEY:-}
+    depends_on:
+      api:
+        condition: service_healthy
 
   frontend:
-    image: node:20-alpine
+    profiles: ["local"]
+    image: node:22.22.0-alpine
     read_only: true
     security_opt:
       - no-new-privileges:true
@@ -46,11 +82,17 @@ services:
     working_dir: /app
     volumes:
       - ./frontend:/app
-    command: sh -c "npm install && npm run dev -- --host"
+      - frontend_node_modules:/app/node_modules
+    command: ["sh", "-c", "npm ci && npm run dev -- --host 0.0.0.0"]
     ports:
-      - "5173:5173"
+      - "127.0.0.1:5173:5173"
     environment:
-      VITE_API_BASE_URL: http://localhost:8000
+      VITE_API_URL: http://localhost:8000
+      NPM_CONFIG_CACHE: /tmp/.npm
+    depends_on:
+      api:
+        condition: service_healthy
 
 volumes:
   postgres_data:
+  frontend_node_modules:

--- a/docs/ci-pipeline.md
+++ b/docs/ci-pipeline.md
@@ -19,7 +19,7 @@ This document explains each job, how to reproduce every check locally before ope
 | **SAST (Semgrep)** | `semgrep scan --config p/security-audit --config p/owasp-top-ten --config p/python --config p/javascript --error` | A finding from the security-audit / OWASP Top 10 / Python / JS rulesets |
 | **SCA (pip-audit)** | `pip-audit -r requirements.txt` | A dependency with a known CVE (minus documented ignores) |
 | **SBOM (Syft)** | CycloneDX SBOM generated + uploaded as an artifact | SBOM generation error |
-| **Container Scan (Trivy)** | Dormant scaffold — skips until a `Dockerfile` exists (INFRA 1 / #154) | (nothing today) |
+| **Container Runtime + Scan (Trivy)** | Builds one image, starts that tag against PostgreSQL, requires `/ready`, verifies its runtime UID is non-root, then scans the same tag | Boot failure, database-readiness failure, root runtime, or an unfixed policy-blocking vulnerability |
 | **Backend Tests (pytest + coverage)** | Full `tests/` suite against an ephemeral Postgres, `--cov-fail-under=80` | A failing test or coverage below the Silver-level floor |
 | **Frontend (lint + build)** | `npm ci` → `eslint` → `vite build` | An eslint error or a broken dashboard build |
 | **Enforce dev to main source** | `main` PRs must come from `dev` | A non-`dev` branch opening a PR into `main` |
@@ -29,7 +29,7 @@ This document explains each job, how to reproduce every check locally before ope
 
 `.github/workflows/release.yml` (triggered by `v*` tags): requires a verified signed annotated tag, builds a deterministic source archive and CycloneDX SBOM, publishes SHA-256 checksums and identity-bound provenance attestations, then creates the GitHub Release.
 
-The **Container Scan** job is intentionally **not** a required check yet: no `Dockerfile` exists, so it has nothing to scan. It activates automatically once INFRA 1 (#154) adds one.
+The **Container Runtime + Scan** job is a required gate. Deleting the Dockerfile, breaking the WSGI target, losing database connectivity, running as root, or failing the Trivy policy makes the final CI summary fail.
 
 ---
 
@@ -136,6 +136,20 @@ Runs the **entire** `tests/` suite once (not just rule tests). Tests requiring a
 cd frontend && npm ci && npm run lint && npm run build
 ```
 
+### Container runtime + vulnerability scan
+
+The CI job builds a single commit-tagged image, starts that exact tag as a non-root user against PostgreSQL 16, and polls the database-aware `/ready` endpoint before passing the same tag to Trivy. It always removes the smoke container, prints its logs when runtime verification fails, and still runs Trivy when a successfully built image fails to boot.
+
+For a local end-to-end runtime check:
+
+```bash
+docker compose --profile local up --build
+curl --fail http://127.0.0.1:8000/ready
+docker compose --profile local down
+```
+
+Compose's `local` profile is not production configuration. Its credentials are development-only, all exposed ports bind to loopback, API startup applies Alembic migrations, and the worker waits for API readiness before polling the shared database.
+
 ---
 
 ## Branch protection and the promotion flow
@@ -188,7 +202,7 @@ It catches the deletion case: a rule file removed but its compliance-JSON entry 
 
 ## The CI summary
 
-The `ci-summary` job uses `needs: [...]` + `if: always()` so it runs after every other job regardless of outcome, reads each job's `result`, and writes a markdown pass/fail table to `$GITHUB_STEP_SUMMARY` (rendered on the Actions run page). A final step fails the job if any **required** job failed — Container Scan is excluded from that gate until it has an image to scan.
+The `ci-summary` job uses `needs: [...]` + `if: always()` so it runs after every other job regardless of outcome, reads each job's `result`, and writes a markdown pass/fail table to `$GITHUB_STEP_SUMMARY` (rendered on the Actions run page). A final step fails the job if any required job failed, including the container runtime and Trivy result.
 
 ---
 
@@ -202,6 +216,8 @@ The `ci-summary` job uses `needs: [...]` + `if: always()` so it runs after every
 | `pip-audit` reports a CVE | Bump the pin to a fixed version; only add `--ignore-vuln` with a documented reason |
 | `pytest` coverage below 80% | Add tests, or investigate the regression that removed coverage |
 | Frontend eslint error | Fix the reported rule (e.g. remove an unused import); warnings do not fail CI |
+| Container runtime or `/ready` fails | Check the Docker entrypoint, PostgreSQL connection, migration/startup logs, and non-root user; CI prints the container logs on failure |
+| Trivy reports a blocking image CVE | Update the base image or affected package and rebuild; do not bypass the required container job |
 | `Enforce dev to main source` fails | Open the PR from `dev`; merge feature work into `dev` first |
 | `missing field 'RULE_ID'` | Add `RULE_ID = "AZ-XXX-000"` at module level in the rule file |
 | `DUPLICATE RULE_ID '...'` | Assign a unique ID to the newer rule file |

--- a/frontend/API_ENDPOINTS.txt
+++ b/frontend/API_ENDPOINTS.txt
@@ -11,7 +11,8 @@ BASE URL
 
 Set VITE_API_URL to the API origin, without a trailing /api path.
 
-  Local development default:  http://localhost:5000
+  Direct Flask default:       http://localhost:5000
+  Local Compose profile:      http://localhost:8000
   Production fallback:        https://openshield-api.onrender.com
   Example override:           VITE_API_URL=https://api.example.com
 

--- a/infra/terraform/vercel.tf
+++ b/infra/terraform/vercel.tf
@@ -10,7 +10,7 @@ resource "vercel_project" "dashboard" {
 
   environment = [
     {
-      key       = "VITE_API_BASE_URL"
+      key       = "VITE_API_URL"
       value     = "https://openshield-api.onrender.com"
       target    = ["production", "preview"]
       sensitive = false

--- a/tests/test_container_runtime_config.py
+++ b/tests/test_container_runtime_config.py
@@ -1,0 +1,143 @@
+"""Static contract tests for the distributed container runtime."""
+
+from pathlib import Path
+import re
+
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _yaml(path: str):
+    return yaml.safe_load((ROOT / path).read_text(encoding="utf-8"))
+
+
+def _step(steps, name: str):
+    return next(step for step in steps if step.get("name") == name)
+
+
+def test_docker_image_launches_real_wsgi_application_as_non_root():
+    dockerfile = (ROOT / "Dockerfile").read_text(encoding="utf-8")
+    startup = (ROOT / "startup.sh").read_text(encoding="utf-8")
+    assert "ENV PORT=8000" in dockerfile
+    assert 'CMD ["./startup.sh"]' in dockerfile
+    assert re.search(r"(?m)^USER openshield$", dockerfile)
+    assert startup.index("alembic upgrade head") < startup.index("api.app:application")
+    assert "api.app:app " not in startup
+
+
+def test_docker_build_context_excludes_alternate_git_history():
+    entries = {
+        line.strip()
+        for line in (ROOT / ".dockerignore").read_text(encoding="utf-8").splitlines()
+        if line.strip() and not line.lstrip().startswith("#")
+    }
+    assert ".git" in entries
+    assert ".gitdata" in entries
+
+
+def test_compose_is_explicitly_local_only_and_migration_aware():
+    compose = _yaml("docker-compose.yml")
+    assert "version" not in compose
+    services = compose["services"]
+    assert set(services) == {"db", "api", "worker", "frontend"}
+    assert all(service.get("profiles") == ["local"] for service in services.values())
+
+    assert services["db"]["image"] == "postgres:16-alpine"
+    assert services["db"]["ports"] == ["127.0.0.1:5432:5432"]
+    assert "$$POSTGRES_USER" in services["db"]["healthcheck"]["test"][1]
+    assert "postgres_data:/var/lib/postgresql/data" in services["db"]["volumes"]
+
+    api = services["api"]
+    assert "command" not in api  # Inherit the image's migration-aware startup path.
+    assert api["environment"]["PORT"] == "8000"
+    assert api["environment"]["OPENSHIELD_ENV"] == "development"
+    assert api["depends_on"]["db"]["condition"] == "service_healthy"
+    health_command = " ".join(api["healthcheck"]["test"])
+    assert "/ready" in health_command
+    assert "urllib.request" in health_command
+    assert "status" in health_command
+    assert "curl" not in health_command
+
+    worker = services["worker"]
+    assert worker["command"] == ["python", "-m", "scanner.worker"]
+    assert worker["depends_on"]["api"]["condition"] == "service_healthy"
+    assert worker["environment"]["DATABASE_URL"] == api["environment"]["DATABASE_URL"]
+    for name in (
+        "AZURE_SUBSCRIPTION_ID",
+        "AZURE_CLIENT_ID",
+        "AZURE_CLIENT_SECRET",
+        "AZURE_TENANT_ID",
+    ):
+        assert name in worker["environment"]
+
+
+def test_compose_frontend_uses_supported_node_and_browser_api_url():
+    compose = _yaml("docker-compose.yml")
+    frontend = compose["services"]["frontend"]
+    version_match = re.fullmatch(r"node:(\d+)\.(\d+)\.(\d+)-alpine", frontend["image"])
+    assert version_match
+    assert tuple(map(int, version_match.groups())) >= (22, 22, 0)
+    assert "npm ci" in " ".join(frontend["command"])
+    assert frontend["environment"]["VITE_API_URL"] == "http://localhost:8000"
+    assert frontend["environment"]["NPM_CONFIG_CACHE"] == "/tmp/.npm"
+    assert "VITE_API_BASE_URL" not in frontend["environment"]
+    assert "frontend_node_modules:/app/node_modules" in frontend["volumes"]
+    assert "frontend_node_modules" in compose["volumes"]
+
+
+def test_terraform_uses_the_frontend_api_variable_the_client_reads():
+    terraform = (ROOT / "infra" / "terraform" / "vercel.tf").read_text(encoding="utf-8")
+    assert 'key       = "VITE_API_URL"' in terraform
+    assert "VITE_API_BASE_URL" not in terraform
+
+
+def test_ci_builds_starts_and_scans_one_required_image():
+    workflow = _yaml(".github/workflows/ci.yml")
+    job = workflow["jobs"]["container-scan"]
+    assert job["services"]["postgres"]["image"] == "postgres:16"
+    assert job["services"]["postgres"]["ports"] == ["5432/tcp"]
+    assert job["env"]["IMAGE_TAG"] == "openshield-ci-scan:${{ github.sha }}"
+
+    steps = job["steps"]
+    names = [step.get("name") for step in steps]
+    assert "Check for Dockerfile" not in names
+    assert names.index("Build image") < names.index("Start image")
+    assert names.index("Start image") < names.index("Verify readiness and non-root runtime")
+    assert names.index("Verify readiness and non-root runtime") < names.index("Run Trivy")
+
+    build = _step(steps, "Build image")["run"]
+    start = _step(steps, "Start image")["run"]
+    verify = _step(steps, "Verify readiness and non-root runtime")["run"]
+    trivy = _step(steps, "Run Trivy")
+    assert 'docker build --tag "$IMAGE_TAG"' in build
+    assert '"$IMAGE_TAG"' in start
+    assert "--network host" in start
+    assert "127.0.0.1:${POSTGRES_PORT}/ci_db" in start
+    assert _step(steps, "Start image")["env"]["POSTGRES_PORT"] == "${{ job.services.postgres.ports[5432] }}"
+    assert "OPENSHIELD_ENV=production" in start
+    assert "secrets.token_urlsafe(32)" in start
+    assert "/ready" in verify
+    assert '{"status": "ready"}' in verify
+    assert 'docker exec "$CONTAINER_NAME" id -u' in verify
+    assert trivy["with"]["image-ref"] == "${{ env.IMAGE_TAG }}"
+    assert trivy["with"]["exit-code"] == "1"
+    assert "!cancelled()" in trivy["if"]
+    assert "steps.build.outcome == 'success'" in trivy["if"]
+    assert "dockerfile_check" not in (ROOT / ".github" / "workflows" / "ci.yml").read_text(encoding="utf-8")
+
+
+def test_ci_always_cleans_up_and_final_gate_requires_container_job():
+    workflow = _yaml(".github/workflows/ci.yml")
+    runtime_steps = workflow["jobs"]["container-scan"]["steps"]
+    assert _step(runtime_steps, "Show runtime logs on failure")["if"] == "failure()"
+    cleanup = _step(runtime_steps, "Remove runtime smoke container")
+    assert cleanup["if"] == "always()"
+    assert "docker rm --force" in cleanup["run"]
+    names = [step.get("name") for step in runtime_steps]
+    assert names.index("Remove runtime smoke container") < names.index("Run Trivy")
+
+    summary_steps = workflow["jobs"]["ci-summary"]["steps"]
+    final_gate = _step(summary_steps, "Fail if any required job failed")
+    assert "needs.container-scan.result != 'success'" in final_gate["if"]


### PR DESCRIPTION
## Why

The repository already published a Docker image, but its default command pointed at a WSGI object that does not exist. CI built and scanned that image without ever starting it, so the green container check did not prove the API could boot.

Local Compose had the same kind of contract drift: no worker, PostgreSQL 15, unsupported Node 20, and an API variable the frontend never reads.

## What I changed

- Made the image use the same migration-aware startup path as deployed APIs. Alembic must succeed before Gunicorn starts the real `api.app:application` object.
- Kept the runtime non-root and excluded this checkout's alternate `.gitdata` history from the build context.
- Replaced the optional Dockerfile scaffold with a required runtime gate: build one commit tag, start that tag against PostgreSQL 16, require exact `/ready` JSON, verify the actual runtime UID is non-root, and scan the same tag with Trivy.
- Kept Trivy independent enough to run when a successfully built image later fails its boot check, and made the final CI summary fail on the container result.
- Rebuilt Compose as an explicit `local` profile with loopback-only ports, migration-aware API startup, a worker that waits for API readiness, Node 22.22, `npm ci`, writable dependency/cache volumes, and the `VITE_API_URL` the browser actually uses.
- Aligned Terraform's Vercel variable name and corrected local runtime documentation.
- Added static contract tests so the image, Compose, Terraform, workflow, and final gate cannot silently drift apart again.

## Verification

- Runtime/configuration tests plus deployment config tests: 25 passed.
- Broader local backend suite: 747 passed, 5 expected skips (the Chroma runtime dependency test was excluded locally because Python 3.12 cannot build its pinned native extension on this host).
- Fresh GitHub CI passed the authoritative image build, Alembic startup, exact `/ready` response, non-root runtime UID, Trivy scan, backend coverage, Terraform validation, and final CI summary.
- Repository-wide Ruff and format checks passed.
- Compose and GitHub workflow YAML parsed successfully; `startup.sh` passed `bash -n`.

This host does not have Docker installed, so I am not presenting a local image run as evidence. The new draft PR job is the authoritative boot, migration, readiness, runtime-UID, and Trivy check.

## Merge order

#306 is merged and this branch has been rebased onto the updated `dev`. The recurring Compose `/ready` probe now uses the corrected database-connection lifecycle.

## Remaining #299 work

This is the first runtime slice and does not close #299. Follow-up work still has to prove the exact published GHCR digest, make the real Azure staging scan non-skippable, align OIDC/credential handling, wait for worker completion and persisted evaluation coverage, and add worker heartbeat/queue-age promotion signals.

Part of #299
Dependency #306 satisfied

