### PR TITLE
fix(api): enforce token expiry, role, and subscription authorization

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,11 @@ DATABASE_URL=postgresql://openshield:openshield@localhost:5432/openshield
 # Auth
 JWT_SECRET=change-me-in-production
 
+# Optional - comma-separated subscription_id allowlist for POST /api/scans/trigger.
+# Unset accepts any subscription_id (matches historical behavior); the API
+# logs a startup warning when this is unset. See docs/api-reference.md.
+OPENSHIELD_AUTHORIZED_SUBSCRIPTIONS=
+
 # AI providers - add at least one
 ANTHROPIC_API_KEY=
 GROQ_API_KEY=

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ OpenShield uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - AI provider errors no longer expose upstream response details
 - Request body limits, AI rate limiting, and playbook path validation added
 - GitHub Actions dependencies pinned to immutable commit SHAs
+- JWTs must now carry an `exp` claim and a recognized `role`; a `viewer` token can no longer perform any write operation (scan trigger, AI endpoints), and `POST /api/scans/trigger` now checks `subscription_id` against an optional `OPENSHIELD_AUTHORIZED_SUBSCRIPTIONS` allowlist
 
 ## [0.3.0] - 2026-07-08
 

--- a/api/app.py
+++ b/api/app.py
@@ -32,6 +32,16 @@ _MIN_JWT_SECRET_LENGTH = 32
 _MAX_AUTHORIZATION_HEADER_LENGTH = 8192
 _GENERATE_CMD = 'python -c "import secrets; print(secrets.token_urlsafe(32))"'
 
+# A token's signature proves who signed it, not what the bearer is allowed to
+# do. Every accepted token must carry one of these roles (see issue #294):
+# a missing/unrecognized role is treated the same as an invalid signature.
+# Only operator/admin may perform a write (any non-GET/HEAD); viewer is
+# read-only. This is enforced regardless of demo mode - public_demo only
+# ever widens *read* access to skip the token requirement entirely, it does
+# not touch write authorization.
+_KNOWN_ROLES = {"viewer", "operator", "admin"}
+_WRITE_ROLES = {"operator", "admin"}
+
 
 def _is_production() -> bool:
     return (
@@ -141,6 +151,14 @@ def create_app() -> Flask:
             "Do not use this setting with real Azure scan data in production."
         )
 
+    if not os.environ.get("OPENSHIELD_AUTHORIZED_SUBSCRIPTIONS"):
+        logger.warning(
+            "!!! SECURITY WARNING: OPENSHIELD_AUTHORIZED_SUBSCRIPTIONS NOT SET !!! "
+            "Any authenticated operator/admin token can trigger a scan against any "
+            "subscription_id. Set this to a comma-separated allowlist of the "
+            "subscription(s) this deployment is authorized to scan."
+        )
+
     @app.teardown_appcontext
     def close_db(error=None):
         """Return the request's pooled database connection after the request."""
@@ -182,6 +200,12 @@ def create_app() -> Flask:
                 token,
                 app.config["JWT_SECRET"],
                 algorithms=["HS256"],
+                # A token with no expiry can never be invalidated short of a
+                # full JWT_SECRET rotation - require every accepted token to
+                # carry one (issue #294). MissingRequiredClaimError is a
+                # subclass of InvalidTokenError, so it's already handled by
+                # the except clause below.
+                options={"require": ["exp"]},
             )
             g.user = payload
         except jwt.ExpiredSignatureError:
@@ -189,6 +213,18 @@ def create_app() -> Flask:
         except jwt.InvalidTokenError:
             logger.warning("Invalid JWT token")
             return jsonify({"error": "Invalid token", "request_id": get_request_id()}), 401
+
+        role = payload.get("role")
+        if role not in _KNOWN_ROLES:
+            logger.warning("JWT rejected: missing or unrecognized role %r", role)
+            return jsonify({"error": "Invalid token", "request_id": get_request_id()}), 401
+        if request.method not in ("GET", "HEAD") and role not in _WRITE_ROLES:
+            return jsonify(
+                {
+                    "error": "This token's role is not authorized for write operations",
+                    "request_id": get_request_id(),
+                }
+            ), 403
 
         return None
 

--- a/api/routes/scans.py
+++ b/api/routes/scans.py
@@ -19,6 +19,29 @@ from scanner.cve_correlator import enrich_findings
 scans_bp = Blueprint("scans", __name__)
 logger = logging.getLogger(__name__)
 
+_AUTHORIZED_SUBSCRIPTIONS_ENV = "OPENSHIELD_AUTHORIZED_SUBSCRIPTIONS"
+
+
+def _subscription_is_authorized(subscription_id: str) -> bool:
+    """Return True unless an allowlist is configured and this ID isn't on it.
+
+    OPENSHIELD_AUTHORIZED_SUBSCRIPTIONS is a comma-separated allowlist an
+    operator can set to bound which subscription_id values this deployment
+    will accept for scanning - the single-tenant containment boundary issue
+    #294 asks for until a real multi-tenant/OIDC boundary exists. Any
+    authenticated operator/admin token can otherwise trigger a scan against
+    an arbitrary subscription_id, since role alone doesn't say which
+    subscription a caller is entitled to.
+
+    Left unset (the default), every subscription_id is accepted - identical
+    to today's behavior, so existing single-operator deployments aren't
+    broken by this change. api.app's startup check warns loudly when it's
+    left unset.
+    """
+    raw = os.environ.get(_AUTHORIZED_SUBSCRIPTIONS_ENV, "")
+    allowlist = {value.strip().lower() for value in raw.split(",") if value.strip()}
+    return not allowlist or subscription_id.lower() in allowlist
+
 
 def _get_db() -> DatabaseManager:
     if "db" not in g:
@@ -77,6 +100,10 @@ def trigger_scan():
         if not subscription_id:
             return jsonify({"error": "subscription_id is required"}), 400
         subscription_id = uuid_string(subscription_id, "subscription_id")
+
+        if not _subscription_is_authorized(subscription_id):
+            logger.warning("Scan trigger rejected: subscription %s is not on the authorized allowlist", subscription_id)
+            return jsonify({"error": "Subscription is not authorized for this deployment"}), 403
 
         scan_id = str(uuid.uuid4())
         logger.info("Async scan triggered for subscription %s (id: %s)", subscription_id, scan_id)

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -8,7 +8,20 @@ setting is enabled.
 
 ## Authentication
 
-`/health` and `/` are always public. All other routes — including all `/api/*` GET endpoints — require an `Authorization: Bearer <jwt>` header signed with `JWT_SECRET`.
+`/`, `/health`, `/ready`, and `/metrics` are always public. All other routes — including all `/api/*` GET endpoints — require an `Authorization: Bearer <jwt>` header signed with `JWT_SECRET`.
+
+Every accepted token must carry:
+
+- `exp` — a token with no expiry is rejected outright. There is no way to mint a permanently-valid token; regenerate before it expires.
+- `role` — one of `viewer`, `operator`, or `admin`. A missing or unrecognized role is treated the same as an invalid signature (`401`).
+
+`viewer` is read-only: any non-`GET`/`HEAD` request (scan trigger, AI endpoints) from a `viewer` token is rejected with `403`, regardless of demo mode. Only `operator` and `admin` may perform a write. This is enforced in `api/app.py`'s JWT middleware, not per-route, so it applies uniformly to every current and future write endpoint.
+
+`scripts/generate_demo_jwt.py` mints a `viewer` token with a bounded expiry (`DEMO_JWT_TTL_HOURS`, default 24h) — see the script's own docstring before embedding one as `VITE_JWT_TOKEN`.
+
+### Subscription authorization
+
+`POST /api/scans/trigger` also checks `subscription_id` against `OPENSHIELD_AUTHORIZED_SUBSCRIPTIONS`, a comma-separated allowlist. A valid `operator`/`admin` token can otherwise trigger a scan against *any* subscription_id — role alone doesn't say which subscription a caller is entitled to. Left unset, every subscription_id is accepted (matches historical behavior); the API logs a loud startup warning when it's unset. This is a single-tenant containment boundary, not a substitute for real per-tenant authorization — see issue #294 for the full multi-tenant/OIDC scope this is a stopgap for.
 
 ## Input limits
 

--- a/scripts/generate_demo_jwt.py
+++ b/scripts/generate_demo_jwt.py
@@ -1,20 +1,27 @@
 #!/usr/bin/env python3
 """
-Generate a long-lived demo JWT for the OpenShield frontend.
+Generate a demo JWT for the OpenShield frontend.
 
 The token is signed with the same JWT_SECRET used by the Render backend.
 Set the result as VITE_JWT_TOKEN in the Vercel environment to allow the
-frontend to authenticate against all /api/* endpoints.
+frontend to authenticate against read (GET) /api/* endpoints.
 
 Usage:
     JWT_SECRET=<your-production-secret> python scripts/generate_demo_jwt.py
+    JWT_SECRET=<your-production-secret> DEMO_JWT_TTL_HOURS=8 python scripts/generate_demo_jwt.py
 
-The token has no expiry so it works without rotation. Treat it like a
-password — set it only in the Vercel dashboard, never commit it to the repo.
+The API now requires every token to carry an expiry and rejects any request
+whose role isn't recognized (see issue #294) - this token expires after
+DEMO_JWT_TTL_HOURS (default 24) and must be regenerated after that, and its
+"viewer" role means it can never authorize a write (scan trigger, AI
+endpoints). It is still a bearer credential once issued: treat it like a
+password - set it only in the Vercel dashboard, never commit it to the repo,
+and regenerate it (this script, or a fresh JWT_SECRET) if it may have leaked.
 """
 
 import os
 import sys
+import time
 
 try:
     import jwt
@@ -28,15 +35,30 @@ if not secret:
         "Usage: JWT_SECRET=<your-production-secret> python scripts/generate_demo_jwt.py"
     )
 
+_DEFAULT_TTL_HOURS = 24.0
+try:
+    ttl_hours = float(os.environ.get("DEMO_JWT_TTL_HOURS", _DEFAULT_TTL_HOURS))
+except ValueError:
+    sys.exit("Error: DEMO_JWT_TTL_HOURS must be a number.")
+if ttl_hours <= 0:
+    sys.exit("Error: DEMO_JWT_TTL_HOURS must be greater than zero.")
+
+issued_at = int(time.time())
 token = jwt.encode(
-    {"sub": "openshield-demo", "role": "viewer"},
+    {
+        "sub": "openshield-demo",
+        "role": "viewer",
+        "iat": issued_at,
+        "exp": issued_at + int(ttl_hours * 3600),
+    },
     secret,
     algorithm="HS256",
 )
 
-print("\nGenerated demo JWT (set this as VITE_JWT_TOKEN on Vercel):\n")
+print(f"\nGenerated demo JWT, expires in {ttl_hours:g}h (set this as VITE_JWT_TOKEN on Vercel):\n")
 print(token)
 print(
     "\nNEVER commit this token or the JWT_SECRET to the repository.\n"
     "Set it only in the Vercel dashboard → Settings → Environment Variables.\n"
+    "Regenerate before it expires - there is no automatic renewal.\n"
 )

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -9,13 +9,12 @@ import pytest
 _SECRET = secrets.token_urlsafe(32)
 
 
-def _make_token() -> str:
-    payload = {
-        "sub": "test-user",
-        "role": "admin",
-        "iat": int(time.time()),
-        "exp": int(time.time()) + 3600,
-    }
+def _make_token(role="admin", include_exp=True, include_role=True) -> str:
+    payload = {"sub": "test-user", "iat": int(time.time())}
+    if include_role:
+        payload["role"] = role
+    if include_exp:
+        payload["exp"] = int(time.time()) + 3600
     return jwt.encode(payload, _SECRET, algorithm="HS256")
 
 
@@ -87,3 +86,66 @@ def test_demo_post_still_requires_jwt(demo_client):
 def test_demo_score_allowed_without_jwt(demo_client):
     resp = demo_client.get("/api/score")
     assert resp.status_code != 401
+
+
+# ── Required claims: every accepted token must carry exp and a known role ───
+# (issue #294 - the previously-embeddable demo token had neither enforced)
+
+
+def test_token_without_exp_is_rejected(prod_client):
+    headers = {"Authorization": f"Bearer {_make_token(include_exp=False)}"}
+    resp = prod_client.get("/api/findings", headers=headers)
+    assert resp.status_code == 401
+
+
+def test_token_without_role_is_rejected(prod_client):
+    headers = {"Authorization": f"Bearer {_make_token(include_role=False)}"}
+    resp = prod_client.get("/api/findings", headers=headers)
+    assert resp.status_code == 401
+
+
+def test_token_with_unrecognized_role_is_rejected(prod_client):
+    headers = {"Authorization": f"Bearer {_make_token(role='superuser')}"}
+    resp = prod_client.get("/api/findings", headers=headers)
+    assert resp.status_code == 401
+
+
+# ── viewer is read-only; operator/admin may write ────────────────────────────
+
+
+def test_viewer_role_can_read(prod_client):
+    headers = {"Authorization": f"Bearer {_make_token(role='viewer')}"}
+    resp = prod_client.get("/api/findings", headers=headers)
+    assert resp.status_code != 401
+    assert resp.status_code != 403
+
+
+def test_viewer_role_cannot_write(prod_client):
+    headers = {"Authorization": f"Bearer {_make_token(role='viewer')}"}
+    resp = prod_client.post("/api/scans/trigger", json={}, headers=headers)
+    assert resp.status_code == 403
+
+
+def test_viewer_role_cannot_write_even_in_demo_mode(demo_client):
+    """public_demo only ever widens *read* access - the write-role gate
+    must hold regardless of it."""
+    headers = {"Authorization": f"Bearer {_make_token(role='viewer')}"}
+    resp = demo_client.post("/api/scans/trigger", json={}, headers=headers)
+    assert resp.status_code == 403
+
+
+def test_operator_role_can_write(prod_client):
+    headers = {"Authorization": f"Bearer {_make_token(role='operator')}"}
+    resp = prod_client.post("/api/scans/trigger", json={}, headers=headers)
+    # Fails past auth on missing DATABASE_URL/subscription_id in this test
+    # environment - the point here is only that role enforcement itself
+    # doesn't block it (a 403 would mean the role gate rejected it).
+    assert resp.status_code != 401
+    assert resp.status_code != 403
+
+
+def test_admin_role_can_write(prod_client):
+    headers = {"Authorization": f"Bearer {_make_token(role='admin')}"}
+    resp = prod_client.post("/api/scans/trigger", json={}, headers=headers)
+    assert resp.status_code != 401
+    assert resp.status_code != 403

--- a/tests/test_subscription_authorization.py
+++ b/tests/test_subscription_authorization.py
@@ -1,0 +1,90 @@
+"""Tests for the OPENSHIELD_AUTHORIZED_SUBSCRIPTIONS allowlist on
+POST /api/scans/trigger (issue #294's single-tenant containment boundary).
+
+A valid operator/admin token alone doesn't say which Azure subscription its
+holder is entitled to scan - without this allowlist, any authenticated
+write-capable token can trigger a scan against an arbitrary subscription_id.
+"""
+
+from unittest.mock import MagicMock, patch
+
+AUTHORIZED = "11111111-1111-1111-1111-111111111111"
+UNAUTHORIZED = "22222222-2222-2222-2222-222222222222"
+
+
+def _trigger(client, auth_headers, subscription_id, monkeypatch):
+    monkeypatch.setenv("DATABASE_URL", "postgresql://ci:ci@localhost/ci_db")
+    with patch("api.routes.scans.DatabaseManager", return_value=MagicMock()):
+        return client.post(
+            "/api/scans/trigger",
+            json={"subscription_id": subscription_id},
+            headers=auth_headers,
+        )
+
+
+def test_unset_allowlist_accepts_any_subscription(client, auth_headers, monkeypatch):
+    """Unset (the default) must preserve today's behavior - no allowlist
+    configured means no deployment is unexpectedly broken by this change."""
+    monkeypatch.delenv("OPENSHIELD_AUTHORIZED_SUBSCRIPTIONS", raising=False)
+
+    resp = _trigger(client, auth_headers, UNAUTHORIZED, monkeypatch)
+
+    assert resp.status_code == 202
+
+
+def test_allowlisted_subscription_is_accepted(client, auth_headers, monkeypatch):
+    other = "33333333-3333-3333-3333-333333333333"
+    monkeypatch.setenv("OPENSHIELD_AUTHORIZED_SUBSCRIPTIONS", f"{AUTHORIZED},{other}")
+
+    resp = _trigger(client, auth_headers, AUTHORIZED, monkeypatch)
+
+    assert resp.status_code == 202
+
+
+def test_subscription_outside_allowlist_is_rejected(client, auth_headers, monkeypatch):
+    monkeypatch.setenv("OPENSHIELD_AUTHORIZED_SUBSCRIPTIONS", AUTHORIZED)
+
+    resp = _trigger(client, auth_headers, UNAUTHORIZED, monkeypatch)
+
+    assert resp.status_code == 403
+    assert "not authorized" in resp.get_json()["error"]
+
+
+def test_allowlist_comparison_is_case_insensitive(client, auth_headers, monkeypatch):
+    monkeypatch.setenv("OPENSHIELD_AUTHORIZED_SUBSCRIPTIONS", AUTHORIZED.upper())
+
+    resp = _trigger(client, auth_headers, AUTHORIZED, monkeypatch)
+
+    assert resp.status_code == 202
+
+
+def test_allowlist_ignores_blank_entries_and_whitespace(client, auth_headers, monkeypatch):
+    monkeypatch.setenv("OPENSHIELD_AUTHORIZED_SUBSCRIPTIONS", f" {AUTHORIZED} ,, ")
+
+    resp = _trigger(client, auth_headers, AUTHORIZED, monkeypatch)
+
+    assert resp.status_code == 202
+
+
+def test_startup_warns_when_allowlist_is_unset(monkeypatch, caplog):
+    import logging
+
+    monkeypatch.delenv("OPENSHIELD_AUTHORIZED_SUBSCRIPTIONS", raising=False)
+    from api.app import create_app
+
+    with caplog.at_level(logging.WARNING):
+        create_app()
+
+    assert any("OPENSHIELD_AUTHORIZED_SUBSCRIPTIONS" in record.getMessage() for record in caplog.records)
+
+
+def test_startup_does_not_warn_when_allowlist_is_set(monkeypatch, caplog):
+    import logging
+
+    monkeypatch.setenv("OPENSHIELD_AUTHORIZED_SUBSCRIPTIONS", AUTHORIZED)
+    from api.app import create_app
+
+    with caplog.at_level(logging.WARNING):
+        create_app()
+
+    assert not any("OPENSHIELD_AUTHORIZED_SUBSCRIPTIONS" in record.message for record in caplog.records)


### PR DESCRIPTION
## What does this PR do?
Partially addresses #294: enforces token expiry and role on every accepted JWT, gates every write endpoint to `operator`/`admin` roles, and adds an optional subscription authorization allowlist on `POST /api/scans/trigger`. This is the immediate, in-repo, dependency-free containment slice of #294 - see the scope note below for what's deliberately not in this PR.

## Type of change
- [x] Bug fix
- [x] API endpoint
- [x] Documentation

## Scope note

#294 is really two bodies of work of very different size and dependency profile. This PR is the first only; the second is flagged, not forced.

**In this PR** - confirmed live before starting (`verify_jwt()` only checked the signature and expiry-if-present, `role` was decoded into `g.user` but never read by any route, and the baseline schema has no tenant/org column at all):

1. **No-expiry tokens.** `jwt.decode()` now requires `exp` (`options={"require": ["exp"]}`). A token missing it is rejected the same as an invalid signature — closes the specific hole where the documented `VITE_JWT_TOKEN` demo credential "works without rotation" because it never expires.
2. **Role never enforced.** `verify_jwt()` now requires a recognized `role` (`viewer`/`operator`/`admin`) on every accepted token, and rejects any non-`GET`/`HEAD` request from a `viewer` token with `403`. Enforced once in the middleware, so it covers every current write route (scan trigger, all 5 AI endpoints) and any future one uniformly, rather than needing a per-route check. Confirmed this holds under `OPENSHIELD_PUBLIC_DEMO=true` too — demo mode only ever widens *read* access, never write.
3. **No subscription authorization.** `POST /api/scans/trigger` accepted an arbitrary caller-supplied `subscription_id` with no check that the caller was entitled to it — any `operator`/`admin` token could trigger a scan against any subscription. Added an optional `OPENSHIELD_AUTHORIZED_SUBSCRIPTIONS` comma-separated allowlist, which is the "configured subscription allowlist" this issue itself names as an acceptable single-tenant interim. Left unset, behavior is unchanged from today (no deployment is silently broken by this PR); the API now logs a loud startup warning when it's left unset, matching the existing `ALLOWED_ORIGINS`/`JWT_SECRET` convention in the same function.
4. **`scripts/generate_demo_jwt.py`** minted a permanent, no-expiry token by design. Now requires an expiry (`DEMO_JWT_TTL_HOURS`, default 24h); docstring/output updated to stop claiming it works without rotation.
5. `docs/api-reference.md` and `.env.example` document all of the above.

**Deliberately not in this PR**, flagged rather than forced: the durable-boundary body (Entra/OIDC Authorization Code + PKCE, JWKS validation, per-tenant schema/RLS, cross-tenant integration tests) needs an actual identity-provider app registration (client ID/secret, redirect URIs) against this deployment's real domains, plus a product decision on which IdP and whether multi-tenancy is in scope for a first release. Both are outside what a PR to this repository can provision or decide alone. #294 stays open for that.

Also deliberately untouched: `frontend/src/App.jsx`'s local-dev `dev-local-token` bootstrap. It is not a valid signed JWT (`verify_jwt()` rejects it outright outside demo mode) and only ever worked because `OPENSHIELD_PUBLIC_DEMO` bypasses the JWT check for `GET` — removing it without a replacement login flow would break local dev for every contributor while fixing nothing real, since it was never a working credential. The actual leaked-credential risk is `VITE_JWT_TOKEN`, which is what items 1-2 above bound.

## Testing
- [x] All CI checks pass
- [x] No hardcoded credentials or secrets

New/updated coverage:
- `tests/test_auth.py`: missing-`exp` rejected, missing/unrecognized-`role` rejected, `viewer` can read, `viewer` cannot write (including under demo mode), `operator`/`admin` can write. All pre-existing cases in this file (and `tests/test_async_scan_persistence.py`, `smoke_test.py`) already used tokens carrying `role`+`exp`, so nothing broke.
- `tests/test_subscription_authorization.py` (new): unset allowlist preserves today's behavior, allowlisted/non-allowlisted subscriptions, case-insensitive comparison, blank-entry handling, startup-warning presence/absence.

Verified: full backend suite (796 passed, 5 skipped — pre-existing/environment-only, confirmed identical skip count against unmodified `dev`). `ruff check .` and `ruff format --check .` clean.

## Related issue
Partially addresses #294 — the durable multi-tenant/OIDC boundary remains open, see scope note above.

## Checklist
- [x] Every commit includes a DCO `Signed-off-by` trailer
- [x] I have not committed any real Azure credentials
- [x] My branch name follows the convention: `fix/description`
- [ ] Matching CLI playbook / compliance framework mappings — not applicable, no scanner rule added
