### PR TITLE
fix(deps): move chromadb out of core install (CVE-2026-45830, CVE-2026-45833)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -537,6 +537,11 @@ jobs:
         id: build
         run: docker build --tag "$IMAGE_TAG" --file Dockerfile .
 
+      - name: Verify BM25 retrieval in fresh image
+        run: |
+          docker run --rm --entrypoint python "$IMAGE_TAG" -c \
+            "from ai.retriever import retrieve; results = retrieve('Azure storage account security', n_results=5); assert results; print(results[0]['source'])"
+
       - name: Start image
         env:
           POSTGRES_PORT: ${{ job.services.postgres.ports[5432] }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,12 +6,21 @@ RUN apt-get update \
     && apt-get dist-upgrade -y \
     && rm -rf /var/lib/apt/lists/*
 
-COPY requirements.txt .
+# Set INSTALL_AI_DEPS=true at build time to include the optional RAG pipeline
+# (chromadb + numpy). Excluded by default: chromadb has active CVEs with no
+# upstream fix (CVE-2026-45830, CVE-2026-45833). AI routes return 503 without
+# this; the API server and all other functionality are unaffected.
+ARG INSTALL_AI_DEPS=false
+
+COPY requirements.txt requirements-ai.txt ./
 RUN pip install --no-cache-dir --upgrade \
         pip==26.1.2 \
         setuptools==83.0.0 \
         wheel==0.46.3 && \
-    pip install --no-cache-dir -r requirements.txt
+    pip install --no-cache-dir -r requirements.txt && \
+    if [ "$INSTALL_AI_DEPS" = "true" ]; then \
+        pip install --no-cache-dir -r requirements-ai.txt; \
+    fi
 
 COPY . .
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,8 @@ RUN pip install --no-cache-dir --upgrade \
 
 COPY . .
 
+RUN python -m ai.embed
+
 RUN groupadd --system openshield && \
     useradd --system --gid openshield --no-create-home openshield && \
     chown -R openshield:openshield /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-﻿FROM python:3.11-slim-trixie
+FROM python:3.11-slim-trixie
 
 WORKDIR /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim-trixie
+﻿FROM python:3.11-slim-trixie
 
 WORKDIR /app
 
@@ -6,21 +6,12 @@ RUN apt-get update \
     && apt-get dist-upgrade -y \
     && rm -rf /var/lib/apt/lists/*
 
-# Set INSTALL_AI_DEPS=true at build time to include the optional RAG pipeline
-# (chromadb + numpy). Excluded by default: chromadb has active CVEs with no
-# upstream fix (CVE-2026-45830, CVE-2026-45833). AI routes return 503 without
-# this; the API server and all other functionality are unaffected.
-ARG INSTALL_AI_DEPS=false
-
-COPY requirements.txt requirements-ai.txt ./
+COPY requirements.txt ./
 RUN pip install --no-cache-dir --upgrade \
         pip==26.1.2 \
         setuptools==83.0.0 \
         wheel==0.46.3 && \
-    pip install --no-cache-dir -r requirements.txt && \
-    if [ "$INSTALL_AI_DEPS" = "true" ]; then \
-        pip install --no-cache-dir -r requirements-ai.txt; \
-    fi
+    pip install --no-cache-dir -r requirements.txt
 
 COPY . .
 

--- a/ai/README.md
+++ b/ai/README.md
@@ -1,4 +1,4 @@
-﻿# OpenShield RAG Pipeline
+# OpenShield RAG Pipeline
 
 > **Optional dependency:** ChromaDB is not included in `requirements.txt`.
 > Install the AI extras before using `ai/embed.py` or `ai/retriever.py`:

--- a/ai/README.md
+++ b/ai/README.md
@@ -1,4 +1,11 @@
-# OpenShield RAG Pipeline
+﻿# OpenShield RAG Pipeline
+
+> **Optional dependency:** ChromaDB is not included in `requirements.txt`.
+> Install the AI extras before using `ai/embed.py` or `ai/retriever.py`:
+>
+> ```bash
+> pip install -r requirements-ai.txt
+> ```
 
 Document loader and chunker for OpenShield rules and compliance frameworks.
 Loads all scanner rules and CIS, NIST, ISO 27001 and SOC2 controls

--- a/ai/README.md
+++ b/ai/README.md
@@ -1,26 +1,27 @@
 # OpenShield RAG Pipeline
 
-> **Optional dependency:** ChromaDB is not included in `requirements.txt`.
-> Install the AI extras before using `ai/embed.py` or `ai/retriever.py`:
->
-> ```bash
-> pip install -r requirements-ai.txt
-> ```
-
 Document loader and chunker for OpenShield rules and compliance frameworks.
 Loads all scanner rules and CIS, NIST, ISO 27001 and SOC2 controls
-into structured documents for the RAG vector store.
+into structured documents for the RAG BM25 index.
+
+The RAG pipeline has no optional dependencies. Everything runs on the Python
+standard library (`math`, `json`, `re`). No C extensions, no chromadb, no numpy.
 
 ## Files
 
 - `ai/loader.py` — loads OpenShield rules and compliance frameworks as structured documents
-- `ai/chunker.py` — splits documents into overlapping chunks for embedding
-- `ai/embed.py` — builds the ChromaDB vector store (from PR 97)
-- `ai/retriever.py` — queries the vector store (from PR 97)
+- `ai/chunker.py` — splits documents into overlapping chunks for indexing
+- `ai/embed.py` — builds the BM25 index at `ai/vectorstore/bm25_index.json`
+- `ai/retriever.py` — queries the index using BM25 term scoring
 
-## Vector Store
+## Building the index
 
-The vector store is persisted at `ai/vectorstore/` using ChromaDB.
+```bash
+python ai/embed.py
+```
+
+The index is written atomically to `ai/vectorstore/bm25_index.json` so a
+partial build never leaves a corrupt file.
 
 ## How loader.py works
 
@@ -36,10 +37,22 @@ Also reads all four compliance framework JSON files:
 
 Finally, it reads all Claude-Red AI skills from `ai/knowledge/skills/*.md`:
 - Extracts the full markdown content as a document for offensive methodology knowledge.
-- **Dynamic Grounding:** Automatically injects relevant OpenShield scanner rules into each skill document using the mapping registry at `ai/knowledge/rule_mapping.json`. This ensures the AI provides application-specific responses rather than generic advice.
+- **Dynamic Grounding:** Automatically injects relevant OpenShield scanner rules into each skill document using the mapping registry at `ai/knowledge/rule_mapping.json`.
 
 ## How chunker.py works
 
 Splits documents into 512-character overlapping chunks with 64-character
 overlap. Tries to split on newlines to avoid breaking mid-sentence.
 Each chunk inherits the metadata of its parent document.
+
+## How BM25 works
+
+At build time (`embed.py`):
+1. Tokenizes each chunk (lowercase, non-alphanumeric split, stopword filter)
+2. Computes per-term document frequency and IDF across the corpus
+3. Stores term frequencies per chunk alongside the corpus statistics
+
+At query time (`retriever.py`):
+1. Tokenizes the query
+2. Scores each chunk with the BM25 formula (k1=1.5, b=0.75)
+3. Returns the top-N chunks sorted by score

--- a/ai/README.md
+++ b/ai/README.md
@@ -17,7 +17,7 @@ standard library (`math`, `json`, `re`). No C extensions, no chromadb, no numpy.
 ## Building the index
 
 ```bash
-python ai/embed.py
+python -m ai.embed
 ```
 
 The index is written atomically to `ai/vectorstore/bm25_index.json` so a

--- a/ai/chunker.py
+++ b/ai/chunker.py
@@ -43,7 +43,7 @@ def _split_text(text, chunk_size, chunk_overlap):
             chunks.append(text[start:].strip())
             break
         split_pos = text.rfind("\n", start, end)
-        if split_pos == -1 or split_pos <= start:
+        if split_pos == -1 or split_pos <= start + chunk_overlap:
             split_pos = end
         chunk = text[start:split_pos].strip()
         if chunk:

--- a/ai/embed.py
+++ b/ai/embed.py
@@ -1,86 +1,115 @@
-"""Build the OpenShield knowledge base vector store for RAG AI insights"""
+"""Build the OpenShield knowledge base BM25 index for RAG AI insights."""
 
+import json
 import logging
-import os
+import math
+import re
 import sys
 from pathlib import Path
 
-# Disable ChromaDB telemetry to prevent errors and improve performance on low-RAM machines
-os.environ["ANONYMIZED_TELEMETRY"] = "False"
-
-try:
-    import chromadb
-except ImportError:
-    chromadb = None
-
-# Add project root to path for imports
-sys.path.append(os.getcwd())
-
-from ai.loader import load_all_documents
 from ai.chunker import chunk_documents
+from ai.loader import load_all_documents
 
 logger = logging.getLogger(__name__)
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 VECTORSTORE_DIR = REPO_ROOT / "ai" / "vectorstore"
-COLLECTION_NAME = "openshield"
+INDEX_PATH = VECTORSTORE_DIR / "bm25_index.json"
+
+_STOPWORDS = frozenset(
+    {
+        "a",
+        "an",
+        "and",
+        "are",
+        "as",
+        "at",
+        "be",
+        "but",
+        "by",
+        "for",
+        "from",
+        "had",
+        "has",
+        "have",
+        "if",
+        "in",
+        "is",
+        "it",
+        "no",
+        "not",
+        "of",
+        "on",
+        "or",
+        "so",
+        "that",
+        "the",
+        "this",
+        "to",
+        "was",
+        "were",
+        "with",
+    }
+)
 
 
-def build_vectorstore():
-    if chromadb is None:
-        raise RuntimeError("chromadb is not installed. Install it with 'pip install chromadb'.")
+def _tokenize(text: str) -> list:
+    """Lowercase, split on non-alphanumeric, drop stopwords and short tokens."""
+    return [t for t in re.split(r"[^a-z0-9]+", text.lower()) if len(t) > 2 and t not in _STOPWORDS]
 
-    # 1. Load and chunk documents FIRST (if this fails, existing DB is untouched)
+
+def build_vectorstore() -> int:
+    """Build BM25 index from all documents and persist to JSON.
+
+    Returns the number of chunks indexed.
+    """
     documents = load_all_documents()
     if not documents:
-        raise RuntimeError("No documents found to embed. Check repo paths.")
+        raise RuntimeError("No documents found to index. Check repo paths.")
 
     chunks = chunk_documents(documents)
-    logger.info("Created %d chunks from %d source documents", len(chunks), len(documents))
+    logger.info("Indexing %d chunks from %d source documents", len(chunks), len(documents))
 
-    # 2. Initialize client
-    VECTORSTORE_DIR.mkdir(parents=True, exist_ok=True)
-    from chromadb.config import Settings
+    n = len(chunks)
+    df: dict = {}
+    processed = []
 
-    client = chromadb.PersistentClient(path=str(VECTORSTORE_DIR), settings=Settings(anonymized_telemetry=False))
-
-    # 3. Create a temporary collection for safe building
-    temp_name = f"{COLLECTION_NAME}_temp"
-    try:
-        client.delete_collection(temp_name)
-    except Exception:
-        pass
-    collection = client.create_collection(temp_name)
-
-    # 4. Add to vector store in batches to prevent memory spikes
-    batch_size = 50  # Small batch size for 8GB RAM machines
-    for i in range(0, len(chunks), batch_size):
-        batch = chunks[i : i + batch_size]
-
-        collection.add(
-            ids=[c["id"] for c in batch],
-            documents=[c["content"] for c in batch],
-            metadatas=[c["metadata"] for c in batch],
+    for chunk in chunks:
+        terms: dict = {}
+        for token in _tokenize(chunk["content"]):
+            terms[token] = terms.get(token, 0) + 1
+        for token in terms:
+            df[token] = df.get(token, 0) + 1
+        processed.append(
+            {
+                "id": chunk["id"],
+                "content": chunk["content"],
+                "metadata": chunk["metadata"],
+                "terms": terms,
+                "dl": sum(terms.values()),
+            }
         )
-        print(f"  Progress: {min(i + batch_size, len(chunks))}/{len(chunks)} chunks embedded...")
 
-    # 5. Atomic Swap: Delete main and rename temp to main
-    try:
-        client.delete_collection(COLLECTION_NAME)
-    except Exception:
-        pass
+    avg_dl = sum(c["dl"] for c in processed) / n if n else 1.0
 
-    collection.modify(name=COLLECTION_NAME)
+    idf = {term: math.log((n - freq + 0.5) / (freq + 0.5) + 1.0) for term, freq in df.items()}
 
-    logger.info("Successfully rebuilt vector store '%s' with %d chunks.", COLLECTION_NAME, len(chunks))
-    return len(chunks)
+    index = {"version": "1", "avg_dl": avg_dl, "idf": idf, "chunks": processed}
+
+    VECTORSTORE_DIR.mkdir(parents=True, exist_ok=True)
+    tmp = INDEX_PATH.with_suffix(".tmp")
+    tmp.write_text(json.dumps(index, ensure_ascii=False), encoding="utf-8")
+    tmp.replace(INDEX_PATH)
+
+    logger.info("BM25 index written to %s (%d chunks)", INDEX_PATH, n)
+    return n
 
 
 if __name__ == "__main__":
     logging.basicConfig(level=logging.INFO)
     try:
         count = build_vectorstore()
-        print(f"Done. Vector store built with {count} chunks at {VECTORSTORE_DIR}")
+        print(f"Done. BM25 index built with {count} chunks at {INDEX_PATH}")
     except Exception as exc:
-        print(f"Error building vector store: {exc}")
+        print(f"Error building index: {exc}")
         sys.exit(1)

--- a/ai/retriever.py
+++ b/ai/retriever.py
@@ -2,6 +2,7 @@
 
 import json
 import logging
+import math
 import re
 from pathlib import Path
 
@@ -61,11 +62,65 @@ def _tokenize(text: str) -> list:
 
 def _load_index() -> dict:
     if not INDEX_PATH.exists():
-        raise VectorStoreNotBuilt("BM25 index not found. Run 'python ai/embed.py' first.")
+        raise VectorStoreNotBuilt("BM25 index not found. Run 'python -m ai.embed' first.")
     try:
-        return json.loads(INDEX_PATH.read_text(encoding="utf-8"))
+        index = json.loads(INDEX_PATH.read_text(encoding="utf-8"))
     except Exception as exc:
         raise VectorStoreNotBuilt(f"BM25 index unreadable: {exc}") from exc
+    _validate_index(index)
+    return index
+
+
+def _validate_index(index: object) -> None:
+    """Reject incompatible or malformed indexes before scoring."""
+
+    def invalid(reason: str) -> None:
+        raise VectorStoreNotBuilt(f"BM25 index invalid: {reason}")
+
+    if not isinstance(index, dict):
+        invalid("root must be an object")
+    if index.get("version") != "1":
+        invalid("unsupported or missing version")
+
+    avg_dl = index.get("avg_dl")
+    if isinstance(avg_dl, bool) or not isinstance(avg_dl, (int, float)) or not math.isfinite(avg_dl) or avg_dl <= 0:
+        invalid("avg_dl must be a positive finite number")
+
+    idf = index.get("idf")
+    if not isinstance(idf, dict):
+        invalid("idf must be an object")
+    for term, value in idf.items():
+        if (
+            not isinstance(term, str)
+            or isinstance(value, bool)
+            or not isinstance(value, (int, float))
+            or not math.isfinite(value)
+            or value < 0
+        ):
+            invalid("idf entries must map terms to finite non-negative numbers")
+
+    chunks = index.get("chunks")
+    if not isinstance(chunks, list):
+        invalid("chunks must be an array")
+    for chunk in chunks:
+        if not isinstance(chunk, dict):
+            invalid("each chunk must be an object")
+        if not isinstance(chunk.get("content"), str) or not isinstance(chunk.get("metadata"), dict):
+            invalid("each chunk requires string content and object metadata")
+        terms = chunk.get("terms")
+        dl = chunk.get("dl")
+        if not isinstance(terms, dict) or isinstance(dl, bool) or not isinstance(dl, int) or dl < 0:
+            invalid("each chunk requires object terms and a non-negative integer dl")
+        for term, frequency in terms.items():
+            if (
+                not isinstance(term, str)
+                or isinstance(frequency, bool)
+                or not isinstance(frequency, int)
+                or frequency <= 0
+            ):
+                invalid("chunk terms must map tokens to positive integer frequencies")
+        if sum(terms.values()) != dl:
+            invalid("chunk term frequencies must sum to dl")
 
 
 def _bm25_score(query_terms: list, doc_terms: dict, dl: int, avg_dl: float, idf: dict) -> float:

--- a/ai/retriever.py
+++ b/ai/retriever.py
@@ -1,54 +1,106 @@
-"""Retrieve relevant OpenShield knowledge from the vector store for RAG."""
+"""Retrieve relevant OpenShield knowledge using BM25 scoring."""
 
+import json
 import logging
+import re
 from pathlib import Path
-
-try:
-    import chromadb
-except ImportError:
-    chromadb = None
 
 logger = logging.getLogger(__name__)
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 VECTORSTORE_DIR = REPO_ROOT / "ai" / "vectorstore"
-COLLECTION_NAME = "openshield"
+INDEX_PATH = VECTORSTORE_DIR / "bm25_index.json"
+
+_BM25_K1 = 1.5
+_BM25_B = 0.75
+
+_STOPWORDS = frozenset(
+    {
+        "a",
+        "an",
+        "and",
+        "are",
+        "as",
+        "at",
+        "be",
+        "but",
+        "by",
+        "for",
+        "from",
+        "had",
+        "has",
+        "have",
+        "if",
+        "in",
+        "is",
+        "it",
+        "no",
+        "not",
+        "of",
+        "on",
+        "or",
+        "so",
+        "that",
+        "the",
+        "this",
+        "to",
+        "was",
+        "were",
+        "with",
+    }
+)
 
 
 class VectorStoreNotBuilt(RuntimeError):
-    """Raised when the vector store is missing or chromadb is unavailable."""
+    """Raised when the BM25 index is missing or unreadable."""
 
 
-def _get_collection():
-    if chromadb is None:
-        raise VectorStoreNotBuilt("chromadb is not installed. Install it with 'pip install chromadb'.")
-    if not VECTORSTORE_DIR.exists():
-        raise VectorStoreNotBuilt("Vector store not found. Run 'python ai/embed.py' first.")
-    client = chromadb.PersistentClient(path=str(VECTORSTORE_DIR))
+def _tokenize(text: str) -> list:
+    return [t for t in re.split(r"[^a-z0-9]+", text.lower()) if len(t) > 2 and t not in _STOPWORDS]
+
+
+def _load_index() -> dict:
+    if not INDEX_PATH.exists():
+        raise VectorStoreNotBuilt("BM25 index not found. Run 'python ai/embed.py' first.")
     try:
-        return client.get_collection(COLLECTION_NAME)
+        return json.loads(INDEX_PATH.read_text(encoding="utf-8"))
     except Exception as exc:
-        raise VectorStoreNotBuilt("Vector store collection missing. Run 'python ai/embed.py' first.") from exc
+        raise VectorStoreNotBuilt(f"BM25 index unreadable: {exc}") from exc
 
 
-def retrieve(query, n_results=5):
+def _bm25_score(query_terms: list, doc_terms: dict, dl: int, avg_dl: float, idf: dict) -> float:
+    score = 0.0
+    for term in query_terms:
+        tf = doc_terms.get(term, 0)
+        if tf == 0:
+            continue
+        norm = tf * (_BM25_K1 + 1) / (tf + _BM25_K1 * (1 - _BM25_B + _BM25_B * dl / avg_dl))
+        score += idf.get(term, 0.0) * norm
+    return score
+
+
+def retrieve(query: str, n_results: int = 5) -> list:
     """Return the most relevant knowledge chunks for a query.
 
-    Each result is a dict with 'text' and 'source_meta'.
+    Each result is a dict with 'text', 'source', and 'source_meta'.
     """
-    collection = _get_collection()
-    results = collection.query(query_texts=[query], n_results=n_results)
+    index = _load_index()
+    avg_dl = index["avg_dl"]
+    idf = index["idf"]
+    query_terms = _tokenize(query)
 
-    documents = results.get("documents", [[]])[0]
-    metadatas = results.get("metadatas", [[]])[0]
+    scored = []
+    for chunk in index["chunks"]:
+        score = _bm25_score(query_terms, chunk["terms"], chunk["dl"], avg_dl, idf)
+        if score > 0:
+            scored.append((score, chunk))
 
-    chunks = []
-    for text, meta in zip(documents, metadatas):
-        meta = meta or {}
+    scored.sort(key=lambda x: x[0], reverse=True)
+    top = [chunk for _, chunk in scored[:n_results]]
 
-        # Build structured source for the frontend
-        source_id = "General"
-        source_resource = ""
+    results = []
+    for chunk in top:
+        meta = chunk.get("metadata") or {}
         source_type = meta.get("source", "unknown")
 
         if source_type == "openShield_rule":
@@ -56,14 +108,18 @@ def retrieve(query, n_results=5):
             source_resource = meta.get("rule_name", "")
         elif source_type == "claude_red_skill":
             source_id = meta.get("skill_name", "Skill")
+            source_resource = ""
         elif source_type == "compliance_framework":
             source_id = f"{meta.get('framework', 'Compliance')} {meta.get('control_id', '')}".strip()
             source_resource = meta.get("control_name", "")
+        else:
+            source_id = "General"
+            source_resource = ""
 
-        chunks.append(
+        results.append(
             {
-                "text": text,
-                "source": source_id,  # for LLM prompt context
+                "text": chunk["content"],
+                "source": source_id,
                 "source_meta": {
                     "id": source_id,
                     "type": source_type,
@@ -72,4 +128,4 @@ def retrieve(query, n_results=5):
                 },
             }
         )
-    return chunks
+    return results

--- a/requirements-ai.txt
+++ b/requirements-ai.txt
@@ -1,0 +1,2 @@
+chromadb==0.4.24
+numpy<2.0

--- a/requirements-ai.txt
+++ b/requirements-ai.txt
@@ -1,2 +1,0 @@
-chromadb==0.4.24
-numpy<2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -38,4 +38,5 @@ python-json-logger>=2.0.7
 sentry-sdk>=1.40.0
 pytest>=7.4.0
 pytest-cov>=4.1.0
+six==1.16.0
 certifi==2026.6.17

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,6 +28,7 @@ PyYAML==6.0.3
 gunicorn==26.0.0
 cryptography==50.0.0
 msrest==0.7.1
+six>=1.16.0
 azure-mgmt-postgresqlflexibleservers==1.0.0b1
 azure-keyvault-certificates==4.8.0
 azure-keyvault-keys==4.9.0
@@ -38,5 +39,4 @@ python-json-logger>=2.0.7
 sentry-sdk>=1.40.0
 pytest>=7.4.0
 pytest-cov>=4.1.0
-six==1.16.0
 certifi==2026.6.17

--- a/requirements.txt
+++ b/requirements.txt
@@ -33,8 +33,6 @@ azure-keyvault-certificates==4.8.0
 azure-keyvault-keys==4.9.0
 azure-mgmt-containerregistry==15.0.0
 azure-devops==7.1.0b4
-chromadb==0.4.24
-numpy<2.0
 prometheus-client>=0.19.0
 python-json-logger>=2.0.7
 sentry-sdk>=1.40.0

--- a/tests/test_container_runtime_config.py
+++ b/tests/test_container_runtime_config.py
@@ -104,14 +104,20 @@ def test_ci_builds_starts_and_scans_one_required_image():
     names = [step.get("name") for step in steps]
     assert "Check for Dockerfile" not in names
     assert names.index("Build image") < names.index("Start image")
+    assert names.index("Build image") < names.index("Verify BM25 retrieval in fresh image")
+    assert names.index("Verify BM25 retrieval in fresh image") < names.index("Start image")
     assert names.index("Start image") < names.index("Verify readiness and non-root runtime")
     assert names.index("Verify readiness and non-root runtime") < names.index("Run Trivy")
 
     build = _step(steps, "Build image")["run"]
+    rag_verify = _step(steps, "Verify BM25 retrieval in fresh image")["run"]
     start = _step(steps, "Start image")["run"]
     verify = _step(steps, "Verify readiness and non-root runtime")["run"]
     trivy = _step(steps, "Run Trivy")
     assert 'docker build --tag "$IMAGE_TAG"' in build
+    assert 'docker run --rm --entrypoint python "$IMAGE_TAG"' in rag_verify
+    assert "from ai.retriever import retrieve" in rag_verify
+    assert "assert results" in rag_verify
     assert '"$IMAGE_TAG"' in start
     assert "--network host" in start
     assert "127.0.0.1:${POSTGRES_PORT}/ci_db" in start

--- a/tests/test_rag_dependencies.py
+++ b/tests/test_rag_dependencies.py
@@ -2,6 +2,8 @@
 
 from pathlib import Path
 
+import pytest
+
 
 def test_vulnerable_transformer_stack_is_not_installed():
     requirements = Path("requirements.txt").read_text(encoding="utf-8").lower()
@@ -10,7 +12,17 @@ def test_vulnerable_transformer_stack_is_not_installed():
     assert "transformers" not in requirements
 
 
+def test_chromadb_not_in_core_requirements():
+    requirements = Path("requirements.txt").read_text(encoding="utf-8").lower()
+
+    assert "chromadb" not in requirements, (
+        "chromadb must not appear in requirements.txt (CVE-2026-45830, CVE-2026-45833); "
+        "use requirements-ai.txt for the optional RAG install"
+    )
+
+
 def test_chroma_default_embedding_uses_onnx_runtime():
+    pytest.importorskip("chromadb", exc_type=ImportError, reason="chromadb not installed (optional RAG dependency); skipping")
     from chromadb.utils.embedding_functions import DefaultEmbeddingFunction
 
     embedding_function = DefaultEmbeddingFunction()

--- a/tests/test_rag_dependencies.py
+++ b/tests/test_rag_dependencies.py
@@ -22,7 +22,11 @@ def test_chromadb_not_in_core_requirements():
 
 
 def test_chroma_default_embedding_uses_onnx_runtime():
-    pytest.importorskip("chromadb", exc_type=ImportError, reason="chromadb not installed (optional RAG dependency); skipping")
+    pytest.importorskip(
+        "chromadb",
+        exc_type=ImportError,
+        reason="chromadb not installed (optional RAG dependency); skipping",
+    )
     from chromadb.utils.embedding_functions import DefaultEmbeddingFunction
 
     embedding_function = DefaultEmbeddingFunction()

--- a/tests/test_rag_dependencies.py
+++ b/tests/test_rag_dependencies.py
@@ -2,8 +2,6 @@
 
 from pathlib import Path
 
-import pytest
-
 
 def test_vulnerable_transformer_stack_is_not_installed():
     requirements = Path("requirements.txt").read_text(encoding="utf-8").lower()
@@ -12,23 +10,60 @@ def test_vulnerable_transformer_stack_is_not_installed():
     assert "transformers" not in requirements
 
 
-def test_chromadb_not_in_core_requirements():
+def test_chromadb_absent_from_all_requirements():
+    for req_file in Path(".").glob("requirements*.txt"):
+        content = req_file.read_text(encoding="utf-8").lower()
+        assert "chromadb" not in content, (
+            f"chromadb must not appear in {req_file} "
+            "(CVE-2026-45830 tenant-isolation bypass, CVE-2026-45833 RCE); "
+            "the RAG pipeline now uses a pure-Python BM25 index with no C extensions"
+        )
+
+
+def test_requirements_ai_txt_does_not_exist():
+    assert not Path("requirements-ai.txt").exists(), (
+        "requirements-ai.txt must be deleted; chromadb has been replaced by the "
+        "pure-Python BM25 index in ai/embed.py and ai/retriever.py"
+    )
+
+
+def test_bm25_retriever_tokenizer():
+    from ai.retriever import _tokenize
+
+    tokens = _tokenize("Azure Storage Account immutability policy")
+    assert "azure" in tokens
+    assert "storage" in tokens
+    assert "immutability" in tokens
+    assert "policy" in tokens
+    # stopwords filtered
+    assert "the" not in tokens
+    assert "and" not in tokens
+
+
+def test_bm25_score_zero_for_no_overlap():
+    from ai.retriever import _bm25_score
+
+    score = _bm25_score(["kubernetes"], {"azure": 2, "storage": 1}, dl=3, avg_dl=3.0, idf={"azure": 1.0})
+    assert score == 0.0
+
+
+def test_bm25_score_positive_for_matching_term():
+    from ai.retriever import _bm25_score
+
+    idf = {"storage": 2.0}
+    score = _bm25_score(["storage"], {"storage": 3}, dl=5, avg_dl=5.0, idf=idf)
+    assert score > 0.0
+
+
+def test_bm25_score_higher_for_more_matches():
+    from ai.retriever import _bm25_score
+
+    idf = {"storage": 1.5, "immutable": 1.2}
+    score_one = _bm25_score(["storage"], {"storage": 2, "immutable": 1}, dl=3, avg_dl=3.0, idf=idf)
+    score_two = _bm25_score(["storage", "immutable"], {"storage": 2, "immutable": 1}, dl=3, avg_dl=3.0, idf=idf)
+    assert score_two > score_one
+
+
+def test_numpy_not_required():
     requirements = Path("requirements.txt").read_text(encoding="utf-8").lower()
-
-    assert "chromadb" not in requirements, (
-        "chromadb must not appear in requirements.txt (CVE-2026-45830, CVE-2026-45833); "
-        "use requirements-ai.txt for the optional RAG install"
-    )
-
-
-def test_chroma_default_embedding_uses_onnx_runtime():
-    pytest.importorskip(
-        "chromadb",
-        exc_type=ImportError,
-        reason="chromadb not installed (optional RAG dependency); skipping",
-    )
-    from chromadb.utils.embedding_functions import DefaultEmbeddingFunction
-
-    embedding_function = DefaultEmbeddingFunction()
-
-    assert embedding_function.__class__.__name__ == "ONNXMiniLM_L6_V2"
+    assert "numpy" not in requirements, "numpy must not be in requirements.txt; BM25 retrieval uses only stdlib math"

--- a/tests/test_rag_dependencies.py
+++ b/tests/test_rag_dependencies.py
@@ -3,6 +3,14 @@
 from pathlib import Path
 
 
+def test_dockerfile_starts_with_from_instruction():
+    dockerfile = Path("Dockerfile").read_bytes()
+
+    assert dockerfile.startswith(b"FROM "), (
+        "Dockerfile must start directly with FROM; a UTF-8 BOM makes the first Docker instruction invalid"
+    )
+
+
 def test_vulnerable_transformer_stack_is_not_installed():
     requirements = Path("requirements.txt").read_text(encoding="utf-8").lower()
 
@@ -67,3 +75,42 @@ def test_bm25_score_higher_for_more_matches():
 def test_numpy_not_required():
     requirements = Path("requirements.txt").read_text(encoding="utf-8").lower()
     assert "numpy" not in requirements, "numpy must not be in requirements.txt; BM25 retrieval uses only stdlib math"
+
+
+def test_bm25_index_builds_and_retrieves_openshield_content(tmp_path, monkeypatch):
+    from ai import embed, retriever
+
+    index_path = tmp_path / "bm25_index.json"
+    documents = [
+        {
+            "id": "AZ-STOR-TEST",
+            "content": "Azure storage accounts should require secure transfer and disable public access.",
+            "metadata": {
+                "source": "openShield_rule",
+                "rule_id": "AZ-STOR-TEST",
+                "rule_name": "Secure Azure storage",
+            },
+        },
+        {
+            "id": "AZ-ID-TEST",
+            "content": "Privileged identities should use multifactor authentication and limited role assignments.",
+            "metadata": {
+                "source": "openShield_rule",
+                "rule_id": "AZ-ID-TEST",
+                "rule_name": "Protect privileged identities",
+            },
+        },
+    ]
+    monkeypatch.setattr(embed, "VECTORSTORE_DIR", tmp_path)
+    monkeypatch.setattr(embed, "INDEX_PATH", index_path)
+    monkeypatch.setattr(embed, "load_all_documents", lambda: documents)
+    monkeypatch.setattr(retriever, "INDEX_PATH", index_path)
+
+    assert embed.build_vectorstore() > 0
+
+    results = retriever.retrieve("Azure storage account security", n_results=5)
+
+    assert results
+    assert results[0]["source"] == "AZ-STOR-TEST"
+    assert all(result["text"] for result in results)
+    assert all(result["source"] for result in results)

--- a/tests/test_rag_dependencies.py
+++ b/tests/test_rag_dependencies.py
@@ -1,6 +1,11 @@
 """Regression tests for the RAG dependency and embedding configuration."""
 
+import json
 from pathlib import Path
+import subprocess
+import sys
+
+import pytest
 
 
 def test_dockerfile_starts_with_from_instruction():
@@ -9,6 +14,25 @@ def test_dockerfile_starts_with_from_instruction():
     assert dockerfile.startswith(b"FROM "), (
         "Dockerfile must start directly with FROM; a UTF-8 BOM makes the first Docker instruction invalid"
     )
+
+
+def test_chunker_advances_when_newline_is_inside_overlap_window():
+    script = (
+        "from ai.chunker import _split_text; "
+        "chunks = _split_text('abcdefghijklmno\\n' + 'x' * 30, 20, 10); "
+        "assert ''.join(chunks).replace(' ', ''); print(len(chunks))"
+    )
+
+    completed = subprocess.run(
+        [sys.executable, "-c", script],
+        cwd=Path(__file__).resolve().parents[1],
+        capture_output=True,
+        text=True,
+        timeout=2,
+        check=False,
+    )
+
+    assert completed.returncode == 0, completed.stderr
 
 
 def test_vulnerable_transformer_stack_is_not_installed():
@@ -114,3 +138,24 @@ def test_bm25_index_builds_and_retrieves_openshield_content(tmp_path, monkeypatc
     assert results[0]["source"] == "AZ-STOR-TEST"
     assert all(result["text"] for result in results)
     assert all(result["source"] for result in results)
+
+
+@pytest.mark.parametrize(
+    "index",
+    [
+        {},
+        {"version": "2", "avg_dl": 1.0, "idf": {}, "chunks": []},
+        {"version": "1", "avg_dl": 0, "idf": {}, "chunks": []},
+        {"version": "1", "avg_dl": 1.0, "idf": [], "chunks": []},
+        {"version": "1", "avg_dl": 1.0, "idf": {}, "chunks": [{}]},
+    ],
+)
+def test_malformed_bm25_index_raises_vector_store_not_built(tmp_path, monkeypatch, index):
+    from ai import retriever
+
+    index_path = tmp_path / "bm25_index.json"
+    index_path.write_text(json.dumps(index), encoding="utf-8")
+    monkeypatch.setattr(retriever, "INDEX_PATH", index_path)
+
+    with pytest.raises(retriever.VectorStoreNotBuilt, match="BM25 index invalid"):
+        retriever.retrieve("Azure storage")


### PR DESCRIPTION
## Summary

- Remove `chromadb==0.4.24`, which is affected by CVE-2026-45830 and CVE-2026-45833, from every supported installation path.
- Replace the ChromaDB vector store with a dependency-free persisted BM25 JSON index.
- Preserve the existing `retrieve()` response contract used by the AI routes.
- Keep the existing route-level handling for a missing or unreadable index.

## Changes

- `requirements.txt`: remove ChromaDB and NumPy; retain `six>=1.16.0` for the runtime import used by `azure-mgmt-rdbms`.
- `requirements-ai.txt`: remove the obsolete optional vulnerable dependency file.
- `ai/embed.py`: tokenize repository knowledge, calculate BM25 corpus statistics, and atomically write `ai/vectorstore/bm25_index.json`.
- `ai/retriever.py`: validate the versioned JSON schema, reject malformed indexes through `VectorStoreNotBuilt`, and rank matching chunks using BM25.
- `Dockerfile`: use core requirements, build the BM25 index into every image, and ensure the file begins with a valid `FROM` instruction without a UTF-8 BOM.
- `ai/README.md`: document the dependency-free build and retrieval flow.
- `ai/chunker.py`: guarantee forward progress when a newline falls inside the overlap window.
- `.github/workflows/ci.yml`: retrieve OpenShield content inside the freshly built production image before runtime and Trivy checks.
- `tests/test_rag_dependencies.py`: cover dependency absence, Dockerfile validity, chunker progress, malformed indexes, BM25 scoring, index persistence, and retrieval.

## Test plan

- [x] `python -m ruff check .`
- [x] `python -m ruff format --check .`
- [x] `python -m pytest` (`759 passed, 5 skipped` locally on commit `bfa95f0`)
- [x] ChromaDB absent from all `requirements*.txt` files
- [x] BM25 index builds and retrieves relevant OpenShield content using core dependencies
- [x] Required GitHub checks complete successfully
- [ ] Maintainer re-review confirms the requested changes

## Security scope

OpenShield used ChromaDB as an embedded local dependency rather than exposing a standalone ChromaDB server. Removing the unpatched package eliminates the vulnerable component from supported installs without claiming that OpenShield previously exposed ChromaDB's network API.

## Closes

Dependabot alerts #16 and #17



