### PR TITLE
infra: add Mergify serial merge queue for dev branch

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -25,6 +25,11 @@
 ## Related issue
 Closes #
 
+## Dependencies
+<!-- List any PRs or issues that must merge before this one. -->
+<!-- Replace "none" with one or more references, e.g. Depends-On: #123 -->
+Depends-On: none
+
 ## Checklist
 - [ ] Every commit includes a DCO `Signed-off-by` trailer (`git commit -s`; see `docs/dco.md`)
 - [ ] My code follows the rule template in CONTRIBUTING.md

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -28,15 +28,17 @@ queue_rules:
     # These conditions must hold at the moment Mergify merges the PR.
     # Mergify re-evaluates them after rebasing onto the current dev HEAD.
     #
-    # CI Summary covers all required GitHub Actions jobs. Once PR #329 merges,
-    # it will also include the Astro website build and rendered-site verification
-    # ("Website (Astro build + verification)"), so no separate check-success
-    # condition is needed for the website gate. If maintainers later want an
-    # explicit condition, add "check-success=Build site" after #329 has merged.
+    # CI Summary aggregates the jobs inside ci.yml. Once PR #329 merges it
+    # also covers the Astro website build and rendered-site verification.
+    # CodeQL runs in a separate workflow (codeql.yml) and is NOT included in
+    # CI Summary, so it is gated explicitly below.
     merge_conditions:
       - check-success=CI Summary
       - check-success=DCO sign-off
       - check-success=dependency-review
+      - check-success=CodeQL
+      - check-success=Analyze (python)
+      - check-success=Analyze (javascript)
       - "#approved-reviews-by>=1"
       - "#changes-requested-reviews-by=0"
       - "#review-threads-unresolved=0"

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -25,13 +25,29 @@ queue_rules:
     # above, this gives a fully serial merge queue.
     batch_size: 1
 
+    # Dequeue a PR whose required checks have not posted within this
+    # window instead of stalling the entire queue indefinitely. The
+    # default ("auto") applies no timeout until enough queue history has
+    # been gathered, so a stuck check on the very first queued PR would
+    # block every subsequent PR forever.
+    checks_timeout: 2 hours
+
     # These conditions must hold at the moment Mergify merges the PR.
     # Mergify re-evaluates them after rebasing onto the current dev HEAD.
     #
-    # CI Summary aggregates the jobs inside ci.yml. Once PR #329 merges it
-    # also covers the Astro website build and rendered-site verification.
-    # CodeQL runs in a separate workflow (codeql.yml) and is NOT included in
-    # CI Summary, so it is gated explicitly below.
+    # CI Summary aggregates all jobs inside ci.yml, including the Astro
+    # website build and rendered-site verification added by PR #329
+    # (now on dev). CodeQL runs in a separate workflow (codeql.yml) and
+    # is NOT included in CI Summary, so it is gated explicitly below.
+    # Build site is gated explicitly for belt-and-braces coverage: it
+    # runs unconditionally on every dev-targeted PR (no paths filter)
+    # so it cannot stall the queue.
+    #
+    # External Semgrep app checks (Semgrep OSS, semgrep-cloud-platform/scan)
+    # are deliberately not gated: their coverage duplicates the SAST
+    # (Semgrep) job already gated through CI Summary, and third-party app
+    # checks can vanish if the app is uninstalled or its plan changes,
+    # which would stall the queue permanently.
     merge_conditions:
       - check-success=CI Summary
       - check-success=DCO sign-off
@@ -39,6 +55,14 @@ queue_rules:
       - check-success=CodeQL
       - check-success=Analyze (python)
       - check-success=Analyze (javascript)
+      - check-success=Build site
+      # terraform-plan only runs for PRs touching infra/terraform/**. An
+      # unconditional check-success would stall every non-terraform PR
+      # forever. This condition passes when the PR touches no terraform
+      # files; otherwise the check must be green.
+      - or:
+          - -files~=^infra/terraform/
+          - check-success=Terraform fmt / validate / plan
       - "#approved-reviews-by>=1"
       - "#changes-requested-reviews-by=0"
       - "#review-threads-unresolved=0"
@@ -46,30 +70,48 @@ queue_rules:
       - -label=blocked
 
 pull_request_rules:
-  # Dismiss approvals when a new commit is pushed to a dev-targeted PR.
-  # This ensures the approval in merge_conditions always reflects the
-  # latest push and cannot be satisfied by a pre-push review.
-  # Note: this rule fires on any push, including bot-created rebases.
-  # Reviewers must re-approve after each push before the PR can re-enter
-  # the queue.
-  - name: dismiss stale approvals on new push
+  # Dismiss all stale reviews (both approvals and changes-requested) on
+  # every push to a dev-targeted PR. The approval precondition is
+  # intentionally absent: if it were present, a reviewer who requested
+  # changes and then went offline would leave a stale CHANGES_REQUESTED
+  # verdict that survives the author's fix push (zero approvals at that
+  # moment), permanently blocking #changes-requested-reviews-by=0 with
+  # no way to clear it except pushing again after approvals exist.
+  # Without the precondition, every author push clears all stale verdicts
+  # regardless of the current approval count.
+  #
+  # Dismissing a review does not resolve its comment threads. Unresolved
+  # threads continue to block via #review-threads-unresolved=0 until a
+  # human resolves them, and the reviewer can re-request changes after
+  # re-reviewing. This rule fires on author pushes and on Mergify's own
+  # queue rebases: a queued PR whose base moves is ejected and needs a
+  # fresh approval before it re-enters the queue.
+  - name: dismiss stale reviews on new push
     conditions:
       - base=dev
-      - "#approved-reviews-by>=1"
     actions:
       dismiss_reviews:
         approved: true
-        message: "A new commit was pushed. Please re-review before this PR can merge."
+        changes_requested: true
+        message: "A new commit was pushed. All reviews were dismissed. Please re-review before this PR can merge."
 
   # Queue an eligible PR automatically once all conditions are met.
-  # The PR is rebased onto the latest dev HEAD before merge so CI runs
-  # against the actual post-merge state.
+  # Entry conditions mirror merge_conditions so only fully green PRs
+  # enter the queue. A PR admitted while a check is still pending
+  # occupies the single queue slot and stalls every PR behind it.
   - name: add to merge queue when eligible
     conditions:
       - base=dev
       - check-success=CI Summary
       - check-success=DCO sign-off
       - check-success=dependency-review
+      - check-success=CodeQL
+      - check-success=Analyze (python)
+      - check-success=Analyze (javascript)
+      - check-success=Build site
+      - or:
+          - -files~=^infra/terraform/
+          - check-success=Terraform fmt / validate / plan
       - "#approved-reviews-by>=1"
       - "#changes-requested-reviews-by=0"
       - "#review-threads-unresolved=0"

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -70,30 +70,28 @@ queue_rules:
       - -label=blocked
 
 pull_request_rules:
-  # Dismiss all stale reviews (both approvals and changes-requested) on
-  # every push to a dev-targeted PR. The approval precondition is
-  # intentionally absent: if it were present, a reviewer who requested
-  # changes and then went offline would leave a stale CHANGES_REQUESTED
-  # verdict that survives the author's fix push (zero approvals at that
-  # moment), permanently blocking #changes-requested-reviews-by=0 with
-  # no way to clear it except pushing again after approvals exist.
-  # Without the precondition, every author push clears all stale verdicts
-  # regardless of the current approval count.
+  # Dismiss stale approvals when a new commit is pushed to a dev-targeted PR.
+  # CHANGES_REQUESTED reviews are intentionally NOT dismissed (changes_requested
+  # is explicitly set to false). A reviewer's objection must survive the
+  # contributor's push and be cleared only by the reviewer re-reviewing, or
+  # by a maintainer manually dismissing it via GitHub after verifying the fix
+  # (see the inactive-reviewer process in docs/merge-queue.md).
+  # Auto-dismissing CHANGES_REQUESTED reviews would allow any push followed
+  # by a third-party approval to silently erase a blocking concern without
+  # the original reviewer ever checking the fix.
   #
-  # Dismissing a review does not resolve its comment threads. Unresolved
-  # threads continue to block via #review-threads-unresolved=0 until a
-  # human resolves them, and the reviewer can re-request changes after
-  # re-reviewing. This rule fires on author pushes and on Mergify's own
-  # queue rebases: a queued PR whose base moves is ejected and needs a
-  # fresh approval before it re-enters the queue.
-  - name: dismiss stale reviews on new push
+  # Reviewers: use inline conversation threads for every blocking concern.
+  # Threads survive this dismissal and continue to block via
+  # #review-threads-unresolved=0, giving an independent gate beyond the
+  # review verdict itself.
+  - name: dismiss stale approvals on new push
     conditions:
       - base=dev
     actions:
       dismiss_reviews:
         approved: true
-        changes_requested: true
-        message: "A new commit was pushed. All reviews were dismissed. Please re-review before this PR can merge."
+        changes_requested: false
+        message: "A new commit was pushed. Please re-review and re-approve before this PR can merge."
 
   # Queue an eligible PR automatically once all conditions are met.
   # Entry conditions mirror merge_conditions so only fully green PRs

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -8,11 +8,21 @@
 #
 # Related: https://github.com/openshield-org/openshield/issues/334
 
+# Limit speculative checks globally so at most one PR is tested at a time.
+# This enforces serial behaviour across the queue.
+merge_queue:
+  max_parallel_checks: 1
+
 queue_rules:
   - name: default
-    # Serial queue: one pull request processed at a time.
-    # No batch merging, no parallel queue, no automatic conflict resolution.
-    speculative_checks: 1
+    # Restrict queue entry to PRs targeting dev, including manual
+    # @mergifyio queue commands. Without this, a maintainer could
+    # manually queue a PR targeting any branch.
+    queue_conditions:
+      - base=dev
+
+    # One PR merged per operation. Combined with max_parallel_checks: 1
+    # above, this gives a fully serial merge queue.
     batch_size: 1
 
     # These conditions must hold at the moment Mergify merges the PR.
@@ -27,6 +37,21 @@ queue_rules:
       - -draft
 
 pull_request_rules:
+  # Dismiss approvals when a new commit is pushed to a dev-targeted PR.
+  # This ensures the approval in merge_conditions always reflects the
+  # latest push and cannot be satisfied by a pre-push review.
+  # Note: this rule fires on any push, including bot-created rebases.
+  # Reviewers must re-approve after each push before the PR can re-enter
+  # the queue.
+  - name: dismiss stale approvals on new push
+    conditions:
+      - base=dev
+      - "#approved-reviews-by>=1"
+    actions:
+      dismiss_reviews:
+        approved: true
+        message: "A new commit was pushed. Please re-review before this PR can merge."
+
   # Queue an eligible PR automatically once all conditions are met.
   # The PR is rebased onto the latest dev HEAD before merge so CI runs
   # against the actual post-merge state.
@@ -46,8 +71,6 @@ pull_request_rules:
         name: default
 
   # Apply awaiting-author when a reviewer has requested changes.
-  # This makes blocked PRs visible in the issue tracker without any
-  # manual triage step.
   - name: label awaiting-author when changes are requested
     conditions:
       - base=dev

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -27,6 +27,12 @@ queue_rules:
 
     # These conditions must hold at the moment Mergify merges the PR.
     # Mergify re-evaluates them after rebasing onto the current dev HEAD.
+    #
+    # CI Summary covers all required GitHub Actions jobs. Once PR #329 merges,
+    # it will also include the Astro website build and rendered-site verification
+    # ("Website (Astro build + verification)"), so no separate check-success
+    # condition is needed for the website gate. If maintainers later want an
+    # explicit condition, add "check-success=Build site" after #329 has merged.
     merge_conditions:
       - check-success=CI Summary
       - check-success=DCO sign-off
@@ -35,6 +41,7 @@ queue_rules:
       - "#changes-requested-reviews-by=0"
       - "#review-threads-unresolved=0"
       - -draft
+      - -label=blocked
 
 pull_request_rules:
   # Dismiss approvals when a new commit is pushed to a dev-targeted PR.

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,0 +1,69 @@
+# .mergify.yml
+# Merge-queue configuration for the OpenShield dev branch.
+#
+# This file is inactive until the Mergify GitHub App is installed and
+# authorized for this repository. GitHub Actions remains the CI system.
+# Mergify reads pull-request state and operates the queue; it does not
+# run CI, replace existing workflows, or bypass GitHub branch protection.
+#
+# Related: https://github.com/openshield-org/openshield/issues/334
+
+queue_rules:
+  - name: default
+    # Serial queue: one pull request processed at a time.
+    # No batch merging, no parallel queue, no automatic conflict resolution.
+    speculative_checks: 1
+    batch_size: 1
+
+    # These conditions must hold at the moment Mergify merges the PR.
+    # Mergify re-evaluates them after rebasing onto the current dev HEAD.
+    merge_conditions:
+      - check-success=CI Summary
+      - check-success=DCO sign-off
+      - check-success=dependency-review
+      - "#approved-reviews-by>=1"
+      - "#changes-requested-reviews-by=0"
+      - "#review-threads-unresolved=0"
+      - -draft
+
+pull_request_rules:
+  # Queue an eligible PR automatically once all conditions are met.
+  # The PR is rebased onto the latest dev HEAD before merge so CI runs
+  # against the actual post-merge state.
+  - name: add to merge queue when eligible
+    conditions:
+      - base=dev
+      - check-success=CI Summary
+      - check-success=DCO sign-off
+      - check-success=dependency-review
+      - "#approved-reviews-by>=1"
+      - "#changes-requested-reviews-by=0"
+      - "#review-threads-unresolved=0"
+      - -draft
+      - -label=blocked
+    actions:
+      queue:
+        name: default
+
+  # Apply awaiting-author when a reviewer has requested changes.
+  # This makes blocked PRs visible in the issue tracker without any
+  # manual triage step.
+  - name: label awaiting-author when changes are requested
+    conditions:
+      - base=dev
+      - "#changes-requested-reviews-by>0"
+    actions:
+      label:
+        add:
+          - awaiting-author
+
+  # Remove awaiting-author once all change requests are resolved.
+  - name: remove awaiting-author when no changes are requested
+    conditions:
+      - base=dev
+      - label=awaiting-author
+      - "#changes-requested-reviews-by=0"
+    actions:
+      label:
+        remove:
+          - awaiting-author

--- a/docs/merge-queue.md
+++ b/docs/merge-queue.md
@@ -18,12 +18,18 @@ A pull request enters the queue automatically when all of the following
 are true:
 
 - The PR targets the `dev` branch
-- `CI Summary` check is successful (aggregates all jobs in `ci.yml`)
+- `CI Summary` check is successful (aggregates all jobs in `ci.yml`,
+  including the Astro website build and rendered-site verification)
 - `DCO sign-off` check is successful
 - `dependency-review` check is successful
 - `CodeQL` check is successful
 - `Analyze (python)` check is successful
 - `Analyze (javascript)` check is successful
+- `Build site` check is successful
+- `Terraform fmt / validate / plan` check is successful, or the PR does
+  not touch any files under `infra/terraform/` (the check only runs for
+  terraform-touching PRs, so a plain `check-success` condition would stall
+  every other PR)
 - At least one approving review exists and is current for the latest push
 - No active `CHANGES_REQUESTED` review exists
 - All review conversations are resolved
@@ -34,10 +40,13 @@ Mergify processes one pull request at a time. It rebases the queued PR onto
 the latest `dev` and runs CI again before merging, so the branch is always
 tested against what is actually on `dev` at merge time.
 
-`CI Summary` covers all jobs inside `ci.yml`. Once PR #329 merges, it will
-also include the Astro website build and rendered-site verification. CodeQL
-runs in a separate workflow (`codeql.yml`) and is not part of `CI Summary`,
-which is why it is listed explicitly above.
+`CI Summary` covers all jobs inside `ci.yml`. `CodeQL` and `Build site` run
+in separate workflows (`codeql.yml` and `website.yml`) and are not part of
+`CI Summary`, which is why they are listed explicitly above. The external
+Semgrep app checks are deliberately not gated: their coverage duplicates the
+`SAST (Semgrep)` job already in `CI Summary`, and gating third-party app
+checks would stall the queue if the app is ever uninstalled or its plan
+changes.
 
 ## Keeping a PR out of the queue
 
@@ -91,17 +100,20 @@ If the author remains inactive after the label is applied:
 
 ## Approval freshness
 
-Approvals are dismissed automatically when a new commit is pushed to a
-pull request targeting `dev`. This includes both author-pushed commits and
-bot-created rebases (for example, when Mergify rebases your PR onto the
-latest `dev` HEAD).
+Every push to a dev-targeted PR dismisses all existing reviews, both
+approvals and `CHANGES_REQUESTED` verdicts. This applies to author-pushed
+commits and to Mergify's own queue rebases (when Mergify rebases your PR
+onto the latest `dev` HEAD before merging).
 
 After each dismissal, at least one reviewer must re-approve before Mergify
-can queue or merge the PR. This means the approval in `merge_conditions`
-always reflects the state of the actual code that will land on `dev`.
+can queue or merge the PR. Dismissing a review does not resolve its comment
+threads: unresolved threads continue to block via the
+`#review-threads-unresolved=0` condition until a human resolves them, and a
+reviewer can re-request changes after re-reviewing.
 
-If your PR gets rebased while waiting in the queue, expect your approval
-to be dismissed and the PR to return to "needs review" state.
+If your PR gets rebased while waiting in the queue, expect all reviews to be
+dismissed and the PR to return to "needs review" state before it can
+re-enter the queue.
 
 ## GitHub branch protection
 

--- a/docs/merge-queue.md
+++ b/docs/merge-queue.md
@@ -26,11 +26,25 @@ are true:
 - All review conversations are resolved
 - The pull request is not a draft
 - The `blocked` label is not applied
-- All declared dependencies have merged (see below)
 
 Mergify processes one pull request at a time. It rebases the queued PR onto
 the latest `dev` and runs CI again before merging, so the branch is always
 tested against what is actually on `dev` at merge time.
+
+`CI Summary` covers all required GitHub Actions jobs. Once PR #329 merges,
+it will also include the Astro website build and rendered-site verification,
+so the website gate is satisfied through `CI Summary` with no separate
+condition needed.
+
+## Keeping a PR out of the queue
+
+To prevent a PR from entering the queue while it is still in progress, either:
+
+- Open it as a **draft**. Mergify will not queue it until you mark it ready
+  for review.
+- Apply the **`blocked` label**. This removes the PR from queue eligibility
+  and also prevents it from merging even if it is already in the queue.
+  Remove the label when the PR is ready to proceed.
 
 ## Declaring dependencies
 
@@ -41,9 +55,10 @@ pull request description:
 Depends-On: #123
 ```
 
-Use one `Depends-On:` line per dependency. Mergify holds the PR in the queue
-until every declared dependency is merged, then re-evaluates it against the
-latest `dev` state.
+Use one `Depends-On:` line per dependency. The PR can enter the queue
+immediately, but Mergify holds it there until every declared dependency has
+merged. Once all dependencies are satisfied, Mergify re-evaluates the PR
+against the latest `dev` state and proceeds.
 
 Leave the placeholder as `none` when there are no dependencies:
 

--- a/docs/merge-queue.md
+++ b/docs/merge-queue.md
@@ -1,0 +1,79 @@
+# Merge Queue
+
+OpenShield uses Mergify to run a serial merge queue on the `dev` branch.
+GitHub Actions remains the CI system. Mergify reads pull-request state,
+waits for all conditions to be met, rebases each PR onto the current `dev`
+HEAD, and merges it only after CI passes on the updated state.
+
+## Eligibility
+
+A pull request enters the queue automatically when all of the following
+are true:
+
+- `CI Summary` check is successful (all GitHub Actions CI jobs passed)
+- `DCO sign-off` check is successful
+- `dependency-review` check is successful
+- At least one approving review exists and is current for the latest push
+- No active `CHANGES_REQUESTED` review exists
+- All review conversations are resolved
+- The pull request is not a draft
+- The `blocked` label is not applied
+- All declared dependencies have merged (see below)
+
+Mergify processes one pull request at a time. It rebases the queued PR onto
+the latest `dev` and runs CI again before merging, so the branch is always
+tested against what is actually on `dev` at merge time.
+
+## Declaring dependencies
+
+If your PR depends on another PR or issue merging first, declare it in the
+pull request description:
+
+```
+Depends-On: #123
+```
+
+Use one `Depends-On:` line per dependency. Mergify holds the PR in the queue
+until every declared dependency is merged, then re-evaluates it against the
+latest `dev` state.
+
+Replace the placeholder in the PR template with `none` when there are no
+dependencies:
+
+```
+Depends-On: none
+```
+
+Do not delete the section. It makes dependency state visible to reviewers.
+
+## awaiting-author label
+
+Mergify applies the `awaiting-author` label automatically when a reviewer
+submits a `CHANGES_REQUESTED` review. The label is removed automatically
+when all change requests are resolved.
+
+Maintainers use this label to identify PRs that are blocked on the author
+rather than on review availability.
+
+## Inactive-author process
+
+1. A maintainer applies `awaiting-author` after required changes are
+   requested and the author is inactive for several days.
+2. After five working days of inactivity, a maintainer may take over the
+   branch, open a replacement PR, or remove a dependency that review
+   confirms is unnecessary.
+3. The decision is recorded in the PR before changing ownership or
+   dependency state.
+
+## GitHub branch protection
+
+Mergify does not replace or weaken GitHub branch protection. It operates
+on top of it. Any protection rules set directly in GitHub repository
+settings remain the source of truth and are enforced independently of
+Mergify.
+
+## Pausing the queue
+
+If the queue merges a PR that bypasses a protection or produces unexpected
+behavior, a maintainer pauses queue operation immediately and records the
+incident in issue #334 before resuming.

--- a/docs/merge-queue.md
+++ b/docs/merge-queue.md
@@ -5,11 +5,19 @@ GitHub Actions remains the CI system. Mergify reads pull-request state,
 waits for all conditions to be met, rebases each PR onto the current `dev`
 HEAD, and merges it only after CI passes on the updated state.
 
+This configuration is inactive until the Mergify GitHub App is installed
+and authorized for this repository. The `.mergify.yml` file has no effect
+before installation.
+
 ## Eligibility
+
+The queue applies only to pull requests that target the `dev` branch.
+PRs targeting any other branch are not affected by this configuration.
 
 A pull request enters the queue automatically when all of the following
 are true:
 
+- The PR targets the `dev` branch
 - `CI Summary` check is successful (all GitHub Actions CI jobs passed)
 - `DCO sign-off` check is successful
 - `dependency-review` check is successful
@@ -37,8 +45,7 @@ Use one `Depends-On:` line per dependency. Mergify holds the PR in the queue
 until every declared dependency is merged, then re-evaluates it against the
 latest `dev` state.
 
-Replace the placeholder in the PR template with `none` when there are no
-dependencies:
+Leave the placeholder as `none` when there are no dependencies:
 
 ```
 Depends-On: none
@@ -46,23 +53,22 @@ Depends-On: none
 
 Do not delete the section. It makes dependency state visible to reviewers.
 
-## awaiting-author label
+If a dependency PR is closed without merging, Mergify will hold your PR
+indefinitely. To unblock it, edit the PR description and remove or replace
+the `Depends-On:` line for that closed PR, then update the branch to
+trigger re-evaluation.
 
-Mergify applies the `awaiting-author` label automatically when a reviewer
-submits a `CHANGES_REQUESTED` review. The label is removed automatically
-when all change requests are resolved.
+## awaiting-author label and inactive-author process
 
-Maintainers use this label to identify PRs that are blocked on the author
-rather than on review availability.
+Mergify applies `awaiting-author` automatically when a reviewer submits a
+`CHANGES_REQUESTED` review. No manual step is needed.
 
-## Inactive-author process
+If the author remains inactive after the label is applied:
 
-1. A maintainer applies `awaiting-author` after required changes are
-   requested and the author is inactive for several days.
-2. After five working days of inactivity, a maintainer may take over the
-   branch, open a replacement PR, or remove a dependency that review
-   confirms is unnecessary.
-3. The decision is recorded in the PR before changing ownership or
+1. After five working days, a maintainer notes the inactivity in the PR
+   and may take over the branch, open a replacement PR, or remove a
+   dependency that review confirms is unnecessary.
+2. The decision is recorded in the PR before changing ownership or
    dependency state.
 
 ## GitHub branch protection

--- a/docs/merge-queue.md
+++ b/docs/merge-queue.md
@@ -18,9 +18,12 @@ A pull request enters the queue automatically when all of the following
 are true:
 
 - The PR targets the `dev` branch
-- `CI Summary` check is successful (all GitHub Actions CI jobs passed)
+- `CI Summary` check is successful (aggregates all jobs in `ci.yml`)
 - `DCO sign-off` check is successful
 - `dependency-review` check is successful
+- `CodeQL` check is successful
+- `Analyze (python)` check is successful
+- `Analyze (javascript)` check is successful
 - At least one approving review exists and is current for the latest push
 - No active `CHANGES_REQUESTED` review exists
 - All review conversations are resolved
@@ -31,10 +34,10 @@ Mergify processes one pull request at a time. It rebases the queued PR onto
 the latest `dev` and runs CI again before merging, so the branch is always
 tested against what is actually on `dev` at merge time.
 
-`CI Summary` covers all required GitHub Actions jobs. Once PR #329 merges,
-it will also include the Astro website build and rendered-site verification,
-so the website gate is satisfied through `CI Summary` with no separate
-condition needed.
+`CI Summary` covers all jobs inside `ci.yml`. Once PR #329 merges, it will
+also include the Astro website build and rendered-site verification. CodeQL
+runs in a separate workflow (`codeql.yml`) and is not part of `CI Summary`,
+which is why it is listed explicitly above.
 
 ## Keeping a PR out of the queue
 

--- a/docs/merge-queue.md
+++ b/docs/merge-queue.md
@@ -71,6 +71,20 @@ If the author remains inactive after the label is applied:
 2. The decision is recorded in the PR before changing ownership or
    dependency state.
 
+## Approval freshness
+
+Approvals are dismissed automatically when a new commit is pushed to a
+pull request targeting `dev`. This includes both author-pushed commits and
+bot-created rebases (for example, when Mergify rebases your PR onto the
+latest `dev` HEAD).
+
+After each dismissal, at least one reviewer must re-approve before Mergify
+can queue or merge the PR. This means the approval in `merge_conditions`
+always reflects the state of the actual code that will land on `dev`.
+
+If your PR gets rebased while waiting in the queue, expect your approval
+to be dismissed and the PR to return to "needs review" state.
+
 ## GitHub branch protection
 
 Mergify does not replace or weaken GitHub branch protection. It operates

--- a/docs/merge-queue.md
+++ b/docs/merge-queue.md
@@ -100,20 +100,39 @@ If the author remains inactive after the label is applied:
 
 ## Approval freshness
 
-Every push to a dev-targeted PR dismisses all existing reviews, both
-approvals and `CHANGES_REQUESTED` verdicts. This applies to author-pushed
-commits and to Mergify's own queue rebases (when Mergify rebases your PR
-onto the latest `dev` HEAD before merging).
+When a contributor pushes a new commit to a dev-targeted PR, all existing
+approvals are dismissed automatically. `CHANGES_REQUESTED` reviews are NOT
+dismissed: a reviewer's objection survives the push and continues to block
+`#changes-requested-reviews-by=0` until the reviewer themselves re-reviews
+and clears it, or a maintainer manually dismisses it via GitHub (see
+inactive-reviewer process below).
 
-After each dismissal, at least one reviewer must re-approve before Mergify
-can queue or merge the PR. Dismissing a review does not resolve its comment
-threads: unresolved threads continue to block via the
-`#review-threads-unresolved=0` condition until a human resolves them, and a
-reviewer can re-request changes after re-reviewing.
+This means every approval in `merge_conditions` always reflects the code
+that will actually land on `dev`, and no blocking concern can be erased by
+a push followed by a third-party approval.
 
-If your PR gets rebased while waiting in the queue, expect all reviews to be
-dismissed and the PR to return to "needs review" state before it can
+If your PR gets rebased while waiting in the queue, expect your approval to
+be dismissed and the PR to return to "needs review" state before it can
 re-enter the queue.
+
+**For reviewers:** use inline conversation threads for every blocking
+concern, not just the review summary body. Inline threads survive approval
+dismissal and block independently via `#review-threads-unresolved=0`, so
+your concern is protected even if another reviewer later approves.
+
+## Inactive-reviewer process
+
+If a reviewer left `CHANGES_REQUESTED` and has not responded after the
+contributor pushed a fix:
+
+1. After three working days with no response, the contributor tags the
+   reviewer and a maintainer in the PR comments.
+2. If there is still no response after two more working days, a maintainer
+   reads the original review, verifies that the fix addresses the concern,
+   and manually dismisses the stale review via GitHub with a comment
+   recording what was checked and why the fix is accepted.
+3. The decision is recorded in the PR before any dismissal so the reasoning
+   is auditable.
 
 ## GitHub branch protection
 


### PR DESCRIPTION
## What does this PR do?
Introduces a conservative Mergify serial merge queue for the `dev` branch, as specified in #334.

## Type of change
- [ ] New scan rule
- [ ] Remediation playbook
- [ ] Bug fix
- [ ] Dashboard/front-end work
- [ ] API endpoint
- [x] Documentation
- [ ] Compliance mapping

## Changes

**`.mergify.yml`** (new)
- Top-level `merge_queue.max_parallel_checks: 1` enforces serial operation globally
- `queue_rules.queue_conditions: [base=dev]` restricts queue entry for both automatic rules and manual `@mergifyio queue` commands
- `queue_rules.batch_size: 1` merges one PR at a time
- Merge conditions: `CI Summary` + `DCO sign-off` + `dependency-review` all pass, at least one current approval, no `CHANGES_REQUESTED`, all threads resolved, not draft
- `dismiss_reviews` rule invalidates approvals after each push so `merge_conditions` always reflects the latest code
- Auto-labels `awaiting-author` when changes are requested; removes it when resolved
- File is inert until the Mergify GitHub App is installed and authorized

**`.github/PULL_REQUEST_TEMPLATE.md`** (modified)
- Adds a `## Dependencies` section with `Depends-On: none` placeholder

**`docs/merge-queue.md`** (new)
- Explains eligibility conditions and base=dev scope
- Explains `Depends-On` syntax and how Mergify holds PRs until dependencies merge
- Documents approval freshness behaviour (dismissal on push, including bot rebases)
- Documents `awaiting-author` label lifecycle
- Documents the five-working-day inactive-author process
- Notes that GitHub branch protection remains the source of truth

## Pre-activation requirement
The `awaiting-author` label has been created in the repository. The Mergify GitHub App must be installed and authorized (limited to this repository only) by an organization owner before the queue becomes active. This PR only prepares the configuration.

## Branch protection note
The `dev` branch has no GitHub branch protection rules configured. Mergify will act as the primary merge gate once the app is installed. If branch protection rules are added later, Mergify will respect them and will not bypass them.

## Related issue
Related: #334

## Dependencies
Depends-On: none

## Checklist
- [x] Every commit includes a DCO `Signed-off-by` trailer
- [x] No tokens, secrets, or credentials added
- [x] No existing CI workflows modified
- [x] No unrelated files modified
- [x] YAML syntax validated
- [x] `awaiting-author` label created in repository