### PR TITLE
fix(website): correct Pages deployment action pin

### DIFF
--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -82,4 +82,4 @@ jobs:
     steps:
       - name: Deploy
         id: deployment
-        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed8e5614f34e4b3c2c9 # v4.0.5
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5


### PR DESCRIPTION
## Summary

Corrects the immutable `actions/deploy-pages@v4.0.5` commit pin used by the website deployment workflow.

## Why

Website builds on `dev` completed successfully, but the deployment job failed during action resolution because the configured commit does not exist in `actions/deploy-pages`.

## Changes

- Replaced the invalid deployment action SHA with the verified commit behind the official `v4.0.5` tag
- Preserved the pinned-action security model and existing deployment behavior
- Made no website content or runtime changes

## Verification

- `npm run check`: passed for CMS-disabled and CMS-enabled builds, with 14 pages verified
- `actionlint .github/workflows/website.yml`: passed
- `git diff --check`: passed
- Official `actions/deploy-pages` `v4.0.5` tag SHA verified through the GitHub API
- Commit is DCO-signed

## Deployment after merge

The next push to `dev`, or a manual workflow dispatch from `dev`, will rebuild the website and retry GitHub Pages deployment. Repository administrators must still configure **Settings > Pages > Source: GitHub Actions** if Pages is not already enabled.
